### PR TITLE
Fixed draggable bug of '14

### DIFF
--- a/app/assets/javascripts/farmbot_app/controllers/sequence_controller.js.coffee
+++ b/app/assets/javascripts/farmbot_app/controllers/sequence_controller.js.coffee
@@ -14,7 +14,6 @@ controller = ($scope, Data) ->
       # TODO Figure out why angular-data isn't doing this by default.
       # https://github.com/jmdobry/angular-data/issues/299
       delete step.sequence
-      debugger
       Data
         .update('step', step._id, {position: position})
         .catch(nope)

--- a/app/assets/javascripts/farmbot_app/controllers/sequence_controller.js.coffee
+++ b/app/assets/javascripts/farmbot_app/controllers/sequence_controller.js.coffee
@@ -6,17 +6,19 @@ controller = ($scope, Data) ->
   Data.findAll('sequence', {}).catch(nope)
   Data.bindAll($scope, 'storedSequences', 'sequence', {})
 
-  $scope.dragControlListeners = orderChanged: (event) ->
-    position = event.dest.index
-    step = event.source.itemScope.modelValue
-    # Failure to delete step.sequence results in a stack overflow :(
-    # TODO Figure out why angular-data isn't doing this by default.
-    # https://github.com/jmdobry/angular-data/issues/299
-    delete step.sequence
-    Data
-      .update('step', step._id, {position: position})
-      .catch(nope)
-      .then (step) -> null
+  $scope.dragControlListeners =
+    orderChanged: (event) ->
+      position = event.dest.index
+      step = event.source.itemScope.step
+      # Failure to delete step.sequence results in a stack overflow :(
+      # TODO Figure out why angular-data isn't doing this by default.
+      # https://github.com/jmdobry/angular-data/issues/299
+      delete step.sequence
+      debugger
+      Data
+        .update('step', step._id, {position: position})
+        .catch(nope)
+        .then (step) -> $scope.load($scope.sequence)
 
   hasSequence = ->
     whoah = -> alert 'Select or create a sequence first.'
@@ -33,7 +35,7 @@ controller = ($scope, Data) ->
 
   $scope.load = (seq) ->
     Data
-      .loadRelations('sequence', seq._id, ['step'])
+      .loadRelations('sequence', seq._id, ['step'], bypassCache: true)
       .catch(nope)
       .then (sequence) ->
         $scope.sequence = sequence

--- a/app/mutations/steps/update.rb
+++ b/app/mutations/steps/update.rb
@@ -24,8 +24,9 @@ module Steps
       # Or: Use inheritance and embed different classes of Command
 
       # TODO move_to is possibly broke. Going to reorder on every request to stay in sync?
-      step.move_to! step_params[:position] if step_params[:position] && step.valid?
+      step.move_to! step_params[:position]
       update_attributes(step, step_params.except(:position))
+      step.reload
     end
   end
 end

--- a/app/views/dashboard/ng-partials/_sequence.html.erb
+++ b/app/views/dashboard/ng-partials/_sequence.html.erb
@@ -125,9 +125,7 @@
               </div>
             </div>
           </div>
-
-
-          <div class="row">
+          <div class="row" as-sortable='dragControlListeners' ng-model="sequenceSteps" style="padding-bottom: 100px;">
             <div class="small-4 columns">
               <label>Sequence Parameters:</label>
             </div>
@@ -141,13 +139,9 @@
             <div class="small-3 columns">
               <a class="tiny expand button radius dark-gray" href="#">ADD PARAMETER</a>
             </div>
-          </div>
 
-
-          <div class="row" as-sortable='dragControlListeners' ng-model="sequenceSteps" style="border-style: dashed;">
             <div ng-repeat='step in sequenceSteps | orderBy: "position" '>
               <div class="row" as-sortable-item ng-model="step">
-                {{ step.position }} {{ step._id.substr(-6, 3) }}
                 <ng-include src="'sequence-builder/' + step.message_type">
                 </ng-include>
               </div>

--- a/app/views/dashboard/ng-partials/_sequence.html.erb
+++ b/app/views/dashboard/ng-partials/_sequence.html.erb
@@ -144,10 +144,10 @@
           </div>
 
 
-          <div class="row" as-sortable='dragControlListeners' ng-model="sequenceSteps">
-            <div ng-repeat='step in sequenceSteps | orderBy: "position" ' >
+          <div class="row" as-sortable='dragControlListeners' ng-model="sequenceSteps" style="border-style: dashed;">
+            <div ng-repeat='step in sequenceSteps | orderBy: "position" '>
               <div class="row" as-sortable-item ng-model="step">
-                {{ step.position }}
+                {{ step.position }} {{ step._id.substr(-6, 3) }}
                 <ng-include src="'sequence-builder/' + step.message_type">
                 </ng-include>
               </div>


### PR DESCRIPTION
# What's New?

 * Snappier dragging

# What's Next?

 * add that one CSS file I forgot about.
 * `'containerPositioning' option may be set to 'relative' to accomodate relative positioning on the container or its ancestry. Use this if the draggable item is offset from the mouse cursor while dragging. A common scenario for this is when using bootstrap columns.`