### PR TITLE
CSS Touchups while dragging

### DIFF
--- a/app/assets/javascripts/farmbot_app/controllers/sequence_controller.js.coffee
+++ b/app/assets/javascripts/farmbot_app/controllers/sequence_controller.js.coffee
@@ -7,6 +7,8 @@ controller = ($scope, Data) ->
   Data.bindAll($scope, 'storedSequences', 'sequence', {})
 
   $scope.dragControlListeners =
+    containment: true
+    containerPositioning: 'relative'
     orderChanged: (event) ->
       position = event.dest.index
       step = event.source.itemScope.step

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -15,5 +15,6 @@
  *= require_tree ./farmbot_app/
  *= require manual_control
  *= require sequence_builder
+ *= require ng-sortable
  *= require help_we_need_a_designer
  */

--- a/app/mutations/steps/update.rb
+++ b/app/mutations/steps/update.rb
@@ -24,7 +24,7 @@ module Steps
       # Or: Use inheritance and embed different classes of Command
 
       # TODO move_to is possibly broke. Going to reorder on every request to stay in sync?
-      step.move_to! step_params[:position]
+      step.move_to! step_params[:position] if step_params[:position]
       update_attributes(step, step_params.except(:position))
       step.reload
     end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -25,7 +25,7 @@
             %li
               = link_to 'Sequences', '/dashboard#/sequence'
             %li
-              = link_to 'New Controls', '/dashboard#/newmovement'
+              = link_to 'Old Controls (reference)', '/dashboard#/newmovement'
           %li{class: ("active" if current_page? page_path('help'))}
             = link_to 'Help', page_path('help')
         %ul.right


### PR DESCRIPTION
# What's New?

 * Minor fix so that dragged element follows mouse while dragging.

# What's Next?

 * Re-implement the manual control page, pending setup of bot in CA
 * Add background color to draggable elements so you can't see through them when they're being dragged.
 * Darken color scheme on sequence builder
 * (then) make manual control page look like sequence builder (less bright).
 * Help Tim get coverage up on rpi.
 * Implement the schedule builder.
 * Switch from angular-data to js-data-angular.
