### PR TITLE
WIP- upgrading to js-data-angular

### DIFF
--- a/app/assets/javascripts/farmbot_app/controllers/sequence_controller.js.coffee
+++ b/app/assets/javascripts/farmbot_app/controllers/sequence_controller.js.coffee
@@ -4,7 +4,7 @@ controller = ($scope, Data) ->
   #TODO: We really really need an error handler / reporter at this point.
   nope = (e) -> alert 'Doh!'; console.error e
   Data.findAll('sequence', {}).catch(nope)
-  Data.bindAll($scope, 'storedSequences', 'sequence', {})
+  Data.bindAll 'sequence', {}, $scope, 'storedSequences'
 
   $scope.dragControlListeners =
     containment: true
@@ -31,8 +31,7 @@ controller = ($scope, Data) ->
       message_type: message_type
       sequence_id: $scope.sequence._id
     ).catch(nope)
-    .then (step) ->
-      $scope.sequence.steps.push(step)
+    .then (step) -> $scope.sequenceSteps.push(step)
 
   $scope.load = (seq) ->
     Data
@@ -72,8 +71,8 @@ controller = ($scope, Data) ->
         message_type: obj.message_type
         command: obj.command || {}
         position: index
-      ).catch(nope) # Shouldnt angular-data auto-push new elements?
-      .then (step) -> $scope.sequence.steps.push(step)
+      ).catch(nope)
+      .then (step) -> $scope.sequenceSteps.push(step)
 
   $scope.deleteStep = (index) ->
     Data

--- a/app/assets/javascripts/farmbot_app/services/data.js.coffee
+++ b/app/assets/javascripts/farmbot_app/services/data.js.coffee
@@ -1,12 +1,11 @@
-# RESTful data adapter for hooking angular JS into the backend API. SEE:
-# http://angular-data.pseudobry.com/
+# RESTful data adapter for hooking angular JS into the backend API.
+# Checkout "js-data-angular" docs for more info.
 data = (DS) ->
   DS.defineResource
     name: "step"
     endpoint: 'steps',
-    baseUrl: '/api',
+    basePath: '/api',
     idAttribute: "_id"
-    serialize: (resourceName, data) -> _.omit(data, 'sequence')
     relations:
       belongsTo:
         sequence:
@@ -17,9 +16,8 @@ data = (DS) ->
   DS.defineResource
     name: "sequence"
     endpoint: 'sequences',
-    baseUrl: '/api',
+    basePath: '/api',
     idAttribute: "_id"
-    serialize: (resourceName, data) -> _.omit(data, 'steps')
     relations:
       hasMany:
         step:


### PR DESCRIPTION
Going to keep this PR open as a work-in-progress, as progress will be slower than usual this week.

# What's Going On Here?

 - [ ] Re-implement the manual control page, pending setup of bot in CA
 - [ ] Help Tim get coverage up on rpi.
 - [ ] Implement the schedule builder.
 - [X] Switch from angular-data to js-data-angular.
 - [ ] Add `<span>` to sequence.step icons (trash, copy, drag) to fix a bug where the action only happens sometimes.
 - [ ] See if the `scope.sequenceSteps` hack is still needed now that most bugs were fixed in js-data.
