### PR TITLE
Create / List schedules via API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source 'https://rubygems.org'
-source 'https://rails-assets.org'
 
 ruby '2.2.0'
 
@@ -17,10 +16,14 @@ gem 'font-awesome-rails'
 gem 'uglifier'
 gem 'high_voltage', '~> 2.1.0'
 gem 'haml'
-gem 'rails-assets-ng-sortable'
-gem 'rails-assets-js-data'
-gem 'rails-assets-js-data-angular'
-gem 'rails-assets-lodash'
+
+source 'https://rails-assets.org' do
+  gem 'rails-assets-ng-sortable'
+  gem 'rails-assets-js-data'
+  gem 'rails-assets-js-data-angular'
+  gem 'rails-assets-lodash'
+  gem 'rails-assets-angular-native-picker'
+end
 
 gem 'figaro' # Store secrets the 12 factor way. TODO: Get off of this gem.
 gem 'devise', github: 'plataformatec/devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,11 +203,13 @@ GEM
       railties (= 4.1.0)
       sprockets-rails (~> 2.0)
     rails-assets-angular (1.3.13)
-    rails-assets-js-data (1.1.0)
+    rails-assets-angular-native-picker (1.0.4)
+      rails-assets-angular
+    rails-assets-js-data (1.3.0)
     rails-assets-js-data-angular (2.1.0)
       rails-assets-angular (>= 1.0.3)
       rails-assets-js-data (>= 1.1.0)
-    rails-assets-lodash (3.1.0)
+    rails-assets-lodash (3.2.0)
     rails-assets-ng-sortable (1.1.9)
       rails-assets-angular (~> 1.3.0)
     rails_12factor (0.0.3)
@@ -328,10 +330,11 @@ DEPENDENCIES
   ng-rails-csrf
   pry
   rails (= 4.1.0)
-  rails-assets-js-data
-  rails-assets-js-data-angular
-  rails-assets-lodash
-  rails-assets-ng-sortable
+  rails-assets-angular-native-picker!
+  rails-assets-js-data!
+  rails-assets-js-data-angular!
+  rails-assets-lodash!
+  rails-assets-ng-sortable!
   rails_12factor
   rspec
   rspec-rails

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -6,5 +6,6 @@
 //= require js-data
 //= require js-data-angular
 //= require ng-rails-csrf
+//= require angular-native-picker
 //= require farmbot_app/farmbot
 //= require_tree ./farmbot_app

--- a/app/controllers/api/schedules_controller.rb
+++ b/app/controllers/api/schedules_controller.rb
@@ -29,9 +29,9 @@ module Api
 
     private
 
-      def sequence
-        @sequence ||= Sequence.find(params[:sequence_id])
-      end
+    def sequence
+      @sequence ||= Sequence.find(params[:sequence_id])
+    end
     # def schedule
     #   @schedule ||= Schedule.find(params[:id])
     # end

--- a/app/controllers/api/schedules_controller.rb
+++ b/app/controllers/api/schedules_controller.rb
@@ -1,0 +1,39 @@
+module Api
+  class SchedulesController < Api::AbstractController
+    def index
+      render json: Schedule.where(user: current_user)
+    end
+
+    def create
+      mutate Schedules::Create.run(params,
+                                   user: current_user,
+                                   sequence: sequence)
+    end
+
+    # def show
+    #   render json: schedule
+    # end
+
+    # def update
+    #   mutate Schedules::Update.run(params[:schedule],
+    #                                user: current_user)
+    # end
+
+    # def destroy
+    #   if (schedule.user == current_user) && schedule.destroy
+    #     render nothing: true
+    #   else
+    #     raise Errors::Forbidden, "Not your schedule."
+    #   end
+    # end
+
+    private
+
+      def sequence
+        @sequence ||= Sequence.find(params[:sequence_id])
+      end
+    # def schedule
+    #   @schedule ||= Schedule.find(params[:id])
+    # end
+  end
+end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -4,7 +4,9 @@ class Schedule
   UNITS_OF_TIME = %w(minutely hourly daily weekly monthly yearly)
 
   belongs_to :sequence
+  validates_presence_of :sequence_id
   belongs_to :user
+  validates_presence_of :user_id
 
   field :start_time, type: Time
   field :end_time, type: Time

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -25,4 +25,9 @@ class Schedule
   def calculate_next_occurence
     schedule.next_occurrence
   end
+
+  def between(start, finish)
+    # Just for reference for later. Probably should just delegate.
+    schedule.occurrences_between(start, finish)
+  end
 end

--- a/app/serializers/schedule_serializer.rb
+++ b/app/serializers/schedule_serializer.rb
@@ -1,0 +1,9 @@
+class ScheduleSerializer < ActiveModel::Serializer
+  attributes :_id, :start_time, :end_time, :next_time, :repeat, :time_unit,
+             :sequence_id
+
+  # TODO: This is almost certainly wrong. I shouldn't need to write this method.
+  def sequence_id
+    object.sequence._id.to_s
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Dss::Application.routes.draw do
     resources :sequences, only: [:create, :update, :destroy, :index, :show] do
       resources :steps, only: [:show, :create, :index, :update, :destroy]
     end
+    resources :schedules, only: [:create, :index]
   end
 
   devise_for :users, :controllers => {:registrations => "registrations"}

--- a/spec/controllers/api/schedules/schedules_create_spec.rb
+++ b/spec/controllers/api/schedules/schedules_create_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe Api::SchedulesController do
+  include Devise::TestHelpers
+
+  describe '#create' do
+    let(:user) { FactoryGirl.create(:user) }
+    it 'makes a schedule' do
+      sign_in user
+      seq_id = FactoryGirl.create(:sequence)._id.to_s
+      input = { sequence_id: seq_id,
+                start_time: '2015-02-17T15:16:17.000Z',
+                end_time: '2099-02-17T18:19:20.000Z',
+                repeat: 4,
+                time_unit: 'minutely' }
+      before = Schedule.count
+      post :create, input
+      expect(response.status).to eq(200)
+      expect(before < Schedule.count).to be_truthy
+    end
+  end
+end

--- a/spec/controllers/api/schedules/schedules_index_spec.rb
+++ b/spec/controllers/api/schedules/schedules_index_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Api::SchedulesController do
-
   include Devise::TestHelpers
 
   describe '#index' do

--- a/spec/controllers/api/schedules/schedules_index_spec.rb
+++ b/spec/controllers/api/schedules/schedules_index_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe Api::SchedulesController do
+
+  include Devise::TestHelpers
+
+  describe '#index' do
+
+    let(:user) { FactoryGirl.create(:user) }
+
+    it 'lists all schedules for a user' do
+      sign_in user
+      schedules = FactoryGirl
+                    .create_list(:schedule, 2, user: user)
+                    .map(&:_id)
+                    .map(&:to_s)
+                    .sort
+      get :index
+      expect(response.status).to eq(200)
+      expect(json.length).to eq(2)
+      expect(json.map{ |s| s[:_id] }.sort).to eq(schedules)
+    end
+  end
+end

--- a/spec/factories/schedules.rb
+++ b/spec/factories/schedules.rb
@@ -4,6 +4,10 @@ FactoryGirl.define do
     end_time { Date.today + 1.minute + 2.days }
     time_unit "daily"
     repeat 1
-    after(:build) { |s| s.next_time ||= s.calculate_next_occurence }
+    after(:build) do |s|
+      s.next_time ||= s.calculate_next_occurence
+      s.sequence ||= create(:sequence)
+      s.user ||= s.sequence.user
+    end
   end
 end


### PR DESCRIPTION
# What's New?

 * Basic functionality that exposes schedules through the API.

# What's Next?

 - [ ] Call API from UI
 - [ ] Re-implement the manual control page, pending setup of bot in CA
 - [ ] Help Tim get coverage up on rpi (I really need to do this).
 - [ ] Implement the schedule builder UI on the front end (lots of sub tasks).