### PR TITLE
Add date picker to schedule page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,9 @@ source 'https://rails-assets.org' do
   gem 'rails-assets-js-data'
   gem 'rails-assets-js-data-angular'
   gem 'rails-assets-lodash'
-  gem 'rails-assets-angular-native-picker'
+  gem 'rails-assets-jquery'
+  gem 'rails-assets-pickadate'
+  gem 'rails-assets-ng-pickadate'
 end
 
 gem 'figaro' # Store secrets the 12 factor way. TODO: Get off of this gem.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,15 +203,19 @@ GEM
       railties (= 4.1.0)
       sprockets-rails (~> 2.0)
     rails-assets-angular (1.3.13)
-    rails-assets-angular-native-picker (1.0.4)
-      rails-assets-angular
+    rails-assets-jquery (2.1.3)
     rails-assets-js-data (1.3.0)
     rails-assets-js-data-angular (2.1.0)
       rails-assets-angular (>= 1.0.3)
       rails-assets-js-data (>= 1.1.0)
     rails-assets-lodash (3.2.0)
+    rails-assets-ng-pickadate (0.1.6)
+      rails-assets-angular (~> 1.3.12)
+      rails-assets-pickadate (~> 3.5.4)
     rails-assets-ng-sortable (1.1.9)
       rails-assets-angular (~> 1.3.0)
+    rails-assets-pickadate (3.5.5)
+      rails-assets-jquery (>= 1.7)
     rails_12factor (0.0.3)
       rails_serve_static_assets
       rails_stdout_logging
@@ -330,11 +334,13 @@ DEPENDENCIES
   ng-rails-csrf
   pry
   rails (= 4.1.0)
-  rails-assets-angular-native-picker!
+  rails-assets-jquery!
   rails-assets-js-data!
   rails-assets-js-data-angular!
   rails-assets-lodash!
+  rails-assets-ng-pickadate!
   rails-assets-ng-sortable!
+  rails-assets-pickadate!
   rails_12factor
   rspec
   rspec-rails

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,4 +1,6 @@
 //= require lodash
+//= require jquery
+//= require pickadate
 //= require skynet
 //= require angular/angular
 //= require angular/angular-route
@@ -6,6 +8,6 @@
 //= require js-data
 //= require js-data-angular
 //= require ng-rails-csrf
-//= require angular-native-picker
+//= require ng-pickadate
 //= require farmbot_app/farmbot
 //= require_tree ./farmbot_app

--- a/app/assets/javascripts/farmbot_app/controllers/schedule_controller.js.coffee
+++ b/app/assets/javascripts/farmbot_app/controllers/schedule_controller.js.coffee
@@ -1,5 +1,7 @@
 controller = ($scope, Data) ->
+  $scope.form = {}
   $scope.world = 'world'
+  $scope.pickADateOptions = {}
 
 angular.module('FarmBot').controller "ScheduleController", [
   '$scope'

--- a/app/assets/javascripts/farmbot_app/controllers/schedule_controller.js.coffee
+++ b/app/assets/javascripts/farmbot_app/controllers/schedule_controller.js.coffee
@@ -1,7 +1,6 @@
 controller = ($scope, Data) ->
-  $scope.form = {}
-  $scope.world = 'world'
-  $scope.pickADateOptions = {}
+  $scope.form = {} # Data for new schedules.
+  $scope.pickADateOptions = {interval: 15}
 
 angular.module('FarmBot').controller "ScheduleController", [
   '$scope'

--- a/app/assets/javascripts/farmbot_app/farmbot.js.coffee
+++ b/app/assets/javascripts/farmbot_app/farmbot.js.coffee
@@ -5,6 +5,7 @@ app = angular.module('FarmBot', [
   'ng-rails-csrf'
   'ui.sortable'
   'js-data'
+  'pickadate'
   ])
 
 app.config [

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -9,6 +9,7 @@
  * compiled file, but it's generally better to create a new file per style scope.
  *
  *= require_self
+ *= require pickadate
  *= require font-awesome
  *= require_tree ./foundation/
  *= require_tree ./foundation-icons/

--- a/app/views/dashboard/ng-partials/widgets/_schedule_sequence.html.haml
+++ b/app/views/dashboard/ng-partials/widgets/_schedule_sequence.html.haml
@@ -14,36 +14,36 @@
               .row.content-area.blue-content
                 .large-6.columns
                   .row.collapse.prefix-radius
+                    .small-3.columns
+                      %span.prefix.uppercase Starts
+                    .small-9.columns
+                      %input{'pick-a-date' => "form.dstart", placeholder: "Today", :type => "text"}
+                  .row.collapse.prefix-radius
+                    .small-3.columns
+                      %span.prefix.uppercase Ends
+                    .small-9.columns
+                      %input{'pick-a-date' => "form.dend", :placeholder => "Never", :type => "text"}
+                  .row.collapse.prefix-radius
+                    .small-3.columns
+                      %span.prefix.uppercase Time
+                    .small-9.columns
+                      %input{placeholder: "Now", type: "text"}
+                .large-6.columns
+                  .row.collapse.prefix-radius
+                    .small-4.columns
+                      %span.prefix.uppercase Repeat
+                    .small-8.columns
+                      %input{:placeholder => "Weekly", :type => "text"}
+                  .row.collapse.prefix-radius
                     .small-4.columns
                       %span.prefix.uppercase Plant-ID
                     .small-8.columns
                       %input{:placeholder => "42", :type => "text"}
                   .row.collapse.prefix-radius
                     .small-4.columns
-                      %span.prefix.uppercase Date
-                    .small-8.columns
-                      %input{'pick-a-date' => "form.dstart", placeholder: "25 August", :type => "text"}
-                  .row.collapse.prefix-radius
-                    .small-4.columns
-                      %span.prefix.uppercase Repeat
-                    .small-8.columns
-                      %input{:placeholder => "Weekly", :type => "text"}
-                .large-6.columns
-                  .row.collapse.prefix-radius
-                    .small-6.columns
                       %span.prefix.uppercase Tool-ID
-                    .small-6.columns
+                    .small-8.columns
                       %input{:placeholder => "3", :type => "text"}
-                  .row.collapse.prefix-radius
-                    .small-6.columns
-                      %span.prefix.uppercase Time
-                    .small-6.columns
-                      %input{'pick-a-time' => "form.tstart", placeholder: "9:00am", type: "text"}
-                  .row.collapse.prefix-radius
-                    .small-6.columns
-                      %span.prefix.uppercase Ends
-                    .small-6.columns
-                      %input{:placeholder => "Never", :type => "text"}
         .row.padding-bottom
           .small-12.columns
             %button.green.button-like{"ng-click" => "saveEvent(event)"}

--- a/app/views/dashboard/ng-partials/widgets/_schedule_sequence.html.haml
+++ b/app/views/dashboard/ng-partials/widgets/_schedule_sequence.html.haml
@@ -22,7 +22,7 @@
                     .small-4.columns
                       %span.prefix.uppercase Date
                     .small-8.columns
-                      %input{:placeholder => "25 August", :type => "text"}
+                      %input{'pick-a-date' => "form.dstart", placeholder: "25 August", :type => "text"}
                   .row.collapse.prefix-radius
                     .small-4.columns
                       %span.prefix.uppercase Repeat
@@ -38,7 +38,7 @@
                     .small-6.columns
                       %span.prefix.uppercase Time
                     .small-6.columns
-                      %input{:placeholder => "9:00am", :type => "text"}
+                      %input{'pick-a-time' => "form.tstart", placeholder: "9:00am", type: "text"}
                   .row.collapse.prefix-radius
                     .small-6.columns
                       %span.prefix.uppercase Ends


### PR DESCRIPTION
# What's New?

 * Added a date picker to the schedule page through the `pickADate` library.

# What's Next?

 * Need a dropdown for selecting the start time. I wanted to use the one provided by `pickADate`, but the problem is inconsistent styling when we add a drop down for selecting the interval/tool-id/plant-id