### PR TITLE
Fix that terrible calendar rendering bug

### DIFF
--- a/app/controllers/api/schedules_controller.rb
+++ b/app/controllers/api/schedules_controller.rb
@@ -1,13 +1,9 @@
 module Api
   class SchedulesController < Api::AbstractController
     def index
-      start  = Time.now - 2.day
-      finish = Time.now + 4.days
       # Follow this for better querying in the future:
       # http://www.js-data.io/v1.3.0/docs/query-syntax
-      render json: Schedule.where(user: current_user),
-             start: start,
-             finish: finish
+      render json: Schedule.where(user: current_user)
     end
 
     def create

--- a/app/serializers/schedule_serializer.rb
+++ b/app/serializers/schedule_serializer.rb
@@ -12,12 +12,8 @@ class ScheduleSerializer < ActiveModel::Serializer
   end
 
   def calendar
-    start  = serialization_options[:start]
-    finish = serialization_options[:finish]
-    if start && finish
-      object.between start, finish
-    else
-      []
-    end
+    start  = serialization_options[:start] || Time.current
+    finish = serialization_options[:finish] || Time.current + 1.day
+    object.between start, finish
   end
 end


### PR DESCRIPTION
# What Happened?

 * What appeared to be a front end issue was actually a set of bad `serialization_options` on the backend.

# The Fix

 * We will always need to pass in a `start_date` and `end_date` when serializing schedule objects. We will also need to invalidate cache when we start allowing users to flip between dates.