### PR TITLE
date adjustment

### DIFF
--- a/app/views/dashboard/ng-partials/widgets/_calendar.html.haml
+++ b/app/views/dashboard/ng-partials/widgets/_calendar.html.haml
@@ -7,9 +7,11 @@
     .small-12.columns
       .content-wrapper
         .row.day{'ng-repeat' => '(date, scheds) in prettyDates'}
+          // How can this work in the above line?
+          // :class => ("past" if date < time.now)
           .small-2.columns
-            %h6.calendar-date {{ date | date: 'd MMM'  }}
-            .calendar-month {{ date | date: 'hh:mma' }}
+            %h6.calendar-date {{ date | date: 'd'  }}
+            .calendar-month {{ date | date: 'MMM' }}
           .small-10.columns{'ng-repeat' => 's in scheds'}
             .small-12.columns.event
               // .past is a thing, FYI.


### PR DESCRIPTION
Hey Rick,

I couldn't recreate the styling issues with the out-of-alignment events because all of my events have the date next to them. It used to 'collapse' common dates until the last update. Also, I attempted to add the `.past` class but clearly don't know how ;p

![screenshot from 2015-03-02 17 16 27](https://cloud.githubusercontent.com/assets/5524043/6454623/e155adf6-c0ff-11e4-8abe-e38daeee0f68.png)
