### PR TITLE
Change module name, Api to API

### DIFF
--- a/app/controllers/api/abstract_controller.rb
+++ b/app/controllers/api/abstract_controller.rb
@@ -1,4 +1,4 @@
-module Api
+module API
   class AbstractController < ApplicationController
     respond_to :json
     before_action :authenticate_user!

--- a/app/controllers/api/devices_controller.rb
+++ b/app/controllers/api/devices_controller.rb
@@ -1,7 +1,7 @@
-# Api::DevicesController is the RESTful endpoint for managing device related
+# API::DevicesController is the RESTful endpoint for managing device related
 # settings. Consumed by the Angular SPA on the front end.
-module Api
-  class DevicesController < Api::AbstractController
+module API
+  class DevicesController < API::AbstractController
     before_action :set_device, only: [:show, :edit, :update, :destroy]
 
     # GET /api/devices

--- a/app/controllers/api/schedules_controller.rb
+++ b/app/controllers/api/schedules_controller.rb
@@ -1,5 +1,5 @@
-module Api
-  class SchedulesController < Api::AbstractController
+module API
+  class SchedulesController < API::AbstractController
     def index
       # Follow this for better querying in the future:
       # http://www.js-data.io/v1.3.0/docs/query-syntax

--- a/app/controllers/api/sequences_controller.rb
+++ b/app/controllers/api/sequences_controller.rb
@@ -1,5 +1,5 @@
-module Api
-  class SequencesController < Api::AbstractController
+module API
+  class SequencesController < API::AbstractController
     # TODO add user authorization maybe (privacy)
     def index
       query = { user: current_user }

--- a/app/controllers/api/steps_controller.rb
+++ b/app/controllers/api/steps_controller.rb
@@ -1,5 +1,5 @@
-module Api
-  class StepsController < Api::AbstractController
+module API
+  class StepsController < API::AbstractController
     before_action :must_own_sequence
 
     def create

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,0 +1,3 @@
+ActiveSupport::Inflector.inflections do |inflect|
+  inflect.acronym 'API'
+end

--- a/spec/controllers/api/devices/devices_controller_create_spec.rb
+++ b/spec/controllers/api/devices/devices_controller_create_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Api::DevicesController do
+describe API::DevicesController do
 
   include Devise::TestHelpers
 

--- a/spec/controllers/api/devices/devices_controller_destroy_spec.rb
+++ b/spec/controllers/api/devices/devices_controller_destroy_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Api::DevicesController do
+describe API::DevicesController do
 
   include Devise::TestHelpers
 

--- a/spec/controllers/api/devices/devices_controller_index_spec.rb
+++ b/spec/controllers/api/devices/devices_controller_index_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Api::DevicesController do
+describe API::DevicesController do
 
   include Devise::TestHelpers
 

--- a/spec/controllers/api/devices/devices_controller_show_spec.rb
+++ b/spec/controllers/api/devices/devices_controller_show_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Api::DevicesController do
+describe API::DevicesController do
 
   include Devise::TestHelpers
 

--- a/spec/controllers/api/devices/devices_controller_update_spec.rb
+++ b/spec/controllers/api/devices/devices_controller_update_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-# Api::DevicesController is the RESTful endpoint for managing device related
+# API::DevicesController is the RESTful endpoint for managing device related
 # settings. Consumed by the Angular SPA on the front end.
-describe Api::DevicesController do
+describe API::DevicesController do
 
   include Devise::TestHelpers
 

--- a/spec/controllers/api/schedules/schedules_create_spec.rb
+++ b/spec/controllers/api/schedules/schedules_create_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Api::SchedulesController do
+describe API::SchedulesController do
   include Devise::TestHelpers
 
   describe '#create' do

--- a/spec/controllers/api/schedules/schedules_destroy_spec.rb
+++ b/spec/controllers/api/schedules/schedules_destroy_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Api::SchedulesController do
+describe API::SchedulesController do
   include Devise::TestHelpers
 
   describe '#destroy' do

--- a/spec/controllers/api/schedules/schedules_index_spec.rb
+++ b/spec/controllers/api/schedules/schedules_index_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Api::SchedulesController do
+describe API::SchedulesController do
   include Devise::TestHelpers
 
   describe '#index' do

--- a/spec/controllers/api/schedules/schedules_update_spec.rb
+++ b/spec/controllers/api/schedules/schedules_update_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Api::SchedulesController do
+describe API::SchedulesController do
   include Devise::TestHelpers
 
   describe '#update' do

--- a/spec/controllers/api/sequences/sequences_create_spec.rb
+++ b/spec/controllers/api/sequences/sequences_create_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Api::SequencesController do
+describe API::SequencesController do
 
   include Devise::TestHelpers
 

--- a/spec/controllers/api/sequences/sequences_destroy_spec.rb
+++ b/spec/controllers/api/sequences/sequences_destroy_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Api::SequencesController do
+describe API::SequencesController do
 
   include Devise::TestHelpers
 

--- a/spec/controllers/api/sequences/sequences_index_spec.rb
+++ b/spec/controllers/api/sequences/sequences_index_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Api::SequencesController do
+describe API::SequencesController do
 
   include Devise::TestHelpers
 

--- a/spec/controllers/api/sequences/sequences_show_spec.rb
+++ b/spec/controllers/api/sequences/sequences_show_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Api::SequencesController do
+describe API::SequencesController do
 
   include Devise::TestHelpers
 

--- a/spec/controllers/api/sequences/sequences_update_spec.rb
+++ b/spec/controllers/api/sequences/sequences_update_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Api::SequencesController do
+describe API::SequencesController do
 
   include Devise::TestHelpers
 

--- a/spec/controllers/api/steps/create_spec.rb
+++ b/spec/controllers/api/steps/create_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Api::StepsController do
+describe API::StepsController do
 
   include Devise::TestHelpers
 

--- a/spec/controllers/api/steps/destroy_spec.rb
+++ b/spec/controllers/api/steps/destroy_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Api::StepsController do
+describe API::StepsController do
 
   include Devise::TestHelpers
 

--- a/spec/controllers/api/steps/index_spec.rb
+++ b/spec/controllers/api/steps/index_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Api::StepsController do
+describe API::StepsController do
 
   include Devise::TestHelpers
 

--- a/spec/controllers/api/steps/show_spec.rb
+++ b/spec/controllers/api/steps/show_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Api::StepsController do
+describe API::StepsController do
   include Devise::TestHelpers
 
   describe '#show' do

--- a/spec/controllers/api/steps/update_spec.rb
+++ b/spec/controllers/api/steps/update_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Api::StepsController do
+describe API::StepsController do
 
   include Devise::TestHelpers
 


### PR DESCRIPTION
I think API is better name than Api.

There is a failed test. It raises by a angular-app test, not from by update