### PR TITLE
Allow Bot to access API 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ group :development, :test do
   gem 'factory_girl_rails'
   gem 'faker'
   gem 'jasmine-rails'
+  # gem 'smarf_doc'
 end
 
 group :development do

--- a/app/assets/javascripts/farmbot_app/controllers/devices_controller.js.coffee
+++ b/app/assets/javascripts/farmbot_app/controllers/devices_controller.js.coffee
@@ -12,9 +12,7 @@ controller = ($scope, Data, Devices) ->
     $scope.form = {}
     $scope.logs = []
   $scope.clear()
-  $scope.refreshLogs = ->
-    Devices.fetchLogs (d) ->
-      $scope.logs = d.data || []
+  $scope.refreshLogs = -> (Devices.fetchLogs (d) -> $scope.logs = d.data || [])
   $scope.selectDevice = (device) -> $scope.form = device
   $scope.createDevice = ->
     Data

--- a/app/controllers/api/abstract_controller.rb
+++ b/app/controllers/api/abstract_controller.rb
@@ -19,6 +19,11 @@ module Api
 
 private
 
+    # def authenticate_user!
+    #   authenticate_or_request_with_http_token do |token, other_options |
+    #   end
+    # end
+
     def sorry(msg, status)
       render json: { error: msg }, status: status
     end

--- a/app/controllers/api/abstract_controller.rb
+++ b/app/controllers/api/abstract_controller.rb
@@ -23,13 +23,10 @@ private
       return true if current_user
       auth = Auth::Create.run(request.headers.to_h)
       if auth.success?
-        binding.pry
         @current_user = auth.result
-        super
       else
-        sorry("""You failed to authenticate with the API. If you are an API
-         consumer, ensure that you have provided a `bot_token` and `bot_uuid`
-         header in the HTTP request.
+        sorry("""You failed to authenticate with the API. Ensure that you have
+         provided a `bot_token` and `bot_uuid` header in the HTTP request.
         """.squish, 401)
       end
     end

--- a/app/controllers/api/abstract_controller.rb
+++ b/app/controllers/api/abstract_controller.rb
@@ -19,10 +19,20 @@ module Api
 
 private
 
-    # def authenticate_user!
-    #   authenticate_or_request_with_http_token do |token, other_options |
-    #   end
-    # end
+    def authenticate_user!
+      return true if current_user
+      auth = Auth::Create.run(request.headers.to_h)
+      if auth.success?
+        binding.pry
+        @current_user = auth.result
+        super
+      else
+        sorry("""You failed to authenticate with the API. If you are an API
+         consumer, ensure that you have provided a `bot_token` and `bot_uuid`
+         header in the HTTP request.
+        """.squish, 401)
+      end
+    end
 
     def sorry(msg, status)
       render json: { error: msg }, status: status

--- a/app/mutations/auth/create.rb
+++ b/app/mutations/auth/create.rb
@@ -7,14 +7,10 @@ module Auth
       string :bot_uuid
     end
 
-    def validate
-      @user = Device.find_by(uuid: bot_uuid, token: bot_token).user
-    rescue Mongoid::Errors::DocumentNotFound
-      add_error :auth, 'bad uuid or token'
-    end
-
     def execute
-      @user
+      Device.find_by(uuid: bot_uuid, token: bot_token).user
+    rescue Mongoid::Errors::DocumentNotFound
+      add_error :auth, :*, 'Bad uuid or token'
     end
   end
 end

--- a/app/mutations/auth/create.rb
+++ b/app/mutations/auth/create.rb
@@ -1,0 +1,20 @@
+require 'mutations/time_filter'
+
+module Auth
+  class Create < Mutations::Command
+    required do
+      string :bot_token
+      string :bot_uuid
+    end
+
+    def validate
+      @user = Device.find_by(uuid: bot_uuid, token: bot_token).user
+    rescue Mongoid::Errors::DocumentNotFound
+      add_error :auth, 'bad uuid or token'
+    end
+
+    def execute
+      @user
+    end
+  end
+end

--- a/spec/controllers/api/bot_auth_spec.rb
+++ b/spec/controllers/api/bot_auth_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe Api::SchedulesController do
+
+  include Devise::TestHelpers
+
+  describe 'Bot authentication' do
+
+    let(:device) { FactoryGirl.create(:device) }
+
+    it 'authorizes using MeshBlu UUID / Token' do
+      @request.headers["bot_token"] = device.token
+      @request.headers["bot_uuid"]  = device.uuid
+      get :index
+      expect(subject.current_user).to eq(device.user)
+    end
+
+    it 'tells you why you failed to auth' do
+      get :index
+      expect(response.status).to eq(401)
+      expect(json[:error]).to include("failed to authenticate")
+    end
+  end
+end

--- a/spec/controllers/api/bot_auth_spec.rb
+++ b/spec/controllers/api/bot_auth_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Api::SchedulesController do
-
   include Devise::TestHelpers
 
   describe 'Bot authentication' do
@@ -16,6 +15,14 @@ describe Api::SchedulesController do
     end
 
     it 'tells you why you failed to auth' do
+      get :index
+      expect(response.status).to eq(401)
+      expect(json[:error]).to include("failed to authenticate")
+    end
+
+    it 'handles bad credentials' do
+      @request.headers["bot_token"] = '321'
+      @request.headers["bot_uuid"]  = '123'
       get :index
       expect(response.status).to eq(401)
       expect(json[:error]).to include("failed to authenticate")

--- a/spec/factories/devices.rb
+++ b/spec/factories/devices.rb
@@ -3,6 +3,7 @@ require 'securerandom'
 
 FactoryGirl.define do
   factory :device do
+    user
     name  Faker::Internet.user_name
     uuid  SecureRandom.uuid
     token SecureRandom.urlsafe_base64


### PR DESCRIPTION
# Why?

 * We're switching over to an 'auto-sync' architecture. This requires the bot to have access to the API

# What Changed?

 * Added `bot_uuid` and `bot_token` HTTP headers as a means to auth.