### PR TITLE
Ask for bot status on page load

### DIFF
--- a/app/assets/javascripts/farmbot_app/factories/router.js.coffee
+++ b/app/assets/javascripts/farmbot_app/factories/router.js.coffee
@@ -1,15 +1,16 @@
 angular.module("FarmBot").factory 'Router', [
   ->
     routes =
-      read_status: (data, dvc) -> dvc[k] = v for k, v of (data.params || {})
+      read_status: (data, dvc) ->
+        dvc[k] = v for k, v of (data.params || data.result || {})
       error: (data, device) ->
-        msg = data?.error?.error || "Unexpected error. See console."
+        msg = data?.error?.error || "Unexpected error."
         alert "FarmBot sent back an error: #{msg}. See console for details"
         console.warn data
-      missing: (data, device)        -> yes
-      exec_sequence: (data, device)  -> yes
-      sync_sequence: (data, device)  -> device.syncStatus = "synced"
-      confirmation: (data, device)   -> yes
+      sync_sequence:  (data, device) -> device.syncStatus = "synced"
+      missing:        (data, device) -> yes
+      exec_sequence:  (data, device) -> yes
+      confirmation:   (data, device) -> yes
       single_command: (data, device) -> yes
 
     route: (data, bot = {}) ->

--- a/app/assets/javascripts/farmbot_app/services/devices.js.coffee
+++ b/app/assets/javascripts/farmbot_app/services/devices.js.coffee
@@ -37,7 +37,7 @@ class DeviceService
           token: "bcbd352aaeb9b7f18214a63cb4f3b16b89d8fd24"
         @socket.emit 'subscribe',
           uuid: @current.uuid, token: @current.token,
-          (data) -> console.log 'Subscribed to bot successfully.'
+          (data) => @send "read_status"
   togglePin: (number, cb) ->
     switch @current["pin#{number}"]
        when 'on' then @send "pin_write", pin: number, value1: 0, mode: 0
@@ -61,23 +61,29 @@ class DeviceService
         cb(d)
 
   send: (msg, body = {}) ->
+    return opps() unless @socket.connected()
     uuid = ->
       'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) ->
         r = Math.random() * 16 | 0
         v = if c is 'x' then r else (r & 0x3|0x8)
         v.toString(16)
       )
-    if @socket.connected()
-      cmd = @Command.create(msg, body)
+    # LEGACY COMPATIBILITY STUFF AHEAD! We had a different naming convention
+    # that used 2 object keys (`action` and `message_type`). I switched it to
+    # use 'topic' style routing keys (strings). The code below massages the
+    # legacy code into a usable format with out breaking old stuff. TODO: go
+    # back and remove legacy calls.
+    cmd = @Command.create(msg, body)
+    if cmd.command && cmd.command.action
       stringy_method = "#{cmd.message_type || 'undefined'}"
-      stringy_method += ".#{cmd.command.action}" if cmd.command.action
-      @socket.emit "message",
-        devices: @current.uuid,
-        params: _.omit(cmd.command, "action"),
-        method: stringy_method,
-        id: uuid()
+      stringy_method += ".#{cmd.command.action}"
     else
-      opps()
+      stringy_method = msg
+    @socket.emit "message",
+      devices: @current.uuid,
+      params: _.omit(cmd.command, "action"),
+      method: stringy_method,
+      id: uuid()
 
 angular.module("FarmBot").service "Devices",[
   'Command'


### PR DESCRIPTION
# What's New?

 * Browser needs to do a `read_status` request when it loads, otherwise it won't have status information until the bot moves. Already deployed. 