### PR TITLE
Transfer schedule / sequence ownership from user to bot 

### DIFF
--- a/app/controllers/api/abstract_controller.rb
+++ b/app/controllers/api/abstract_controller.rb
@@ -20,7 +20,9 @@ module Api
 private
 
     def current_device
-      current_user.try(:device) || NullDevice.new(user: current_user)
+      current_user.try(:device) || NullDevice
+                                    .new(users: [current_user])
+                                    .reject(&:empty?)
     end
 
     def authenticate_user!

--- a/app/controllers/api/abstract_controller.rb
+++ b/app/controllers/api/abstract_controller.rb
@@ -20,9 +20,7 @@ module Api
 private
 
     def current_device
-      current_user.try(:device) || NullDevice
-                                    .new(users: [current_user])
-                                    .reject(&:empty?)
+      @current_device ||= (current_user.try(:device) || NullDevice.new)
     end
 
     def authenticate_user!
@@ -30,7 +28,7 @@ private
       auth = Auth::Create.run(bot_token: request.headers["HTTP_BOT_TOKEN"],
                               bot_uuid:  request.headers["HTTP_BOT_UUID"])
       if auth.success?
-        @current_user = auth.result
+        @current_device = auth.result
       else
         sorry("""You failed to authenticate with the API. Ensure that you have
          provided a `bot_token` and `bot_uuid` header in the HTTP request.

--- a/app/controllers/api/abstract_controller.rb
+++ b/app/controllers/api/abstract_controller.rb
@@ -19,6 +19,10 @@ module Api
 
 private
 
+    def current_device
+      current_user.try(:device) || NullDevice.new(user: current_user)
+    end
+
     def authenticate_user!
       return true if current_user
       auth = Auth::Create.run(bot_token: request.headers["HTTP_BOT_TOKEN"],

--- a/app/controllers/api/devices_controller.rb
+++ b/app/controllers/api/devices_controller.rb
@@ -4,18 +4,13 @@ module Api
   class DevicesController < Api::AbstractController
     before_action :set_device, only: [:show, :edit, :update, :destroy]
 
-    # GET /api/devices
-    def index
+    # GET /api/device
+    def show
       @devices = Device.where(user_id: current_user.id)
       render json: @devices
     end
 
-    # GET /api/devices/1
-    # def show
-    #   raise 'Not implemented.'
-    # end
-
-    # POST /api/devices
+    # POST /api/device
     def create
       @device      = Device.new(device_params)
       @device.user = current_user
@@ -24,7 +19,7 @@ module Api
       end
     end
 
-    # PATCH/PUT /api/devices/1
+    # PATCH/PUT /api/device
     def update
       if @device.update_attributes(device_params)
         render json: @device

--- a/app/controllers/api/devices_controller.rb
+++ b/app/controllers/api/devices_controller.rb
@@ -2,43 +2,36 @@
 # settings. Consumed by the Angular SPA on the front end.
 module Api
   class DevicesController < Api::AbstractController
-    before_action :set_device, only: [:show, :edit, :update, :destroy]
 
     # GET /api/device
     def show
-      @devices = Device.where(user_id: current_user.id)
-      render json: @devices
+      render json: current_device
     end
 
     # POST /api/device
     def create
-      @device      = Device.new(device_params)
-      @device.user = current_user
-      if @device.save
-        render json: @device
+      current_user.device = Device.new(device_params)
+      if current_user.device.save
+        render json: current_device
       end
     end
 
     # PATCH/PUT /api/device
     def update
-      if @device.update_attributes(device_params)
-        render json: @device
+      if current_device.update_attributes(device_params)
+        render json: current_device
       end
     end
 
     # DELETE /api/devices/1
     def destroy
-      if @device.user == current_user
-        @device.destroy
+      if current_device.users.include?(current_user)
+        current_device.destroy
         render nothing: true, status: 204
       end
     end
 
     private
-      # Use callbacks to share common setup or constraints between actions.
-      def set_device
-        @device = Device.find(params[:id])
-      end
 
       # Only allow a trusted parameter "white list" through.
       def device_params

--- a/app/controllers/api/devices_controller.rb
+++ b/app/controllers/api/devices_controller.rb
@@ -10,8 +10,8 @@ module Api
 
     # POST /api/device
     def create
-      current_user.device = Device.new(device_params)
-      if current_user.device.save
+      # TODO: Make a service that deletes old devices when they become 'orphans'
+      if current_user.update_attributes(device: Device.create(device_params))
         render json: current_device
       end
     end

--- a/app/controllers/api/schedules_controller.rb
+++ b/app/controllers/api/schedules_controller.rb
@@ -3,7 +3,7 @@ module Api
     def index
       # Follow this for better querying in the future:
       # http://www.js-data.io/v1.3.0/docs/query-syntax
-      render json: Schedule.where(device: current_device)
+      render json: current_device.schedules
     end
 
     def create

--- a/app/controllers/api/schedules_controller.rb
+++ b/app/controllers/api/schedules_controller.rb
@@ -3,30 +3,26 @@ module Api
     def index
       # Follow this for better querying in the future:
       # http://www.js-data.io/v1.3.0/docs/query-syntax
-      render json: Schedule.where(user: current_user)
+      render json: Schedule.where(device: current_device)
     end
 
     def create
       mutate Schedules::Create.run(params,
-                                   user: current_user,
+                                   device: current_device,
                                    sequence: sequence)
     end
 
-    # def show
-    #   render json: schedule
-    # end
-
     def update
-      if schedule.user != current_user
+      if schedule.device != current_device
         raise Errors::Forbidden, 'Not your schedule.'
       end
       mutate Schedules::Update.run(params[:schedule],
-                                   user: current_user,
+                                   device: current_device,
                                    schedule: schedule)
     end
 
     def destroy
-      if (schedule.user == current_user) && schedule.destroy
+      if (schedule.device_id == current_device.id) && schedule.destroy
         render nothing: true
       else
         raise Errors::Forbidden, 'Not your schedule.'

--- a/app/controllers/api/sequences_controller.rb
+++ b/app/controllers/api/sequences_controller.rb
@@ -2,7 +2,7 @@ module Api
   class SequencesController < Api::AbstractController
     # TODO add user authorization maybe (privacy)
     def index
-      query = { user: current_user }
+      query = { device: current_device }
       query.merge!(schedule_id: params[:schedule_id]) if params[:schedule_id]
       render json: Sequence.where(query)
     end
@@ -12,7 +12,7 @@ module Api
     end
 
     def create
-      mutate Sequences::Create.run(params, user: current_user)
+      mutate Sequences::Create.run(params, device: current_device)
     end
 
     def update
@@ -24,7 +24,7 @@ module Api
     def destroy
       # HEY YOU!! If you touch this again, add a mutation. This is the most
       # complexity I would like to see in one controlelr action.
-      if (sequence.user == current_user) && sequence.destroy
+      if (sequence.device == current_device) && sequence.destroy
         render nothing: true
       else
         raise Errors::Forbidden, "Not your Sequence object."

--- a/app/controllers/api/steps_controller.rb
+++ b/app/controllers/api/steps_controller.rb
@@ -35,7 +35,7 @@ module Api
     end
 
     def must_own_sequence
-      if sequence.user != current_user
+      if sequence.device != current_device
         raise Errors::Forbidden, 'Not your Sequence object.'
       end
     end

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -3,7 +3,10 @@
 class Device
   include Mongoid::Document
 
-  belongs_to :user
+  has_many :users
+  has_many :schedules, dependent: :destroy
+  has_many :sequences
+
 
   # The SkyNet UUID of the device
   field :uuid

--- a/app/models/null_device.rb
+++ b/app/models/null_device.rb
@@ -1,0 +1,13 @@
+class NullDevice < Device
+  def save
+    no(__method__)
+  end
+
+  def save!
+    no(__method__)
+  end
+
+  def no(method)
+    raise 'Cant call #{method} on a NullDevice'
+  end
+end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -5,8 +5,8 @@ class Schedule
 
   belongs_to :sequence
   validates_presence_of :sequence_id
-  belongs_to :user
-  validates_presence_of :user_id
+  belongs_to :device
+  validates_presence_of :device_id
 
   field :start_time, type: Time
   field :end_time, type: Time

--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -2,7 +2,7 @@ class Sequence
   include Mongoid::Document
 
   belongs_to :schedule
-  belongs_to :user
+  belongs_to :device
   embeds_many :steps
   has_many :schedules, dependent: :destroy
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,8 +2,7 @@
 class User
   include Mongoid::Document
 
-  has_many :devices, dependent: :destroy
-  has_many :schedules, dependent: :destroy
+  belongs_to :device, dependent: :destroy
 
   field :name, type: String
   validates_uniqueness_of :name
@@ -11,8 +10,6 @@ class User
 
   field :email, type: String, default: ""
   validates_uniqueness_of :email
-
-  has_many :sequences
 
   # BEGIN DEVISE CRAP ==========================================================
   devise :database_authenticatable, :registerable, :recoverable, :rememberable,

--- a/app/mutations/auth/create.rb
+++ b/app/mutations/auth/create.rb
@@ -8,7 +8,7 @@ module Auth
     end
 
     def execute
-      Device.find_by(uuid: bot_uuid, token: bot_token).user
+      Device.find_by(uuid: bot_uuid, token: bot_token)
     rescue Mongoid::Errors::DocumentNotFound
       add_error :auth, :*, 'Bad uuid or token'
     end

--- a/app/mutations/schedules/create.rb
+++ b/app/mutations/schedules/create.rb
@@ -6,7 +6,7 @@ module Schedules
 
     required do
       model :sequence, class: Sequence
-      model :user, class: User
+      model :device, class: Device
       integer :repeat
       string :time_unit, in: Schedule::UNITS_OF_TIME
     end

--- a/app/mutations/schedules/update.rb
+++ b/app/mutations/schedules/update.rb
@@ -6,7 +6,7 @@ module Schedules
 
     required do
       model :schedule, class: Schedule
-      model :user, class: User
+      model :device, class: Device
     end
 
     optional do

--- a/app/mutations/sequences/create.rb
+++ b/app/mutations/sequences/create.rb
@@ -3,7 +3,7 @@ module Sequences
     using MongoidRefinements
 
     required do
-      model :user, class: User
+      model :device, class: Device
       string :name
       array :steps, default: [] do
         model :step, builder: Steps::Initialize, new_records: true

--- a/app/mutations/sequences/update.rb
+++ b/app/mutations/sequences/update.rb
@@ -13,7 +13,7 @@ module Sequences
     end
 
     def validate
-      raise Errors::Forbidden unless sequence.user == user
+      raise Errors::Forbidden unless sequence.device.users.include?(user)
     end
 
     def execute

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ FarmBot::Application.routes.draw do
 
   mount JasmineRails::Engine => '/specs' if defined?(JasmineRails)
   namespace :api, defaults: {format: :json} do
-    resources :devices, only: [:index, :destroy, :create, :update]
+    resource :device, only: [:show, :destroy, :create, :update]
     resources :sequences, only: [:create, :update, :destroy, :index, :show] do
       resources :steps, only: [:show, :create, :index, :update, :destroy]
     end

--- a/spec/controllers/api/bot_auth_spec.rb
+++ b/spec/controllers/api/bot_auth_spec.rb
@@ -11,7 +11,7 @@ describe Api::SchedulesController do
       @request.headers["HTTP_BOT_TOKEN"] = device.token
       @request.headers["HTTP_BOT_UUID"]  = device.uuid
       get :index
-      expect(subject.current_user).to eq(device.user)
+      expect(device.users).to include(subject.current_user)
     end
 
     it 'tells you why you failed to auth' do

--- a/spec/controllers/api/bot_auth_spec.rb
+++ b/spec/controllers/api/bot_auth_spec.rb
@@ -5,13 +5,14 @@ describe Api::SchedulesController do
 
   describe 'Bot authentication' do
 
-    let(:device) { FactoryGirl.create(:device) }
+    let(:user) { FactoryGirl.create(:user) }
+    let(:device) { user.device }
 
     it 'authorizes using MeshBlu UUID / Token' do
       @request.headers["HTTP_BOT_TOKEN"] = device.token
       @request.headers["HTTP_BOT_UUID"]  = device.uuid
       get :index
-      expect(device.users).to include(subject.current_user)
+      expect(device).to eq(subject.send(:current_device))
     end
 
     it 'tells you why you failed to auth' do

--- a/spec/controllers/api/devices/devices_controller_create_spec.rb
+++ b/spec/controllers/api/devices/devices_controller_create_spec.rb
@@ -14,7 +14,7 @@ describe Api::DevicesController do
       post :create, params
       resp       = JSON.parse(response.body)
       new_device = Device.find(resp['_id'])
-      expect(new_device.user).to eq(user)
+      expect(user.device).to eq(new_device)
       expect(response.status).to eq(200)
     end
   end

--- a/spec/controllers/api/devices/devices_controller_create_spec.rb
+++ b/spec/controllers/api/devices/devices_controller_create_spec.rb
@@ -14,6 +14,7 @@ describe Api::DevicesController do
       post :create, params
       resp       = JSON.parse(response.body)
       new_device = Device.find(resp['_id'])
+      user.reload
       expect(user.device).to eq(new_device)
       expect(response.status).to eq(200)
     end

--- a/spec/controllers/api/devices/devices_controller_destroy_spec.rb
+++ b/spec/controllers/api/devices/devices_controller_destroy_spec.rb
@@ -10,9 +10,9 @@ describe Api::DevicesController do
 
     it 'destroys a Device' do
       sign_in user
-      delete :destroy, id: user.devices.first.id, fromat: :json
+      delete :destroy, id: user.device.id, fromat: :json
       user.reload
-      expect(user.devices.count).to eq(0)
+      expect(user.device).to be_nil
       expect(response.status).to eq(204)
     end
   end

--- a/spec/controllers/api/devices/devices_controller_index_spec.rb
+++ b/spec/controllers/api/devices/devices_controller_index_spec.rb
@@ -4,21 +4,21 @@ describe Api::DevicesController do
 
   include Devise::TestHelpers
 
-  describe '#index' do
+  describe '#show' do
 
     let(:user) { FactoryGirl.create(:user) }
 
     it 'returns all the users devices, as JSON' do
       sign_in user
-      get :index, format: :json
-      device = user.devices.first
-      id = JSON.parse(response.body).first["_id"]
+      get :show, format: :json
+      device = user.device
+      id = JSON.parse(response.body)["_id"]
       expect(Device.find(id)).to eq(device)
       expect(response.status).to eq(200)
     end
 
     it 'handles requests from unauthenticated users' do
-      get :index, format: :json # FIXME: Y U NO DEFAULT JSON?
+      get :show, format: :json # FIXME: Y U NO DEFAULT JSON?
       expect(response.status).to eq(401)
     end
   end

--- a/spec/controllers/api/devices/devices_controller_show_spec.rb
+++ b/spec/controllers/api/devices/devices_controller_show_spec.rb
@@ -5,16 +5,5 @@ describe Api::DevicesController do
   include Devise::TestHelpers
 
   describe '#show' do
-
-    # let(:user) { FactoryGirl.create(:user) }
-
-    # it 'shows a single Device' do
-    #   pending 'Pending until implemented'
-    #   sign_in user
-    #   get :show, {id: user.devices.first.id}
-    #   shown = JSON.parse response.body
-    #   expect(shown).to eq(user.devices.first.to_json)
-    #   expect(response.status).to eq(204)
-    # end
   end
 end

--- a/spec/controllers/api/devices/devices_controller_update_spec.rb
+++ b/spec/controllers/api/devices/devices_controller_update_spec.rb
@@ -13,10 +13,10 @@ describe Api::DevicesController do
     it 'updates a Device' do
       sign_in user
       fake_name = Faker::Name.name
-      put :update, {id: user.devices.first.id, name: fake_name}, format: :json
+      put :update, {id: user.device.id, name: fake_name}, format: :json
       # put path, params, options
       user.reload
-      device = user.devices.first
+      device = user.device
       expect(device.name).to eq(fake_name)
       expect(response.status).to eq(200)
     end

--- a/spec/controllers/api/schedules/schedules_destroy_spec.rb
+++ b/spec/controllers/api/schedules/schedules_destroy_spec.rb
@@ -8,7 +8,7 @@ describe Api::SchedulesController do
 
     it 'deletes a schedule' do
       sign_in user
-      schedule = FactoryGirl.create(:schedule, user: user)
+      schedule = FactoryGirl.create(:schedule, device: user.device)
       before = Schedule.count
       delete :destroy, id: schedule._id.to_s
 

--- a/spec/controllers/api/schedules/schedules_index_spec.rb
+++ b/spec/controllers/api/schedules/schedules_index_spec.rb
@@ -10,7 +10,7 @@ describe Api::SchedulesController do
     it 'lists all schedules for a user' do
       sign_in user
       schedules = FactoryGirl
-                    .create_list(:schedule, 2, user: user)
+                    .create_list(:schedule, 2, device: user.device)
                     .map(&:_id)
                     .map(&:to_s)
                     .sort

--- a/spec/controllers/api/schedules/schedules_update_spec.rb
+++ b/spec/controllers/api/schedules/schedules_update_spec.rb
@@ -6,9 +6,9 @@ describe Api::SchedulesController do
   describe '#update' do
     let(:user) { FactoryGirl.create(:user) }
 
-    it 'prevents unauthorized modification' do
+    it 'allows authorized modification' do
       sign_in user
-      id = FactoryGirl.create(:schedule, user: user)._id.to_s
+      id = FactoryGirl.create(:schedule, device: user.device)._id.to_s
       input = { id: id, schedule: { repeat: 66 } }
       patch :update, input
       expect(response.status).to eq(200)

--- a/spec/controllers/api/sequences/sequences_destroy_spec.rb
+++ b/spec/controllers/api/sequences/sequences_destroy_spec.rb
@@ -6,8 +6,10 @@ describe Api::SequencesController do
 
   describe '#destroy' do
 
-    let(:sequence) { FactoryGirl.create(:sequence) }
-    let(:user) { sequence.user }
+
+    let(:user) { FactoryGirl.create(:user) }
+    let(:device) { user.device }
+    let(:sequence) { FactoryGirl.create(:sequence, device: device) }
 
     it 'destroys a sequence' do
       sign_in user

--- a/spec/controllers/api/sequences/sequences_index_spec.rb
+++ b/spec/controllers/api/sequences/sequences_index_spec.rb
@@ -11,7 +11,7 @@ describe Api::SequencesController do
     it 'lists all sequences for a user' do
       sign_in user
       sequences = FactoryGirl
-                    .create_list(:sequence, 2, user: user)
+                    .create_list(:sequence, 2, device: user.device)
                     .map(&:id)
                     .map(&:to_s)
                     .sort

--- a/spec/controllers/api/sequences/sequences_show_spec.rb
+++ b/spec/controllers/api/sequences/sequences_show_spec.rb
@@ -10,7 +10,7 @@ describe Api::SequencesController do
 
     it 'shows sequence' do
       sign_in user
-      id = FactoryGirl.create(:sequence, user: user)._id.to_s
+      id = FactoryGirl.create(:sequence, device: user.device)._id.to_s
       get :show, id: id
       expect(response.status).to eq(200)
       expect(json[:_id]).to eq(id)

--- a/spec/controllers/api/sequences/sequences_update_spec.rb
+++ b/spec/controllers/api/sequences/sequences_update_spec.rb
@@ -10,7 +10,7 @@ describe Api::SequencesController do
 
     it 'updates existing sequences' do
       sign_in user
-      sequence = FactoryGirl.create(:sequence, user: user)
+      sequence = FactoryGirl.create(:sequence, device: user.device)
       input = { id: sequence._id.to_s,
                 sequence: { name: "Scare Birds",
                             steps: [{ message_type: 'move_relative',

--- a/spec/controllers/api/steps/create_spec.rb
+++ b/spec/controllers/api/steps/create_spec.rb
@@ -6,8 +6,8 @@ describe Api::StepsController do
 
   describe '#create' do
 
-    let(:sequence) { FactoryGirl.create(:sequence) }
-    let(:user) { sequence.user }
+    let(:sequence) { FactoryGirl.create(:sequence, device: user.device) }
+    let(:user) { FactoryGirl.create :user }
 
     it 'creates a new step sequence' do
       sign_in user

--- a/spec/controllers/api/steps/destroy_spec.rb
+++ b/spec/controllers/api/steps/destroy_spec.rb
@@ -5,11 +5,13 @@ describe Api::StepsController do
   include Devise::TestHelpers
 
   describe '#destroy' do
+    let(:user) { FactoryGirl.create(:user) }
     let(:sequence) do
-      FactoryGirl.create(:sequence, steps: FactoryGirl.build_list(:step, 2))
+      FactoryGirl.create(:sequence,
+                         steps: FactoryGirl.build_list(:step, 2),
+                         device: user.device)
     end
     let(:step) { sequence.steps[0] }
-    let(:user) { sequence.user }
 
     it 'destroys a step sequence' do
       sign_in user

--- a/spec/controllers/api/steps/index_spec.rb
+++ b/spec/controllers/api/steps/index_spec.rb
@@ -5,8 +5,8 @@ describe Api::StepsController do
   include Devise::TestHelpers
 
   describe '#index' do
-    let(:sequence) { FactoryGirl.create(:sequence) }
-    let(:user) { sequence.user }
+    let(:user) { FactoryGirl.create(:user) }
+    let(:sequence) { FactoryGirl.create(:sequence, device: user.device) }
 
     it 'retrieves all steps for a sequence' do
       sign_in user

--- a/spec/controllers/api/steps/show_spec.rb
+++ b/spec/controllers/api/steps/show_spec.rb
@@ -4,8 +4,8 @@ describe Api::StepsController do
   include Devise::TestHelpers
 
   describe '#show' do
-    let(:sequence) { FactoryGirl.create(:sequence) }
-    let(:user) { sequence.user }
+    let(:sequence) { FactoryGirl.create(:sequence, device: user.device) }
+    let(:user) { FactoryGirl.create :user }
 
     it 'retrieves all steps for a sequence' do
       id = sequence.steps.first._id.to_s

--- a/spec/controllers/api/steps/update_spec.rb
+++ b/spec/controllers/api/steps/update_spec.rb
@@ -5,9 +5,9 @@ describe Api::StepsController do
   include Devise::TestHelpers
 
   describe '#update' do
-    let(:sequence) { FactoryGirl.create(:sequence) }
+    let(:sequence) { FactoryGirl.create(:sequence, device: user.device) }
     let(:step) { sequence.steps[0] }
-    let(:user) { sequence.user }
+    let(:user) { FactoryGirl.create :user }
 
     it 'updates a step' do
       sign_in user

--- a/spec/factories/devices.rb
+++ b/spec/factories/devices.rb
@@ -3,7 +3,6 @@ require 'securerandom'
 
 FactoryGirl.define do
   factory :device do
-    user
     name  Faker::Internet.user_name
     uuid  SecureRandom.uuid
     token SecureRandom.urlsafe_base64

--- a/spec/factories/schedules.rb
+++ b/spec/factories/schedules.rb
@@ -7,7 +7,7 @@ FactoryGirl.define do
     after(:build) do |s|
       s.next_time ||= s.calculate_next_occurence
       s.sequence ||= create(:sequence)
-      s.user ||= s.sequence.user
+      s.device ||= s.sequence.device
     end
   end
 end

--- a/spec/factories/sequences.rb
+++ b/spec/factories/sequences.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
   factory :sequence do
     name { Faker::Company.catch_phrase }
     color { Sequence::COLORS.sample }
-    user
+    device
     steps { FactoryGirl.build_list(:step, 1) }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,11 +2,10 @@
 
 FactoryGirl.define do
   factory :user do
+    device
     name { Faker::Name.name }
     email { Faker::Internet.email }
     password { Faker::Internet.password(8) }
-    after(:create) do |user|
-      FactoryGirl.create(:device, user: user)
-    end
+    after(:create) { |user| user.device ||= FactoryGirl.create(:device) }
   end
 end

--- a/spec/models/farmbot_device_spec.rb
+++ b/spec/models/farmbot_device_spec.rb
@@ -1,13 +1,12 @@
 require 'spec_helper'
 
 describe Device do
-  let(:user)  { FactoryGirl.create(:user) }
-  let(:device){ FactoryGirl.create(:device, user: user)}
+  let(:device){ FactoryGirl.create(:device, users: [FactoryGirl.create(:user)])}
+  let(:user)  { device.users.first }
 
   it 'is associated with a user' do
-    expect(device.user).to be_kind_of(User)
-    expect(user.devices).to be_kind_of(Array)
-    expect(user.devices.first).to be_kind_of(Device)
+    expect(device.users.first).to be_kind_of(User)
+    expect(user.device).to be_kind_of(Device)
   end
 
   it 'destroys dependant devices' do

--- a/spec/mutations/schedules/create_spec.rb
+++ b/spec/mutations/schedules/create_spec.rb
@@ -3,17 +3,17 @@ require 'spec_helper'
 describe Schedules::Create do
   it 'Builds a schedule' do
     seq = FactoryGirl.create(:sequence)
-    user = seq.user
+    device = seq.device
     start_time = '2015-02-17T15:16:17.000Z'
     end_time = '2099-02-17T18:19:20.000Z'
-    schedule = Schedules::Create.run!(user: user,
+    schedule = Schedules::Create.run!(device: device,
                                       sequence: seq,
                                       start_time: start_time,
                                       end_time: end_time,
                                       repeat: 4,
                                       time_unit: 'minutely').reload
     expect(schedule).to be_kind_of(Schedule)
-    expect(schedule.user).to eq(user)
+    expect(schedule.device).to eq(device)
     expect(schedule.sequence).to eq(seq)
     expect(schedule.start_time.to_time).to eq(Time.parse start_time)
     expect(schedule.end_time.to_time).to eq(Time.parse end_time)

--- a/spec/mutations/sequences/create_spec.rb
+++ b/spec/mutations/sequences/create_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe Steps::Create do
   let(:user) { FactoryGirl.create(:user) }
+  let(:device) { user.device }
   let(:mutation) { Sequences::Create }
   let(:step) do
     { message_type: 'move_relative',
@@ -14,18 +15,16 @@ describe Steps::Create do
   end
 
   let(:valid_params) do
-    { user: user,
+    { device: device,
       name: 'Hi.',
       steps: [step] }
   end
 
   it 'Builds a `sequence`' do
-    outcome = mutation.run(valid_params)
-    expect(outcome.success?).to be_truthy
-    seq = outcome.result
+    seq = mutation.run!(valid_params)
 
     expect(seq.steps.count).to eq(1)
     expect(seq.name).to eq('Hi.')
-    expect(seq.user).to eq(user)
+    expect(seq.device).to eq(device)
   end
 end

--- a/spec/mutations/steps/update_spec.rb
+++ b/spec/mutations/steps/update_spec.rb
@@ -2,8 +2,9 @@ require 'spec_helper'
 
 describe Steps::Update do
   let(:user) { FactoryGirl.create(:user) }
+  let(:device) { user.device }
   let(:mutation) { Steps::Update }
-  let(:sequence) { FactoryGirl.create(:sequence, user: user) }
+  let(:sequence) { FactoryGirl.create(:sequence, device: device) }
 
   it 'automatically populates position field via black magic.' do
     # This feature is a crime against humanity. Sorry :(
@@ -38,7 +39,7 @@ describe Steps::Update do
   end
 
   it 'moves first to middle' do
-    sequence = Sequences::Create.run!(name: 'test', user: user)
+    sequence = Sequences::Create.run!(name: 'test', device: device)
 
     a = Steps::Create.run!(message_type: 'pin_write',
                           sequence: sequence,


### PR DESCRIPTION
# Why?

 * Sometimes Rory and I would work on the same bot and get weird situations where we were overwriting eachothers work on the device.
 * Sharing devices was problematic

# What's New?

 * We have `current_device` alongside `current_user`
 * Devices are the owners of their sequences.