### PR TITLE
npm install step

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ This Repo is the Web based side of FarmBot. It allows users to control the devic
  3. [Install MongoDB](http://docs.mongodb.org/manual/tutorial/install-mongodb-on-os-x/)
  4. Start Mongo if you have not already done so. (typically via the `mongod` command)
  3. `bundle install`
- 4. `rails s`
- 5. Go to `http://localhost:3000`
+ 4.  `npm install`
+ 5. `rails s`
+ 6. Go to `http://localhost:3000`
 
 **We can't fix issues we don't know about.** Please submit an issue if you are having trouble installing on your local machine.
 


### PR DESCRIPTION
Needed to also ```npm install``` for the front end app relevant piece. Noting in the documentation.

Without it, i got this error after step 5:

```bash
ActionView::Template::Error (Unable to run node_modules/.bin/browserify. Ensure you have installed it with npm.
  (in /home/yuvilio/ws/apps/ruby/farmbot-web-app/app/assets/javascripts/application.js.jsx))
    10:     = stylesheet_link_tag "application"
    11:     = csrf_meta_tags
    12:     = javascript_include_tag "//cdnjs.cloudflare.com/ajax/libs/redux/1.0.1/redux.min.js"
    13:     = javascript_include_tag "application"
    14:   %body{'ng-app' => 'FarmBot'}
    15:     .row
    16:       %nav.drop-shadow{ng_app: 'farmbot', ng_controller: 'nav'}  
```