### PR TITLE
Re-add coverage checks for Ruby code.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem "rollbar"
 gem "skylight"
 
 group :development, :test do
-  gem 'coveralls', require: false
+  gem 'codecov', require: false
   gem "database_cleaner"
   gem "pry"
   gem "factory_girl_rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,14 +97,12 @@ GEM
     climate_control (0.2.0)
     cocaine (0.5.8)
       climate_control (>= 0.0.3, < 1.0)
+    codecov (0.1.10)
+      json
+      simplecov
+      url
     coderay (1.1.1)
     concurrent-ruby (1.0.5)
-    coveralls (0.8.21)
-      json (>= 1.8, < 3)
-      simplecov (~> 0.14.1)
-      term-ansicolor (~> 1.3)
-      thor (~> 0.19.4)
-      tins (~> 1.6)
     daemons (1.2.4)
     database_cleaner (1.6.1)
     diff-lcs (1.3)
@@ -260,17 +258,15 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    term-ansicolor (1.6.0)
-      tins (~> 1.0)
     thin (1.7.0)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
       rack (>= 1, < 3)
     thor (0.19.4)
     thread_safe (0.3.6)
-    tins (1.15.0)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
+    url (0.3.2)
     warden (1.2.7)
       rack (>= 1.0)
     websocket-driver (0.6.5)
@@ -282,7 +278,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers
-  coveralls
+  codecov
   database_cleaner
   delayed_job!
   delayed_job_active_record!

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![codebeat badge](https://codebeat.co/badges/7b023dc5-6509-42af-ad6e-ec0b8262ef13)](https://codebeat.co/projects/github-com-rickcarlino-farmbot-web-app-master)
 [![Coverage Status](https://coveralls.io/repos/github/FarmBot/Farmbot-Web-App/badge.svg)](https://coveralls.io/github/FarmBot/Farmbot-Web-App)
+[![codecov](https://codecov.io/gh/FarmBot/Farmbot-Web-App/branch/master/graph/badge.svg)](https://codecov.io/gh/FarmBot/Farmbot-Web-App)
 
 # Q: Do I need this?
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,9 @@ SimpleCov.start do
   add_filter '/spec/'
   add_filter 'config/initializers'
 end
+
+require 'codecov'
+SimpleCov.formatter = SimpleCov::Formatter::Codecov
 require 'pry'
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV['RAILS_ENV'] ||= 'test'


### PR DESCRIPTION
# What's New?

 * Coveralls is only recording JS coverage at the moment.
 * I still want to track Ruby coverage.
 * Going to try using `codecov.io` for Ruby and `coveralls.io` for TS code.

If all goes well, this PR should add Ruby coverage back to the CI.