### PR TITLE
Dont render calendar if its a FarmEvent<Regimen>

### DIFF
--- a/app/serializers/farm_event_serializer.rb
+++ b/app/serializers/farm_event_serializer.rb
@@ -6,7 +6,7 @@ class FarmEventSerializer < ActiveModel::Serializer
   def calendar
     case object.executable
       when Sequence then sequence_calendar
-      when Regimen  then regimen_calendar
+      when Regimen  then []
       else
         msg = "Dont know how to calendarize #{object.executable.class}"
         throw BadExe.new(msg)
@@ -14,18 +14,6 @@ class FarmEventSerializer < ActiveModel::Serializer
   end
 
   private
-
-  def regimen_calendar
-    object
-      .executable
-      .regimen_items
-      .pluck(:time_offset)
-      .map { |x| x / 1000 }
-      .map { |x| object.start_time.midnight + x }
-      .map(&:utc)
-      .select { |x| !x.past? }
-      .map(&:as_json) || []
-  end
 
   def sequence_calendar
     FarmEvents::GenerateCalendar

--- a/spec/serializers/farm_event_serializer_spec.rb
+++ b/spec/serializers/farm_event_serializer_spec.rb
@@ -10,13 +10,6 @@ describe FarmEventSerializer do
     fe
   end
 
-  it "renders a regimen" do
-    result = FarmEventSerializer.new(farm_event).as_json
-    cal = result[:calendar]
-    expect(cal.length).to be(1)
-    expect(cal.first).to eq((farm_event.start_time.midnight + 7.seconds).as_json)
-  end
-
   it "does not render `nil` and friends" do
     farm_event.executable = nil
     expect{


### PR DESCRIPTION
# Why?

 * We don't use the `calendar` property returned from `/farm_events` if it executes a `Regimen`.

# What Changed?

 * Return `[]` if `farm_event.executable_type == "Regimen"`.

# What's Next?

 * Sunset the `calendar` property?