### PR TITLE
More Calendar tweaks; New log types

### DIFF
--- a/app/controllers/api/logs_controller.rb
+++ b/app/controllers/api/logs_controller.rb
@@ -9,8 +9,12 @@ module Api
                  .create(raw_json.last(current_device.max_log_count)
                                  .map    { |i| new_log(i) }
                                  .select { |i| i.success? } # <= Ignore rejects
-                                 .map    { |i| i.result } # Don't save jokes:
-                                 .select { |i| i.meta["type"] != "fun"}
+                                 .map    { |i| i.result }
+                                 .reject do |i|
+                                   # Don't save jokes or debug info:
+                                   t = i.meta["type"]
+                                   ["fun", "debug"].include?(t)
+                                 end
                                  .map    { |i| i.as_json })
                  .tap { |i| maybe_deliver(i) }
         render json: logs

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -5,7 +5,7 @@ class Log < ApplicationRecord
   # pagination, but could later on.
   PAGE_SIZE = 25
   # self.meta[:type] is used by the bot and the frontend as a sort of
-  TYPES     = %w(success busy warn error info fun)
+  TYPES     = %w(success busy warn error info fun debug)
   # The means by which the message will be sent. Ex: frontend toast notification
   serialize  :channels
   belongs_to :device

--- a/spec/controllers/api/logs/logs_spec.rb
+++ b/spec/controllers/api/logs/logs_spec.rb
@@ -65,7 +65,7 @@ describe Api::LogsController do
       expect(before_count + 3).to eq(Log.count)
     end
 
-    it 'does not bother saving `fun` logs' do
+    it 'does not bother saving `fun` or `debug` logs' do
       sign_in user
       Log.destroy_all
       before_count = Log.count
@@ -76,6 +76,9 @@ describe Api::LogsController do
               channels: ["toast"],
               message: "one" },
             { meta: { x: 1, y: 2, z: 3, type: "fun" }, # Ignored
+              channels: [],
+              message: "two" },
+            { meta: { x: 1, y: 2, z: 3, type: "debug" }, # Ignored
               channels: [],
               message: "two" },
             { meta: { x: 1, y: 2, z: 3, type: "info" },


### PR DESCRIPTION
# What's New?

 * Add a 5 minute grace period to calendar scheduling so stuff doesn't disappear so fast.
 * Add an ephemeral `debug` log type for "noisy" messages.
