### PR TITLE
Bug: Device auto saving when editing name and time zone

### DIFF
--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -14,10 +14,11 @@ class Device < ApplicationRecord
   has_many  :peripherals,      dependent: :destroy
   has_many  :tools,            dependent: :destroy
   has_many  :images,           dependent: :destroy
-  validates :name,             uniqueness: true
   validates :timezone,         inclusion: { in: TIMEZONES,
                                             message: BAD_TZ,
                                             allow_nil: true }
+  validates_presence_of :name
+
   # Give the user back the amount of logs they are allowed to view.
   def limited_log_list
     logs.all.last(max_log_count || DEFAULT_MAX_LOGS)

--- a/webpack/controls/webcam_panel.tsx
+++ b/webpack/controls/webcam_panel.tsx
@@ -69,16 +69,6 @@ export class WebcamPanel extends
               {t("Reset")}
             </button>
           }
-          {/*
-        {isEditing &&
-          <button
-            className="fb-button clear-webcam-url-btn"
-            onClick={this.clearURL}
-          >
-            <i className="fa fa-times"></i>
-          </button>
-        }
-        */}
           {!isEditing &&
             <button
               className="fb-button gray"

--- a/webpack/devices/actions.ts
+++ b/webpack/devices/actions.ts
@@ -7,7 +7,7 @@ import { devices } from "../device";
 import { Log } from "../interfaces";
 import { GithubRelease, MoveRelProps } from "./interfaces";
 import { Thunk, GetState } from "../redux/interfaces";
-import { DeviceAccountSettings, BotState } from "../devices/interfaces";
+import { BotState } from "../devices/interfaces";
 import {
   McuParams,
   Configuration,
@@ -20,7 +20,7 @@ import { Sequence } from "../sequences/interfaces";
 import { HardwareState, ControlPanelState } from "../devices/interfaces";
 import { API } from "../api/index";
 import { User } from "../auth/interfaces";
-import { init, edit } from "../api/crud";
+import { init } from "../api/crud";
 import { getDeviceAccountSettings } from "../resources/selectors";
 import { TaggedDevice } from "../resources/tagged_resources";
 import { versionOK } from "./reducer";
@@ -187,14 +187,6 @@ export function save(input: TaggedDevice) {
  */
 export function toggleControlPanel(payload: keyof ControlPanelState) {
   return { type: "TOGGLE_CONTROL_PANEL_OPTION", payload };
-}
-
-export function changeDevice(device: TaggedDevice,
-  update: Partial<DeviceAccountSettings>): Thunk {
-  return function (dispatch, getState) {
-    dispatch(edit(device, update));
-    dispatch(save(getDeviceAccountSettings(getState().resources.index)));
-  };
 }
 
 export function MCUFactoryReset() {

--- a/webpack/devices/components/farmbot_os_settings.tsx
+++ b/webpack/devices/components/farmbot_os_settings.tsx
@@ -3,7 +3,6 @@ import { t } from "i18next";
 import { info, error, success } from "farmbot-toastr";
 import { FarmbotOsProps, FarmbotOsState } from "../interfaces";
 import {
-  changeDevice,
   saveAccountChanges,
   reboot,
   powerOff,
@@ -20,7 +19,7 @@ import {
   Col,
   SaveBtn
 } from "../../ui/index";
-import { save } from "../../api/crud";
+import { save, edit } from "../../api/crud";
 import { MustBeOnline } from "../must_be_online";
 import { ToolTips, Content } from "../../constants";
 import { TimezoneSelector } from "../timezones/timezone_selector";
@@ -43,7 +42,7 @@ export class FarmbotOsSettings
 
   changeBot = (e: React.ChangeEvent<HTMLInputElement>) => {
     let { account, dispatch } = this.props;
-    dispatch(changeDevice(account, { name: e.currentTarget.value }));
+    dispatch(edit(account, { name: e.currentTarget.value }));
   }
 
   saveBot(e: React.MouseEvent<{}>) {
@@ -70,7 +69,7 @@ export class FarmbotOsSettings
 
   handleTimezone = (timezone: string) => {
     let { account, dispatch } = this.props;
-    dispatch(changeDevice(account, { timezone }));
+    dispatch(edit(account, { timezone }));
     dispatch(save(account.uuid));
   }
 


### PR DESCRIPTION
# Why?

 * Changing the device name on the FarmBot OS settings panel would auto-save the device name. This was originally implemented for legacy reasons and is no longer needed.

# What Changed?

 * Device name no longer autosaves (click "SAVE" instead)