### PR TITLE
Webcam feed resource (API only)

### DIFF
--- a/app/controllers/api/webcam_feeds_controller.rb
+++ b/app/controllers/api/webcam_feeds_controller.rb
@@ -1,0 +1,31 @@
+# Api::WebcamFeedController is the RESTful endpoint for managing webcam URLs
+# and settings. Most notably seen in the "webcam" panel of the frontend app.
+module Api
+  class WebcamFeedsController < Api::AbstractController
+
+    def show
+      render json: webcam_feed
+    end
+
+    def update
+      # URL is the only updateable field- write a mutation when there is real
+      # business logic to deal with - RC.
+      webcam_feed.update_attributes!(url: params[:url])
+      render json: webcam_feed
+    end
+  private
+
+    # If the user does not have one, create one upon request. Many users
+    # registered for accounts before this resource existed.
+    def webcam_feed
+      @webcam_feed ||= WebcamFeed
+        .find_or_create_by!(device: current_device) do |f|
+          # Some day, `webcam_url` will become legacy and be deleted from
+          # devices table.
+          primary  = current_device.try(:webcam_url)
+          fallback = WebcamFeed::DEFAULT_FEED_URL
+          f.url = primary || fallback
+        end
+    end
+  end
+end

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -6,17 +6,18 @@ class Device < ApplicationRecord
   BAD_TZ             = "%{value} is not a valid timezone"
 
   has_many  :users
-  has_many  :farm_events,      dependent: :destroy
-  has_many  :points,           dependent: :destroy
-  has_many  :logs,             dependent: :destroy
-  has_many  :sequences,        dependent: :destroy
-  has_many  :regimens,         dependent: :destroy
-  has_many  :peripherals,      dependent: :destroy
-  has_many  :tools,            dependent: :destroy
-  has_many  :images,           dependent: :destroy
-  validates :timezone,         inclusion: { in: TIMEZONES,
-                                            message: BAD_TZ,
-                                            allow_nil: true }
+  has_many  :farm_events, dependent: :destroy
+  has_many  :points,      dependent: :destroy
+  has_many  :logs,        dependent: :destroy
+  has_many  :sequences,   dependent: :destroy
+  has_many  :regimens,    dependent: :destroy
+  has_many  :peripherals, dependent: :destroy
+  has_many  :tools,       dependent: :destroy
+  has_many  :images,      dependent: :destroy
+  has_one   :webcam_feed, dependent: :destroy
+  validates :timezone,    inclusion: { in: TIMEZONES,
+                                       message: BAD_TZ,
+                                       allow_nil: true }
   validates_presence_of :name
 
   # Give the user back the amount of logs they are allowed to view.

--- a/app/models/webcam_feed.rb
+++ b/app/models/webcam_feed.rb
@@ -1,0 +1,5 @@
+class WebcamFeed < ApplicationRecord
+  belongs_to :device
+  validates_presence_of :url
+  validates_presence_of :device
+end

--- a/app/models/webcam_feed.rb
+++ b/app/models/webcam_feed.rb
@@ -1,4 +1,5 @@
 class WebcamFeed < ApplicationRecord
+  DEFAULT_FEED_URL = "/placeholder_farmbot.jpg"
   belongs_to :device
   validates_presence_of :url
   validates_presence_of :device

--- a/app/serializers/webcam_feed_serializer.rb
+++ b/app/serializers/webcam_feed_serializer.rb
@@ -1,3 +1,3 @@
-class DeviceSerializer < ActiveModel::Serializer
+class WebcamFeedSerializer < ActiveModel::Serializer
   attributes :id, :url, :updated_at, :created_at
 end

--- a/app/serializers/webcam_feed_serializer.rb
+++ b/app/serializers/webcam_feed_serializer.rb
@@ -1,0 +1,3 @@
+class DeviceSerializer < ActiveModel::Serializer
+  attributes :id, :url, :updated_at, :created_at
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ FarmBot::Application.routes.draw do
     resource :tokens,         only: [:create]
     resource :users,          only: [:create, :update, :destroy, :show]
     resource :device,         only: [:show, :destroy, :create, :update]
+    resource :webcam_feed,    only: [:show, :destroy, :create, :update]
     resources :password_resets, only: [:create, :update]
     put "/password_resets"     => "password_resets#update", as: :whatever
     put "/users/verify/:token" => "users#verify",           as: :users_verify

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ FarmBot::Application.routes.draw do
     resource :tokens,         only: [:create]
     resource :users,          only: [:create, :update, :destroy, :show]
     resource :device,         only: [:show, :destroy, :create, :update]
-    resource :webcam_feed,    only: [:show, :destroy, :create, :update]
+    resource :webcam_feed,    only: [:show, :update]
     resources :password_resets, only: [:create, :update]
     put "/password_resets"     => "password_resets#update", as: :whatever
     put "/users/verify/:token" => "users#verify",           as: :users_verify

--- a/db/migrate/20170818163411_create_webcam_feeds.rb
+++ b/db/migrate/20170818163411_create_webcam_feeds.rb
@@ -1,0 +1,10 @@
+class CreateWebcamFeeds < ActiveRecord::Migration[5.1]
+  def change
+    create_table :webcam_feeds do |t|
+      t.references :device
+      t.string     :url
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170814084814) do
+ActiveRecord::Schema.define(version: 20170818163411) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -107,7 +107,7 @@ ActiveRecord::Schema.define(version: 20170814084814) do
   end
 
   create_table "points", id: :serial, force: :cascade do |t|
-    t.float "radius", default: 50.0, null: false
+    t.float "radius", default: 25.0, null: false
     t.float "x", null: false
     t.float "y", null: false
     t.float "z", default: 0.0, null: false
@@ -201,6 +201,14 @@ ActiveRecord::Schema.define(version: 20170814084814) do
     t.index ["agreed_to_terms_at"], name: "index_users_on_agreed_to_terms_at"
     t.index ["device_id"], name: "index_users_on_device_id"
     t.index ["email"], name: "index_users_on_email", unique: true
+  end
+
+  create_table "webcam_feeds", force: :cascade do |t|
+    t.bigint "device_id"
+    t.string "url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["device_id"], name: "index_webcam_feeds_on_device_id"
   end
 
   add_foreign_key "log_dispatches", "devices"

--- a/spec/controllers/api/webcam_feeds/show_spec.rb
+++ b/spec/controllers/api/webcam_feeds/show_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe Api::WebcamFeedsController do
+  let(:user) { FactoryGirl.create(:user) }
+  include Devise::Test::ControllerHelpers
+
+  it 'shows a webcam feed- even if you dont have one' do
+    sign_in user
+    expect(user.device.webcam_feed).to be(nil)
+    get :show, format: :json
+    expect(response.status).to eq(200)
+    expect(user.device.reload.webcam_feed).to be
+    expect(json[:url]).to eq(WebcamFeed::DEFAULT_FEED_URL)
+  end
+end

--- a/spec/controllers/api/webcam_feeds/show_spec.rb
+++ b/spec/controllers/api/webcam_feeds/show_spec.rb
@@ -7,6 +7,7 @@ describe Api::WebcamFeedsController do
   it 'shows a webcam feed- even if you dont have one' do
     sign_in user
     expect(user.device.webcam_feed).to be(nil)
+    user.device.update_attributes!(webcam_url: nil)
     get :show, format: :json
     expect(response.status).to eq(200)
     expect(user.device.reload.webcam_feed).to be

--- a/spec/controllers/api/webcam_feeds/update_spec.rb
+++ b/spec/controllers/api/webcam_feeds/update_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe Api::WebcamFeedsController do
+  let(:user) { FactoryGirl.create(:user) }
+  include Devise::Test::ControllerHelpers
+
+  it 'updates a webcam feed URL' do
+    # Create a webcam feed first....
+    sign_in user
+
+    input = { url: "/foo.jpg", format: :json }
+    patch :update, params: input
+    expect(response.status).to eq(200)
+    expect(json[:url]).to eq("/foo.jpg")
+  end
+end

--- a/spec/factories/webcam_feeds.rb
+++ b/spec/factories/webcam_feeds.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :webcam_feed do
+    device
+    url "http://placehold.it/320x240"
+  end
+end

--- a/spec/models/webcam_feed_spec.rb
+++ b/spec/models/webcam_feed_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe WebcamFeed do
+  let(:feed) { FactoryGirl.create(:webcam_feed) }
+
+  it "requires a URL" do
+    result = feed.update_attributes(url: nil)
+    expect(result).to be(false)
+    expect(result).to be(false)
+    expect(feed.errors.messages[:url]).to include("can't be blank")
+  end
+end


### PR DESCRIPTION
# What's New?

Webcam feeds will see a big update soon. This PR adds a `/webcam_feed` endpoint to the API. The `devices.webcam_url` attribute will be deprecated soon in favor of the fully formed `webcam_feed` resource. Later on, this will allow us show multiple cam feeds per account on a single page and other things of that nature.

# What's Next?

 * Integrate this new endpoint with the frontend SPA
