### PR TITLE
Improvements to Farm Designer plant editing

### DIFF
--- a/webpack/farm_designer/interfaces.ts
+++ b/webpack/farm_designer/interfaces.ts
@@ -168,6 +168,7 @@ export interface GardenMapState {
   botOriginQuadrant: BotOriginQuadrant;
   pageX: number | undefined;
   pageY: number | undefined;
+  activeDragXY: BotPosition | undefined;
 }
 
 export interface GardenPlantProps {
@@ -178,6 +179,7 @@ export interface GardenPlantProps {
   dragging: boolean;
   onClick: (plant: Readonly<TaggedPlantPointer>) => void;
   zoomLvl: number;
+  activeDragXY: BotPosition | undefined;
 }
 
 export interface GardenPlantState {

--- a/webpack/farm_designer/map/__tests__/garden_plant_test.tsx
+++ b/webpack/farm_designer/map/__tests__/garden_plant_test.tsx
@@ -13,69 +13,124 @@ describe("<GardenPlant/>", () => {
       dragging: false,
       onClick: jest.fn(),
       dispatch: jest.fn(),
-      zoomLvl: 1.8
+      zoomLvl: 1.8,
+      activeDragXY: { x: undefined, y: undefined, z: undefined }
     };
   }
 
   it("renders plant", () => {
-    let result = shallow(<GardenPlant {...fakeProps() } />);
-    expect(result.find("image").length).toEqual(1);
-    expect(result.find("image").props().opacity).toEqual(1);
-    expect(result.find("Circle").length).toEqual(1);
-    expect(result.find("Circle").props().selected).toBeFalsy();
-    expect(result.find("text").length).toEqual(0);
-    expect(result.find("rect").length).toEqual(0);
+    let wrapper = shallow(<GardenPlant {...fakeProps() } />);
+    expect(wrapper.find("image").length).toEqual(1);
+    expect(wrapper.find("image").props().opacity).toEqual(1);
+    expect(wrapper.find("Circle").length).toEqual(1);
+    expect(wrapper.find("Circle").props().selected).toBeFalsy();
+    expect(wrapper.find("text").length).toEqual(0);
+    expect(wrapper.find("rect").length).toEqual(0);
+  });
+
+  it("renders drag helpers", () => {
+    let p = fakeProps();
+    p.dragging = true;
+    let wrapper = shallow(<GardenPlant {...p } />);
+    expect(wrapper.find("#coordinates-tooltip").length).toEqual(1);
+    expect(wrapper.find("#long-crosshair").length).toEqual(1);
+    expect(wrapper.find("#short-crosshair").length).toEqual(1);
+    expect(wrapper.find("#vert-alignment-indicator").length).toEqual(0);
+    expect(wrapper.find("#horiz-alignment-indicator").length).toEqual(0);
   });
 
   it("renders coordinates tooltip while dragging", () => {
     let p = fakeProps();
     p.dragging = true;
-    let result = shallow(<GardenPlant {...p } />);
-    expect(result.find("text").length).toEqual(1);
-    expect(result.find("text").text()).toEqual("100, 200");
-    expect(result.find("text").props().fontSize).toEqual("1.25rem");
-    expect(result.find("text").props().dy).toEqual(-20);
+    let wrapper = shallow(<GardenPlant {...p } />);
+    expect(wrapper.find("text").length).toEqual(1);
+    expect(wrapper.find("text").text()).toEqual("100, 200");
+    expect(wrapper.find("text").props().fontSize).toEqual("1.25rem");
+    expect(wrapper.find("text").props().dy).toEqual(-20);
   });
 
   it("renders coordinates tooltip while dragging: scaled", () => {
     let p = fakeProps();
     p.dragging = true;
     p.zoomLvl = 0.9;
-    let result = shallow(<GardenPlant {...p } />);
-    expect(result.find("text").length).toEqual(1);
-    expect(result.find("text").text()).toEqual("100, 200");
-    expect(result.find("text").props().fontSize).toEqual("3rem");
-    expect(result.find("text").props().dy).toEqual(-48);
+    let wrapper = shallow(<GardenPlant {...p } />);
+    expect(wrapper.find("text").length).toEqual(1);
+    expect(wrapper.find("text").text()).toEqual("100, 200");
+    expect(wrapper.find("text").props().fontSize).toEqual("3rem");
+    expect(wrapper.find("text").props().dy).toEqual(-48);
   });
 
   it("renders crosshair while dragging", () => {
     let p = fakeProps();
     p.dragging = true;
-    let result = shallow(<GardenPlant {...p } />);
-    expect(result.find("rect").length).toEqual(4);
-    let r1Props = result.find("rect").at(0).props();
-    expect(r1Props).toEqual({ "height": 2, "width": 8, "x": 90, "y": 199 });
-    let r2Props = result.find("rect").at(1).props();
-    expect(r2Props).toEqual({ "height": 8, "width": 2, "x": 99, "y": 190 });
-    let r3Props = result.find("rect").at(2).props();
-    expect(r3Props).toEqual({ "height": 2, "width": 8, "x": 102, "y": 199 });
-    let r4Props = result.find("rect").at(3).props();
-    expect(r4Props).toEqual({ "height": 8, "width": 2, "x": 99, "y": 202 });
+    let wrapper = shallow(<GardenPlant {...p } />);
+    let crosshair = wrapper.find("#short-crosshair");
+    expect(crosshair.length).toEqual(1);
+    let r1Props = crosshair.find("rect").at(0).props();
+    expect(r1Props).toEqual({
+      "height": 2, "width": 8, "x": 90, "y": 199, "style": { "fill": "#434343" }
+    });
+    let r2Props = crosshair.find("rect").at(1).props();
+    expect(r2Props).toEqual({
+      "height": 8, "width": 2, "x": 99, "y": 190, "style": { "fill": "#434343" }
+    });
+    let r3Props = crosshair.find("rect").at(2).props();
+    expect(r3Props).toEqual({
+      "height": 2, "width": 8, "x": 102, "y": 199, "style": { "fill": "#434343" }
+    });
+    let r4Props = crosshair.find("rect").at(3).props();
+    expect(r4Props).toEqual({
+      "height": 8, "width": 2, "x": 99, "y": 202, "style": { "fill": "#434343" }
+    });
   });
 
   it("renders crosshair while dragging: scaled", () => {
     let p = fakeProps();
     p.dragging = true;
     p.zoomLvl = 0.9;
-    let result = shallow(<GardenPlant {...p } />);
-    expect(result.find("rect").length).toEqual(4);
-    let r1Props = result.find("rect").at(0).props();
-    expect(r1Props).toEqual({ "height": 4.8, "width": 19.2, "x": 76, "y": 197.6 });
-    let r2Props = result.find("rect").at(1).props();
-    expect(r2Props).toEqual({ "height": 19.2, "width": 4.8, "x": 97.6, "y": 176 });
-    let r3Props = result.find("rect").at(2).props();
-    expect(r3Props).toEqual({ "height": 4.8, "width": 19.2, "x": 104.8, "y": 197.6 });
-    let r4Props = result.find("rect").at(3).props();
-    expect(r4Props).toEqual({ "height": 19.2, "width": 4.8, "x": 97.6, "y": 204.8 });
+    let wrapper = shallow(<GardenPlant {...p } />);
+    let crosshair = wrapper.find("#short-crosshair");
+    expect(crosshair.length).toEqual(1);
+    let r1Props = crosshair.find("rect").at(0).props();
+    expect(r1Props).toEqual({
+      "height": 4.8, "width": 19.2, "x": 76, "y": 197.6, "style": { "fill": "#434343" }
+    });
+    let r2Props = crosshair.find("rect").at(1).props();
+    expect(r2Props).toEqual({
+      "height": 19.2, "width": 4.8, "x": 97.6, "y": 176, "style": { "fill": "#434343" }
+    });
+    let r3Props = crosshair.find("rect").at(2).props();
+    expect(r3Props).toEqual({
+      "height": 4.8, "width": 19.2, "x": 104.8, "y": 197.6, "style": { "fill": "#434343" }
+    });
+    let r4Props = crosshair.find("rect").at(3).props();
+    expect(r4Props).toEqual({
+      "height": 19.2, "width": 4.8, "x": 97.6, "y": 204.8, "style": { "fill": "#434343" }
+    });
   });
+
+  it("renders vertical alignment indicators", () => {
+    let p = fakeProps();
+    p.dragging = false;
+    p.plant.body.x = 100;
+    p.plant.body.y = 100;
+    p.activeDragXY = { x: 100, y: 0, z: 0 };
+    let wrapper = shallow(<GardenPlant {...p } />);
+    expect(wrapper.find("#vert-alignment-indicator").length).toEqual(1);
+    expect(wrapper.find("#horiz-alignment-indicator").length).toEqual(0);
+    expect(wrapper.find("rect").length).toEqual(2);
+  });
+
+  it("renders horizontal alignment indicators", () => {
+    let p = fakeProps();
+    p.dragging = false;
+    p.plant.body.x = 100;
+    p.plant.body.y = 100;
+    p.activeDragXY = { x: 0, y: 100, z: 0 };
+    let wrapper = shallow(<GardenPlant {...p } />);
+    expect(wrapper.find("#vert-alignment-indicator").length).toEqual(0);
+    expect(wrapper.find("#horiz-alignment-indicator").length).toEqual(1);
+    expect(wrapper.find("rect").length).toEqual(2);
+  });
+
 });

--- a/webpack/farm_designer/map/garden_map.tsx
+++ b/webpack/farm_designer/map/garden_map.tsx
@@ -36,7 +36,10 @@ export class GardenMap extends
       this.props.dispatch(edit(p, { x: round(p.body.x), y: round(p.body.y) }));
       this.props.dispatch(save(p.uuid));
     }
-    this.setState({ isDragging: false, pageX: 0, pageY: 0 });
+    this.setState({
+      isDragging: false, pageX: 0, pageY: 0,
+      activeDragXY: { x: undefined, y: undefined, z: undefined }
+    });
   }
 
   startDrag = (): void => this.setState({ isDragging: true });
@@ -102,7 +105,10 @@ export class GardenMap extends
       let { qx, qy } = getXYFromQuadrant(e.pageX, e.pageY, botOriginQuadrant);
       let deltaX = Math.round((qx - (this.state.pageX || qx)) / zoomLvl);
       let deltaY = Math.round((qy - (this.state.pageY || qy)) / zoomLvl);
-      this.setState({ pageX: qx, pageY: qy });
+      this.setState({
+        pageX: qx, pageY: qy,
+        activeDragXY: { x: plant.body.x + deltaX, y: plant.body.y + deltaY, z: 0 }
+      });
       this.props.dispatch(movePlant({ deltaX, deltaY, plant }));
     }
   }
@@ -137,7 +143,8 @@ export class GardenMap extends
           currentPlant={this.getPlant()}
           dragging={!!this.state.isDragging}
           editing={!!this.isEditing}
-          zoomLvl={this.props.zoomLvl} />
+          zoomLvl={this.props.zoomLvl}
+          activeDragXY={this.state.activeDragXY} />
         <ToolSlotLayer
           botOriginQuadrant={this.props.designer.botOriginQuadrant}
           visible={!!this.props.showFarmbot}

--- a/webpack/farm_designer/map/garden_plant.tsx
+++ b/webpack/farm_designer/map/garden_plant.tsx
@@ -3,6 +3,10 @@ import { GardenPlantProps, GardenPlantState } from "../interfaces";
 import { cachedCrop, DEFAULT_ICON, svgToUrl } from "../../open_farm/index";
 import { Circle } from "./circle";
 import { round, getXYFromQuadrant } from "./util";
+import { isUndefined } from "util";
+
+const GRAY = "#434343";
+const RED = "#ee6666";
 
 export class GardenPlant extends
   React.Component<GardenPlantProps, Partial<GardenPlantState>> {
@@ -18,15 +22,32 @@ export class GardenPlant extends
   }
 
   render() {
-    let { selected, dragging, plant, onClick, dispatch, quadrant, zoomLvl } = this.props;
+    let { selected, dragging, plant, onClick, dispatch,
+      quadrant, zoomLvl, activeDragXY } = this.props;
     let { radius, x, y } = plant.body;
     let { icon } = this.state;
 
     let scale = 1 + Math.round(15 * (1.8 - zoomLvl)) / 10; // scale factor
-    let alpha = dragging ? 0.4 : 1.0;
 
     let action = { type: "TOGGLE_HOVERED_PLANT", payload: { plant, icon } };
     let { qx, qy } = getXYFromQuadrant(round(x), round(y), quadrant);
+    let gardenCoord = getXYFromQuadrant(qx, qy, quadrant);
+
+    let horizAlign = false;
+    let vertAlign = false;
+    let alpha = dragging ? 0.4 : 1.0;
+    if (activeDragXY && !isUndefined(activeDragXY.x) && !isUndefined(activeDragXY.y)) {
+      // Plant editing (dragging) is occuring
+      let activeXY = { qx: round(activeDragXY.x), qy: round(activeDragXY.y) };
+      if (activeXY.qx == gardenCoord.qx) {
+        // The plant is aligned vertically with the dragged plant
+        vertAlign = true;
+      }
+      if (activeXY.qy == gardenCoord.qy) {
+        // The plant is aligned horizontally with the dragged plant
+        horizAlign = true;
+      }
+    }
 
     return <g>
       <Circle
@@ -47,16 +68,40 @@ export class GardenPlant extends
         width={radius * 2}
         x={qx - radius}
         y={qy - radius} />
-      {dragging && // coordinates tooltip
-        <text x={qx} y={qy} dy={-20 * scale} fontSize={1.25 * scale + "rem"}>
-          {qx}, {qy}
+      {dragging &&
+        <text id="coordinates-tooltip"
+          x={qx} y={qy} dy={-20 * scale} fontSize={1.25 * scale + "rem"} style={{ fill: GRAY }}>
+          {gardenCoord.qx}, {gardenCoord.qy}
         </text>}
-      {dragging && // crosshair
-        <g>
-          <rect x={qx - 10 * scale} y={qy - 1 * scale} width={8 * scale} height={2 * scale} />
-          <rect x={qx - 1 * scale} y={qy - 10 * scale} width={2 * scale} height={8 * scale} />
-          <rect x={qx + 2 * scale} y={qy - 1 * scale} width={8 * scale} height={2 * scale} />
-          <rect x={qx - 1 * scale} y={qy + 2 * scale} width={2 * scale} height={8 * scale} />
+      {dragging &&
+        <g id="long-crosshair">
+          <rect x={qx - 0.5} y={0} width={1} height={1500} style={{ fill: GRAY }} />
+          <rect x={0} y={qy - 0.5} width={3000} height={1} style={{ fill: GRAY }} />
+        </g>}
+      {dragging &&
+        <g id="short-crosshair">
+          <rect x={qx - 10 * scale} y={qy - 1 * scale}
+            width={8 * scale} height={2 * scale} style={{ fill: GRAY }} />
+          <rect x={qx - 1 * scale} y={qy - 10 * scale}
+            width={2 * scale} height={8 * scale} style={{ fill: GRAY }} />
+          <rect x={qx + 2 * scale} y={qy - 1 * scale}
+            width={8 * scale} height={2 * scale} style={{ fill: GRAY }} />
+          <rect x={qx - 1 * scale} y={qy + 2 * scale}
+            width={2 * scale} height={8 * scale} style={{ fill: GRAY }} />
+        </g>}
+      {!dragging && horizAlign &&
+        <g id="horiz-alignment-indicator">
+          <rect x={qx - radius - 10 * scale} y={qy - 1 * scale}
+            width={8 * scale} height={2 * scale} style={{ fill: RED }} />
+          <rect x={qx + radius + 2 * scale} y={qy - 1 * scale}
+            width={8 * scale} height={2 * scale} style={{ fill: RED }} />
+        </g>}
+      {!dragging && vertAlign &&
+        <g id="vert-alignment-indicator">
+          <rect x={qx - 1 * scale} y={qy - radius - 10 * scale}
+            width={2 * scale} height={8 * scale} style={{ fill: RED }} />
+          <rect x={qx - 1 * scale} y={qy + radius + 2 * scale}
+            width={2 * scale} height={8 * scale} style={{ fill: RED }} />
         </g>}
     </g >;
   }

--- a/webpack/farm_designer/map/interfaces.ts
+++ b/webpack/farm_designer/map/interfaces.ts
@@ -3,6 +3,7 @@ import {
   TaggedCrop
 } from "../../resources/tagged_resources";
 import { State, BotOriginQuadrant } from "../interfaces";
+import { BotPosition } from "../../devices/interfaces";
 
 export interface PlantLayerProps {
   plants: TaggedPlantPointer[];
@@ -14,6 +15,7 @@ export interface PlantLayerProps {
   dispatch: Function;
   botOriginQuadrant: BotOriginQuadrant;
   zoomLvl: number;
+  activeDragXY: BotPosition | undefined;
 }
 
 export interface CropSpreadDict {

--- a/webpack/farm_designer/map/layers/plant_layer.tsx
+++ b/webpack/farm_designer/map/layers/plant_layer.tsx
@@ -53,7 +53,8 @@ export function PlantLayer(props: PlantLayerProps) {
               dragging={p.selected && dragging && editing}
               onClick={() => dispatch(action)}
               dispatch={props.dispatch}
-              zoomLvl={props.zoomLvl} />
+              zoomLvl={props.zoomLvl}
+              activeDragXY={props.activeDragXY} />
           </Link>;
         })}
     </g>;

--- a/webpack/farm_designer/plants/__tests__/plant_panel_test.tsx
+++ b/webpack/farm_designer/plants/__tests__/plant_panel_test.tsx
@@ -3,25 +3,31 @@ import { PlantPanel } from "../plant_panel";
 import { shallow } from "enzyme";
 
 describe("<PlantPanel/>", () => {
-  it("renders", () => {
-    let info = {
-      x: 12,
-      y: 34,
-      id: undefined,
-      name: "tomato",
-      uuid: "444-555-666-777-888",
-      daysOld: 1,
-      plantedAt: "2017-06-19T08:02:22.466-05:00",
-      slug: "tomato"
-    };
+  let info = {
+    x: 12,
+    y: 34,
+    id: undefined,
+    name: "tomato",
+    uuid: "444-555-666-777-888",
+    daysOld: 1,
+    plantedAt: "2017-06-19T08:02:22.466-05:00",
+    slug: "tomato"
+  };
 
+  it("renders: editing", () => {
     let onDestroy = jest.fn();
-
     let el = shallow(<PlantPanel info={info} onDestroy={onDestroy} />);
     let txt = el.text().toLowerCase();
     expect(txt).toContain("1 days old");
-    expect(txt).toContain("(12, 34)");
+    expect(txt).toContain("(10, 30)");
     el.find("button").simulate("click");
     expect(onDestroy.mock.calls.length).toEqual(1);
+  });
+
+  it("renders", () => {
+    let el = shallow(<PlantPanel info={info} />);
+    let txt = el.text().toLowerCase();
+    expect(txt).toContain("1 days old");
+    expect(txt).toContain("(12, 34)");
   });
 });

--- a/webpack/farm_designer/plants/plant_panel.tsx
+++ b/webpack/farm_designer/plants/plant_panel.tsx
@@ -3,6 +3,7 @@ import * as _ from "lodash";
 import { t } from "i18next";
 import { Link } from "react-router";
 import { FormattedPlantInfo } from "./map_state_to_props";
+import { round } from "../map/util";
 
 interface PlantPanelProps {
   info: FormattedPlantInfo;
@@ -11,6 +12,7 @@ interface PlantPanelProps {
 
 export function PlantPanel({ info, onDestroy }: PlantPanelProps) {
   let { name, slug, plantedAt, daysOld, x, y, uuid } = info;
+  if (onDestroy) { x = round(x); y = round(y); }
   let destroy = () => onDestroy && onDestroy(uuid);
   return <div className="panel-content">
     <label>
@@ -58,7 +60,7 @@ export function PlantPanel({ info, onDestroy }: PlantPanelProps) {
         </b>
         <span>
           ({x}, {y})
-          </span>
+        </span>
       </li>
     </ul>
     <div>


### PR DESCRIPTION
- Display indicators for plants which are horizontally or vertically aligned with the plant being edited.
- Display thin full-height and full-width lines on the map when a plant is edited to aid with grid and garden alignment.