### PR TITLE
Ability to Disable i18n

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "deep-freeze": "^0.0.1",
     "enzyme": "^2.9.1",
     "extract-text-webpack-plugin": "^2.1.2",
-    "farmbot": "4.3.9",
+    "farmbot": "4.3.10",
     "farmbot-toastr": "^1.0.3",
     "fastclick": "^1.0.6",
     "file-loader": "^0.11.2",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "ts-jest": "^20.0.10",
     "ts-lint": "^4.5.1",
     "ts-loader": "^2.3.3",
-    "tslint": "^5.6.0",
+    "tslint": "^5.7.0",
     "typescript": "^2.4.2",
     "url-loader": "^0.5.9",
     "webpack": "^3.5.5",

--- a/tslint.json
+++ b/tslint.json
@@ -56,7 +56,6 @@
     "no-default-export": true,
     "no-duplicate-variable": true,
     "no-eval": true,
-    "no-for-in-array": true,
     "no-internal-module": true,
     "no-invalid-this": true,
     "no-null-keyword": true,
@@ -69,9 +68,11 @@
         "selfClosing": "after-props"
       }
     ],
-    "no-use-before-declare": true,
     "no-var-keyword": true,
     "no-var-requires": false,
+    "deprecation": true,
+    "use-isnan": true,
+    "prefer-const": true,
     "whitespace": [
       true,
       "check-branch",

--- a/webpack/__test_support__/fake_state/bot.ts
+++ b/webpack/__test_support__/fake_state/bot.ts
@@ -44,11 +44,15 @@ export let bot: Everything["bot"] = {
       "farmwares": {}
     }
   },
-  "x_axis_inverted": false,
-  "y_axis_inverted": false,
-  "z_axis_inverted": false,
-  "raw_encoders": false,
-  "scaled_encoders": false,
+  axis_inversion: {
+    "x": false,
+    "y": false,
+    "z": false,
+  },
+  encoder_visibility: {
+    "raw_encoders": false,
+    "scaled_encoders": false,
+  },
   "dirty": false,
   "currentOSVersion": "3.1.6"
 };

--- a/webpack/account/actions.ts
+++ b/webpack/account/actions.ts
@@ -18,7 +18,7 @@ export function deleteUser(payload: DeletionRequest): Thunk {
       })
         .then((resp: HttpData<{}>) => {
           alert("We're sorry to see you go. :(");
-          Session.clear(true);
+          Session.clear();
         })
         .catch((err: UnsafeError) => {
           toastErrors({ err });

--- a/webpack/auth/actions.ts
+++ b/webpack/auth/actions.ts
@@ -30,7 +30,7 @@ export function didLogin(authState: AuthState, dispatch: Function) {
 function onLogin(dispatch: Function) {
   return (response: HttpData<AuthState>) => {
     let { data } = response;
-    Session.put(data);
+    Session.replace(data);
     didLogin(data, dispatch);
     push("/app/controls");
   };
@@ -126,8 +126,8 @@ export function logout() {
   // In those cases, seeing a logout message may confuse the user.
   // To circumvent this, we must check if the user had a token.
   // If there was infact a token, we can safely show the message.
-  if (Session.get()) { success("You have been logged out."); }
-  Session.clear(true);
+  if (Session.getAll()) { success("You have been logged out."); }
+  Session.clear();
   // Technically this is unreachable code:
   return {
     type: "LOGOUT",

--- a/webpack/config/__tests__/actions_test.ts
+++ b/webpack/config/__tests__/actions_test.ts
@@ -1,7 +1,13 @@
 jest.unmock("../../auth/actions");
 const actions = require("../../auth/actions");
 let didLogin = jest.fn();
-jest.mock("../../session", () => ({ Session: { get: () => false } }));
+jest.mock("../../session", () => ({
+  Session: {
+    getNum: () => undefined,
+    getBool: () => undefined,
+    getAll: () => undefined
+  }
+}));
 actions.didLogin = didLogin;
 import { ready } from "../actions";
 

--- a/webpack/config/actions.ts
+++ b/webpack/config/actions.ts
@@ -5,7 +5,7 @@ import { Session } from "../session";
 /** Lets Redux know that the app is ready to bootstrap. */
 export function ready(): Thunk {
   return (dispatch, getState) => {
-    let state = Session.get() || getState().auth;
+    let state = Session.getAll() || getState().auth;
     if (state) { didLogin(state, dispatch); }
   };
 }

--- a/webpack/controls/__tests__/move_test.tsx
+++ b/webpack/controls/__tests__/move_test.tsx
@@ -4,13 +4,13 @@ import { Move } from "../move";
 import { bot } from "../../__test_support__/fake_state/bot";
 
 describe("<Move />", () => {
-  let fakeBot = bot;
+  const fakeBot = bot;
   it("has default elements", () => {
-    let wrapper = mount(<Move dispatch={jest.fn()}
+    const wrapper = mount(<Move dispatch={jest.fn()}
       bot={fakeBot}
       user={undefined}
       disabled={false} />);
-    let txt = wrapper.text().toLowerCase();
+    const txt = wrapper.text().toLowerCase();
     expect(txt).toContain("move amount (mm)");
     expect(txt).toContain("110100100010000");
     expect(txt).toContain("x axisy axisz axis");
@@ -19,24 +19,24 @@ describe("<Move />", () => {
   });
 
   it("has only raw encoder data display", () => {
-    fakeBot.raw_encoders = true;
-    let wrapper = mount(<Move dispatch={jest.fn()}
+    fakeBot.encoder_visibility.raw_encoders = true;
+    const wrapper = mount(<Move dispatch={jest.fn()}
       bot={fakeBot}
       user={undefined}
       disabled={false} />);
-    let txt = wrapper.text().toLowerCase();
+    const txt = wrapper.text().toLowerCase();
     expect(txt).toContain("raw");
     expect(txt).not.toContain("scaled");
   });
 
   it("has both encoder data displays", () => {
-    fakeBot.raw_encoders = true;
-    fakeBot.scaled_encoders = true;
-    let wrapper = mount(<Move dispatch={jest.fn()}
+    fakeBot.encoder_visibility.raw_encoders = true;
+    fakeBot.encoder_visibility.scaled_encoders = true;
+    const wrapper = mount(<Move dispatch={jest.fn()}
       bot={fakeBot}
       user={undefined}
       disabled={false} />);
-    let txt = wrapper.text().toLowerCase();
+    const txt = wrapper.text().toLowerCase();
     expect(txt).toContain("raw");
     expect(txt).toContain("scaled");
   });

--- a/webpack/controls/move.tsx
+++ b/webpack/controls/move.tsx
@@ -12,14 +12,21 @@ import { MoveProps, EncoderDisplay } from "./interfaces";
 import { Xyz, BotLocationData } from "../devices/interfaces";
 import { Popover, Position } from "@blueprintjs/core";
 import { AxisDisplayGroup } from "./axis_display_group";
+import { Session } from "../session";
+import { INVERSION_MAPPING, ENCODER_MAPPING } from "../devices/reducer";
 
 export class Move extends React.Component<MoveProps, {}> {
 
-  toggle = (name: Xyz) => () =>
+  toggle = (name: Xyz) => () => {
+    Session.invertBool(INVERSION_MAPPING[name]);
     this.props.dispatch({ type: "INVERT_JOG_BUTTON", payload: name });
+  };
 
-  toggle_encoder_data = (name: EncoderDisplay) => () =>
+  toggle_encoder_data =
+  (name: EncoderDisplay) => () => {
+    Session.invertBool(ENCODER_MAPPING[name]);
     this.props.dispatch({ type: "DISPLAY_ENCODER_DATA", payload: name });
+  }
 
   render() {
     const { sync_status } = this.props.bot.hardware.informational_settings;

--- a/webpack/controls/move.tsx
+++ b/webpack/controls/move.tsx
@@ -23,8 +23,10 @@ export class Move extends React.Component<MoveProps, {}> {
 
   render() {
     const { sync_status } = this.props.bot.hardware.informational_settings;
-    const { x_axis_inverted, y_axis_inverted, z_axis_inverted,
-      raw_encoders, scaled_encoders } = this.props.bot;
+    const x_axis_inverted = this.props.bot.axis_inversion.x;
+    const y_axis_inverted = this.props.bot.axis_inversion.y;
+    const z_axis_inverted = this.props.bot.axis_inversion.z;
+    const { raw_encoders, scaled_encoders } = this.props.bot.encoder_visibility;
     const xBtnColor = x_axis_inverted ? "green" : "red";
     const yBtnColor = y_axis_inverted ? "green" : "red";
     const zBtnColor = z_axis_inverted ? "green" : "red";

--- a/webpack/controls/move.tsx
+++ b/webpack/controls/move.tsx
@@ -22,14 +22,14 @@ export class Move extends React.Component<MoveProps, {}> {
     this.props.dispatch({ type: "DISPLAY_ENCODER_DATA", payload: name });
 
   render() {
-    let { sync_status } = this.props.bot.hardware.informational_settings;
-    let { x_axis_inverted, y_axis_inverted, z_axis_inverted,
+    const { sync_status } = this.props.bot.hardware.informational_settings;
+    const { x_axis_inverted, y_axis_inverted, z_axis_inverted,
       raw_encoders, scaled_encoders } = this.props.bot;
-    let xBtnColor = x_axis_inverted ? "green" : "red";
-    let yBtnColor = y_axis_inverted ? "green" : "red";
-    let zBtnColor = z_axis_inverted ? "green" : "red";
-    let rawBtnColor = raw_encoders ? "green" : "red";
-    let scaledBtnColor = scaled_encoders ? "green" : "red";
+    const xBtnColor = x_axis_inverted ? "green" : "red";
+    const yBtnColor = y_axis_inverted ? "green" : "red";
+    const zBtnColor = z_axis_inverted ? "green" : "red";
+    const rawBtnColor = raw_encoders ? "green" : "red";
+    const scaledBtnColor = scaled_encoders ? "green" : "red";
     let locationData: BotLocationData;
     if (this.props.bot.hardware.location_data) {
       locationData = this.props.bot.hardware.location_data;
@@ -40,9 +40,9 @@ export class Move extends React.Component<MoveProps, {}> {
         scaled_encoders: { x: undefined, y: undefined, z: undefined },
       };
     }
-    let motor_coordinates = locationData.position;
-    let raw_encoders_data = locationData.raw_encoders;
-    let scaled_encoders_data = locationData.scaled_encoders;
+    const motor_coordinates = locationData.position;
+    const raw_encoders_data = locationData.raw_encoders;
+    const scaled_encoders_data = locationData.scaled_encoders;
 
     return (
       <Widget>

--- a/webpack/devices/__tests__/reducer_test.ts
+++ b/webpack/devices/__tests__/reducer_test.ts
@@ -20,13 +20,13 @@ describe("safeStringFetch", () => {
 
 describe("botRedcuer", () => {
   it("Starts / stops an update", () => {
-    let step1 = botReducer(initialState, {
+    const step1 = botReducer(initialState, {
       type: Actions.SETTING_UPDATE_START,
       payload: undefined
     });
     expect(step1.isUpdating).toBe(true);
 
-    let step2 = botReducer(step1, {
+    const step2 = botReducer(step1, {
       type: Actions.SETTING_UPDATE_END,
       payload: undefined
     });
@@ -35,7 +35,7 @@ describe("botRedcuer", () => {
   });
 
   it("changes step size", () => {
-    let state = botReducer(initialState, {
+    const state = botReducer(initialState, {
       type: Actions.CHANGE_STEP_SIZE,
       payload: 23
     });
@@ -43,8 +43,8 @@ describe("botRedcuer", () => {
   });
 
   it("toggles control panel options", () => {
-    let payload: keyof ControlPanelState = "danger_zone";
-    let state = botReducer(initialState, {
+    const payload: keyof ControlPanelState = "danger_zone";
+    const state = botReducer(initialState, {
       type: Actions.TOGGLE_CONTROL_PANEL_OPTION,
       payload
     });
@@ -53,7 +53,7 @@ describe("botRedcuer", () => {
   });
 
   it("fetches OS update info", () => {
-    let r = botReducer(initialState, {
+    const r = botReducer(initialState, {
       type: Actions.FETCH_OS_UPDATE_INFO_OK,
       payload: "1.2.3"
     }).currentOSVersion;
@@ -61,8 +61,8 @@ describe("botRedcuer", () => {
   });
 
   it("sets sync status", () => {
-    let payload: SyncStatus = "locked";
-    let state = botReducer(initialState, {
+    const payload: SyncStatus = "locked";
+    const state = botReducer(initialState, {
       type: Actions.SET_SYNC_STATUS,
       payload
     });
@@ -73,36 +73,34 @@ describe("botRedcuer", () => {
   });
 
   it("inverts X/Y/Z", () => {
-    let action = { type: Actions.INVERT_JOG_BUTTON, payload: "Q" };
-    expect(() => { botReducer(initialState, action); }).toThrow();
+    const action = { type: Actions.INVERT_JOG_BUTTON, payload: "Q" };
 
     action.payload = "x";
-    let result = botReducer(initialState, action);
-    expect(result.x_axis_inverted)
-      .toBe(!initialState.x_axis_inverted);
+    const result = botReducer(initialState, action);
+    expect(result.axis_inversion.x)
+      .toBe(!initialState.axis_inversion.x);
 
     action.payload = "y";
-    expect(botReducer(initialState, action).y_axis_inverted)
-      .toBe(!initialState.y_axis_inverted);
+    expect(botReducer(initialState, action).axis_inversion.y)
+      .toBe(!initialState.axis_inversion.y);
 
     action.payload = "z";
-    expect(botReducer(initialState, action).z_axis_inverted)
-      .toBe(!initialState.z_axis_inverted);
+    expect(botReducer(initialState, action).axis_inversion.z)
+      .toBe(!initialState.axis_inversion.z);
 
   });
 
   it("toggles encoder data display", () => {
-    let action = { type: Actions.DISPLAY_ENCODER_DATA, payload: "Q" };
-    expect(() => { botReducer(initialState, action); }).toThrow();
+    const action = { type: Actions.DISPLAY_ENCODER_DATA, payload: "Q" };
 
     action.payload = "raw_encoders";
-    let result = botReducer(initialState, action);
-    expect(result.raw_encoders)
-      .toBe(!initialState.raw_encoders);
+    const result = botReducer(initialState, action);
+    expect(result.encoder_visibility.raw_encoders)
+      .toBe(!initialState.encoder_visibility.raw_encoders);
 
     action.payload = "scaled_encoders";
-    expect(botReducer(initialState, action).scaled_encoders)
-      .toBe(!initialState.scaled_encoders);
+    expect(botReducer(initialState, action).encoder_visibility.scaled_encoders)
+      .toBe(!initialState.encoder_visibility.scaled_encoders);
 
   });
 

--- a/webpack/devices/interfaces.ts
+++ b/webpack/devices/interfaces.ts
@@ -16,6 +16,7 @@ import {
 import { RestResources } from "../resources/interfaces";
 import { TaggedUser } from "../resources/tagged_resources";
 import { WD_ENV } from "../farmware/weed_detector/remote_env/interfaces";
+import { EncoderDisplay } from "../controls/interfaces";
 
 export interface Props {
   auth: AuthState | undefined;
@@ -52,12 +53,9 @@ export interface BotState {
   isUpdating?: boolean;
   controlPanelState: ControlPanelState;
   /** The inversions for the jog buttons on the controls page. */
-  x_axis_inverted: boolean;
-  y_axis_inverted: boolean;
-  z_axis_inverted: boolean;
+  axis_inversion: Record<Xyz, boolean>;
   /** The display setting for encoder data on the controls page. */
-  raw_encoders: boolean;
-  scaled_encoders: boolean;
+  encoder_visibility: Record<EncoderDisplay, boolean>;
 }
 
 export interface BotProp {

--- a/webpack/devices/reducer.ts
+++ b/webpack/devices/reducer.ts
@@ -79,13 +79,16 @@ export let initialState: BotState = {
   }
 };
 
-const INVERSION_MAPPING: Record<Xyz, BooleanSetting> = {
+/** Translate X/Y/Z to the name that is used in `localStorage` */
+export const INVERSION_MAPPING: Record<Xyz, BooleanSetting> = {
   x: BooleanSetting.X_AXIS_INVERTED,
   y: BooleanSetting.Y_AXIS_INVERTED,
   z: BooleanSetting.Z_AXIS_INVERTED,
 };
 
-const ENCODER_MAPPING: Record<EncoderDisplay, BooleanSetting> = {
+/** Translate `encode_visibility` key name to the name that is
+ * used in `localStorage` */
+export const ENCODER_MAPPING: Record<EncoderDisplay, BooleanSetting> = {
   raw_encoders: BooleanSetting.RAW_ENCODERS,
   scaled_encoders: BooleanSetting.SCALED_ENCODERS,
 };
@@ -128,12 +131,10 @@ export let botReducer = generateReducer<BotState>(initialState)
   })
   .add<Xyz>(Actions.INVERT_JOG_BUTTON, (s, { payload }) => {
     s.axis_inversion[payload] = !s.axis_inversion[payload];
-    Session.setBool(INVERSION_MAPPING[payload], s.axis_inversion[payload]);
     return s;
   })
   .add<EncoderDisplay>(Actions.DISPLAY_ENCODER_DATA, (s, { payload }) => {
     s.encoder_visibility[payload] = !s.encoder_visibility[payload];
-    Session.setBool(ENCODER_MAPPING[payload], s.encoder_visibility[payload]);
     return s;
   })
   .add<boolean>(Actions.SET_MQTT_STATUS, (s, a) => {

--- a/webpack/devices/reducer.ts
+++ b/webpack/devices/reducer.ts
@@ -68,11 +68,26 @@ export let initialState: BotState = {
   dirty: false,
   currentOSVersion: undefined,
   currentFWVersion: undefined,
-  x_axis_inverted: Session.getBool(BooleanSetting.X_AXIS_INVERTED),
-  y_axis_inverted: Session.getBool(BooleanSetting.Y_AXIS_INVERTED),
-  z_axis_inverted: Session.getBool(BooleanSetting.Z_AXIS_INVERTED),
-  raw_encoders: Session.getBool(BooleanSetting.RAW_ENCODERS),
-  scaled_encoders: Session.getBool(BooleanSetting.SCALED_ENCODERS),
+  axis_inversion: {
+    x: Session.getBool(BooleanSetting.X_AXIS_INVERTED),
+    y: Session.getBool(BooleanSetting.Y_AXIS_INVERTED),
+    z: Session.getBool(BooleanSetting.Z_AXIS_INVERTED),
+  },
+  encoder_visibility: {
+    raw_encoders: Session.getBool(BooleanSetting.RAW_ENCODERS),
+    scaled_encoders: Session.getBool(BooleanSetting.SCALED_ENCODERS),
+  }
+};
+
+const INVERSION_MAPPING: Record<Xyz, BooleanSetting> = {
+  x: BooleanSetting.X_AXIS_INVERTED,
+  y: BooleanSetting.Y_AXIS_INVERTED,
+  z: BooleanSetting.Z_AXIS_INVERTED,
+};
+
+const ENCODER_MAPPING: Record<EncoderDisplay, BooleanSetting> = {
+  raw_encoders: BooleanSetting.RAW_ENCODERS,
+  scaled_encoders: BooleanSetting.SCALED_ENCODERS,
 };
 
 export let botReducer = generateReducer<BotState>(initialState)
@@ -112,36 +127,14 @@ export let botReducer = generateReducer<BotState>(initialState)
     return s;
   })
   .add<Xyz>(Actions.INVERT_JOG_BUTTON, (s, { payload }) => {
-    switch (payload) {
-      case "x":
-        s.x_axis_inverted = !s.x_axis_inverted;
-        Session.setBool(BooleanSetting.X_AXIS_INVERTED, s.x_axis_inverted);
-        return s;
-      case "y":
-        s.y_axis_inverted = !s.y_axis_inverted;
-        Session.setBool(BooleanSetting.Y_AXIS_INVERTED, s.y_axis_inverted);
-        return s;
-      case "z":
-        s.z_axis_inverted = !s.z_axis_inverted;
-        Session.setBool(BooleanSetting.Z_AXIS_INVERTED, s.z_axis_inverted);
-        return s;
-      default:
-        throw new Error("Attempted to invert invalid jog button direction.");
-    }
+    s.axis_inversion[payload] = !s.axis_inversion[payload];
+    Session.setBool(INVERSION_MAPPING[payload], s.axis_inversion[payload]);
+    return s;
   })
   .add<EncoderDisplay>(Actions.DISPLAY_ENCODER_DATA, (s, { payload }) => {
-    switch (payload) {
-      case "raw_encoders":
-        s.raw_encoders = !s.raw_encoders;
-        Session.setBool(BooleanSetting.RAW_ENCODERS, s.raw_encoders);
-        return s;
-      case "scaled_encoders":
-        s.scaled_encoders = !s.scaled_encoders;
-        Session.setBool(BooleanSetting.SCALED_ENCODERS, s.scaled_encoders);
-        return s;
-      default:
-        throw new Error("Attempted to toggle display of invalid data.");
-    }
+    s.encoder_visibility[payload] = !s.encoder_visibility[payload];
+    Session.setBool(ENCODER_MAPPING[payload], s.encoder_visibility[payload]);
+    return s;
   })
   .add<boolean>(Actions.SET_MQTT_STATUS, (s, a) => {
     s.connectedToMQTT = a.payload;

--- a/webpack/devices/reducer.ts
+++ b/webpack/devices/reducer.ts
@@ -4,7 +4,8 @@ import { SyncStatus } from "farmbot/dist";
 import { Actions } from "../constants";
 import { EncoderDisplay } from "../controls/interfaces";
 import { EXPECTED_MAJOR, EXPECTED_MINOR } from "./actions";
-import { Session, BooleanSetting } from "../session";
+import { Session } from "../session";
+import { BooleanSetting } from "../session_keys";
 
 /**
  * TODO: Refactor this method to use semverCompare() now that it is a thing.

--- a/webpack/devices/reducer.ts
+++ b/webpack/devices/reducer.ts
@@ -14,14 +14,14 @@ import { BooleanSetting } from "../session_keys";
 export function versionOK(stringyVersion = "0.0.0",
   _EXPECTED_MAJOR = EXPECTED_MAJOR,
   _EXPECTED_MINOR = EXPECTED_MINOR) {
-  let [actual_major, actual_minor] = stringyVersion
+  const [actual_major, actual_minor] = stringyVersion
     .split(".")
     .map(x => parseInt(x, 10));
   if (actual_major > _EXPECTED_MAJOR) {
     return true;
   } else {
-    let majorOK = (actual_major == _EXPECTED_MAJOR);
-    let minorOK = (actual_minor >= _EXPECTED_MINOR);
+    const majorOK = (actual_major == _EXPECTED_MAJOR);
+    const minorOK = (actual_minor >= _EXPECTED_MINOR);
     return (majorOK && minorOK);
   }
 }
@@ -68,11 +68,11 @@ export let initialState: BotState = {
   dirty: false,
   currentOSVersion: undefined,
   currentFWVersion: undefined,
-  x_axis_inverted: !Session.getBool(BooleanSetting.X_AXIS_INVERTED),
-  y_axis_inverted: !Session.getBool(BooleanSetting.Y_AXIS_INVERTED),
-  z_axis_inverted: !Session.getBool(BooleanSetting.Z_AXIS_INVERTED),
-  raw_encoders: !Session.getBool(BooleanSetting.RAW_ENCODERS),
-  scaled_encoders: !Session.getBool(BooleanSetting.SCALED_ENCODERS),
+  x_axis_inverted: Session.getBool(BooleanSetting.X_AXIS_INVERTED),
+  y_axis_inverted: Session.getBool(BooleanSetting.Y_AXIS_INVERTED),
+  z_axis_inverted: Session.getBool(BooleanSetting.Z_AXIS_INVERTED),
+  raw_encoders: Session.getBool(BooleanSetting.RAW_ENCODERS),
+  scaled_encoders: Session.getBool(BooleanSetting.SCALED_ENCODERS),
 };
 
 export let botReducer = generateReducer<BotState>(initialState)
@@ -98,7 +98,7 @@ export let botReducer = generateReducer<BotState>(initialState)
     return s;
   })
   .add<HardwareState>(Actions.BOT_CHANGE, (s, { payload }) => {
-    let nextState = payload;
+    const nextState = payload;
     s.hardware = nextState;
     versionOK(nextState.informational_settings.controller_version);
     return s;

--- a/webpack/devices/reducer.ts
+++ b/webpack/devices/reducer.ts
@@ -1,16 +1,10 @@
 import { BotState, HardwareState, Xyz, ControlPanelState } from "./interfaces";
 import { generateReducer } from "../redux/generate_reducer";
 import { SyncStatus } from "farmbot/dist";
-import { localStorageBoolFetch } from "../util";
 import { Actions } from "../constants";
 import { EncoderDisplay } from "../controls/interfaces";
 import { EXPECTED_MAJOR, EXPECTED_MINOR } from "./actions";
-
-export const X_AXIS_INVERTED = "x_axis_inverted";
-export const Y_AXIS_INVERTED = "y_axis_inverted";
-export const Z_AXIS_INVERTED = "z_axis_inverted";
-export const RAW_ENCODERS = "raw_encoders";
-export const SCALED_ENCODERS = "scaled_encoders";
+import { Session, BooleanSetting } from "../session";
 
 /**
  * TODO: Refactor this method to use semverCompare() now that it is a thing.
@@ -73,11 +67,11 @@ export let initialState: BotState = {
   dirty: false,
   currentOSVersion: undefined,
   currentFWVersion: undefined,
-  x_axis_inverted: !localStorageBoolFetch(X_AXIS_INVERTED),
-  y_axis_inverted: !localStorageBoolFetch(Y_AXIS_INVERTED),
-  z_axis_inverted: !localStorageBoolFetch(Z_AXIS_INVERTED),
-  raw_encoders: !localStorageBoolFetch(RAW_ENCODERS),
-  scaled_encoders: !localStorageBoolFetch(SCALED_ENCODERS)
+  x_axis_inverted: !Session.getBool(BooleanSetting.X_AXIS_INVERTED),
+  y_axis_inverted: !Session.getBool(BooleanSetting.Y_AXIS_INVERTED),
+  z_axis_inverted: !Session.getBool(BooleanSetting.Z_AXIS_INVERTED),
+  raw_encoders: !Session.getBool(BooleanSetting.RAW_ENCODERS),
+  scaled_encoders: !Session.getBool(BooleanSetting.SCALED_ENCODERS),
 };
 
 export let botReducer = generateReducer<BotState>(initialState)
@@ -120,18 +114,15 @@ export let botReducer = generateReducer<BotState>(initialState)
     switch (payload) {
       case "x":
         s.x_axis_inverted = !s.x_axis_inverted;
-        localStorage.setItem(X_AXIS_INVERTED,
-          JSON.stringify(localStorageBoolFetch(X_AXIS_INVERTED)));
+        Session.setBool(BooleanSetting.X_AXIS_INVERTED, s.x_axis_inverted);
         return s;
       case "y":
         s.y_axis_inverted = !s.y_axis_inverted;
-        localStorage.setItem(Y_AXIS_INVERTED,
-          JSON.stringify(localStorageBoolFetch(Y_AXIS_INVERTED)));
+        Session.setBool(BooleanSetting.Y_AXIS_INVERTED, s.y_axis_inverted);
         return s;
       case "z":
         s.z_axis_inverted = !s.z_axis_inverted;
-        localStorage.setItem(Z_AXIS_INVERTED,
-          JSON.stringify(localStorageBoolFetch(Z_AXIS_INVERTED)));
+        Session.setBool(BooleanSetting.Z_AXIS_INVERTED, s.z_axis_inverted);
         return s;
       default:
         throw new Error("Attempted to invert invalid jog button direction.");
@@ -141,13 +132,11 @@ export let botReducer = generateReducer<BotState>(initialState)
     switch (payload) {
       case "raw_encoders":
         s.raw_encoders = !s.raw_encoders;
-        localStorage.setItem(RAW_ENCODERS,
-          JSON.stringify(localStorageBoolFetch(RAW_ENCODERS)));
+        Session.setBool(BooleanSetting.RAW_ENCODERS, s.raw_encoders);
         return s;
       case "scaled_encoders":
         s.scaled_encoders = !s.scaled_encoders;
-        localStorage.setItem(SCALED_ENCODERS,
-          JSON.stringify(localStorageBoolFetch(SCALED_ENCODERS)));
+        Session.setBool(BooleanSetting.SCALED_ENCODERS, s.scaled_encoders);
         return s;
       default:
         throw new Error("Attempted to toggle display of invalid data.");

--- a/webpack/farm_designer/reducer.ts
+++ b/webpack/farm_designer/reducer.ts
@@ -10,7 +10,8 @@ import {
 import { cloneDeep } from "lodash";
 import { TaggedResource } from "../resources/tagged_resources";
 import { Actions } from "../constants";
-import { Session, NumericSetting } from "../session";
+import { Session } from "../session";
+import { NumericSetting } from "../session_keys";
 
 let botOriginVal = Session.getNum(NumericSetting.BOT_ORIGIN_QUADRANT);
 let botOriginQuadrant = isBotOriginQuadrant(botOriginVal) ? botOriginVal : 2;

--- a/webpack/farm_designer/reducer.ts
+++ b/webpack/farm_designer/reducer.ts
@@ -9,16 +9,12 @@ import {
 } from "./interfaces";
 import { cloneDeep } from "lodash";
 import { TaggedResource } from "../resources/tagged_resources";
-import { localStorageNumFetch } from "../util";
 import { Actions } from "../constants";
+import { Session, NumericSetting } from "../session";
 
-export const BOT_ORIGIN_QUADRANT = "bot_origin_quadrant";
-export const ZOOM_LEVEL = "zoom_level";
-
-let botOriginVal = localStorageNumFetch(BOT_ORIGIN_QUADRANT);
+let botOriginVal = Session.getNum(NumericSetting.BOT_ORIGIN_QUADRANT);
 let botOriginQuadrant = isBotOriginQuadrant(botOriginVal) ? botOriginVal : 2;
-
-let zoomLevelVal = localStorageNumFetch(ZOOM_LEVEL);
+let zoomLevelVal = Session.getNum(NumericSetting.ZOOM_LEVEL);
 let zoomLevel = zoomLevelVal ? zoomLevelVal : 1;
 
 export let initialState: DesignerState = {
@@ -48,14 +44,14 @@ export let designer = generateReducer<DesignerState>(initialState)
     return s;
   })
   .add<BotOriginQuadrant>(Actions.UPDATE_BOT_ORIGIN_QUADRANT, (s, a) => {
-    localStorage.setItem(BOT_ORIGIN_QUADRANT, JSON.stringify(a.payload));
+    Session.setNum(NumericSetting.BOT_ORIGIN_QUADRANT, a.payload);
     s.botOriginQuadrant = a.payload;
     return s;
   })
   .add<ZoomLevelPayl>(Actions.UPDATE_MAP_ZOOM_LEVEL, (s, { payload }) => {
     let value = s.zoomLevel + payload;
     s.zoomLevel = value;
-    localStorage.setItem(ZOOM_LEVEL, value.toString());
+    Session.setNum(NumericSetting.ZOOM_LEVEL, value);
     return s;
   })
   .add<CropLiveSearchResult[]>(Actions.OF_SEARCH_RESULTS_OK, (s, a) => {

--- a/webpack/front_page/front_page.tsx
+++ b/webpack/front_page/front_page.tsx
@@ -30,7 +30,7 @@ export class FrontPage extends React.Component<{}, Partial<FrontPageState>> {
   }
 
   componentDidMount() {
-    if (Session.get()) { window.location.href = "/app/controls"; }
+    if (Session.getAll()) { window.location.href = "/app/controls"; }
     logInit();
     API.setBaseUrl(API.fetchBrowserLocation());
     this.setState({
@@ -63,7 +63,7 @@ export class FrontPage extends React.Component<{}, Partial<FrontPageState>> {
     API.setBaseUrl(url);
     axios.post(API.current.tokensPath, payload)
       .then((resp: HttpData<AuthState>) => {
-        Session.put(resp.data);
+        Session.replace(resp.data);
         window.location.href = "/app/controls";
       }).catch((error: Error) => {
         if (_.get(error, "response.status") === 451) {
@@ -346,5 +346,5 @@ export class FrontPage extends React.Component<{}, Partial<FrontPageState>> {
     );
   }
 
-  render() { return Session.get() ? <div /> : this.defaultContent(); }
+  render() { return Session.getAll() ? <div /> : this.defaultContent(); }
 }

--- a/webpack/i18n.ts
+++ b/webpack/i18n.ts
@@ -1,4 +1,6 @@
 import axios from "axios";
+import { Session } from "./session";
+import { BooleanSetting } from "./session_keys";
 
 function generateUrl(langCode: string) {
   let lang = langCode.slice(0, 2);
@@ -15,8 +17,10 @@ function getUserLang(langCode = "en_us") {
 
 export function detectLanguage() {
   return getUserLang(navigator.language).then(function (lang) {
-    // TODO: Possibly requires optimization using Webpack chunking.
-    let langi = require("../public/app-resources/languages/" + lang + ".js");
+    // NOTE: Some international users prefer using the app in English.
+    //       This preference is stored in `DISABLE_I18N`.
+    let choice = Session.getBool(BooleanSetting.DISABLE_I18N) ? "en" : lang;
+    let langi = require("../public/app-resources/languages/" + choice + ".js");
     return {
       nsSeparator: "",
       keySeparator: "",

--- a/webpack/nav/__tests__/lang_toggle_test.tsx
+++ b/webpack/nav/__tests__/lang_toggle_test.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+import { LangToggle } from "../lang_toggle";
+import { mount } from "enzyme";
+import { Session } from "../../session";
+import { BooleanSetting } from "../../session_keys";
+
+describe("<LangToggle/>", () => {
+  it("allows toggling between English and local i18n", () => {
+    jest.mock("../../i18n", () => {
+      return {
+        detectLanguage: () => {
+          return Promise.resolve({
+            nsSeparator: "",
+            keySeparator: "",
+            lng: "es",
+            resources: {
+              es: { translation: {} }
+            }
+          });
+        }
+      };
+    });
+    let el = mount(<LangToggle />);
+    expect(Session.getBool(BooleanSetting.DISABLE_I18N)).toBeFalsy();
+    expect(el.text().toLocaleLowerCase()).toContain("set page to english");
+    el.find("a").first().simulate("click");
+    el.update();
+    expect(Session.getBool(BooleanSetting.DISABLE_I18N)).toBeTruthy();
+    expect(el.text().toLocaleLowerCase()).not.toContain("set page to english");
+    expect(el.text().toLocaleLowerCase()).toContain("internationalize page");
+  });
+});

--- a/webpack/nav/additional_menu.tsx
+++ b/webpack/nav/additional_menu.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Link } from "react-router";
 import { t } from "i18next";
+import { LangToggle } from "./lang_toggle";
 
 export const AdditionalMenu = (logout: () => void) => {
   return <div className="nav-additional-menu">
@@ -8,6 +9,7 @@ export const AdditionalMenu = (logout: () => void) => {
       <i className="fa fa-cog"></i>
       {t("Account Settings")}
     </Link>
+    <LangToggle />
     <div>
       <a
         href="https://software.farmbot.io/docs/the-farmbot-web-app"

--- a/webpack/nav/index.tsx
+++ b/webpack/nav/index.tsx
@@ -24,7 +24,7 @@ export class NavBar extends React.Component<NavBarProps, Partial<NavBarState>> {
     tickerListOpen: false
   };
 
-  logout = () => Session.clear(true);
+  logout = () => Session.clear();
 
   toggle = (name: keyof NavBarState) => () =>
     this.setState({ [name]: !this.state[name] });

--- a/webpack/nav/lang_toggle.tsx
+++ b/webpack/nav/lang_toggle.tsx
@@ -1,0 +1,35 @@
+import * as React from "react";
+import { Session } from "../session";
+import { BooleanSetting } from "../session_keys";
+
+interface Props {
+
+}
+
+interface State {
+
+}
+
+export class LangToggle extends React.Component<Props, State> {
+  state: State = {};
+
+  toggle = () => {
+    Session.setBool(BooleanSetting.DISABLE_I18N, !this.disabled());
+    this.setState({ clicked: true });
+  };
+
+  disabled = () => Session.getBool(BooleanSetting.DISABLE_I18N);
+
+  verbiage() {
+    return (this.disabled() ? "Internationalize Page" : "Set Page to English");
+  }
+
+  render() {
+    return <div>
+      <a onClick={this.toggle} href={window.location.href}>
+        <i className="fa fa-globe"></i>
+        {this.verbiage()}
+      </a>
+    </div>;
+  }
+}

--- a/webpack/redux/root_reducer.ts
+++ b/webpack/redux/root_reducer.ts
@@ -23,7 +23,7 @@ export function rootReducer(
   state: any,
   action: ReduxAction<{}>) {
   if (action.type === Actions.LOGOUT) {
-    Session.clear(true);
+    Session.clear();
   }
   // TODO: Get rid of this nasty type case / hack. Resulted from TSC 2.4 upgrade
   // - RC 30 JUN 17

--- a/webpack/routes.tsx
+++ b/webpack/routes.tsx
@@ -70,14 +70,14 @@ export class RootComponent extends React.Component<RootComponentProps, {}> {
 
   requireAuth(_discard: RouterState, replace: RedirectFunction) {
     let { store } = this.props;
-    if (Session.get()) { // has a previous session in cache
+    if (Session.getAll()) { // has a previous session in cache
       if (store.getState().auth) { // Has session, logged in.
         return;
       } else { // Has session but not logged in (returning visitor).
         store.dispatch(ready());
       }
     } else { // Not logged in yet.
-      Session.clear(true);
+      Session.clear();
     }
   }
 
@@ -281,7 +281,7 @@ export class RootComponent extends React.Component<RootComponentProps, {}> {
   render() {
     // ==== TEMPORARY HACK. TODO: Add a before hook, if such a thing exists in
     // React Router. Or switch routing libs.
-    let notLoggedIn = !Session.get();
+    let notLoggedIn = !Session.getAll();
     let restrictedArea = window.location.pathname.includes("/app/");
     if (notLoggedIn && restrictedArea) {
       window.location.href = "/";

--- a/webpack/session.ts
+++ b/webpack/session.ts
@@ -3,7 +3,17 @@ import { box } from "boxed_value";
 import { get, isNumber } from "lodash";
 import { BooleanSetting, NumericSetting } from "./session_keys";
 
+/** The `Session` namespace is a wrapper for `localStorage`.
+ * Use this to avoid direct access of `localStorage` where possible.
+ *
+ * Problems this namespace aims to solve:
+ *   - Avoid duplication of localStorage key names.
+ *   - Avoid duplication of de-serialization logic.
+ *   - Avoid type errors by explicitly naming keys as (Boolean|Numeric)Setting
+ *   - Create an upgrade path for the eventual server side storage
+ */
 export namespace Session {
+  /** Key that holds the user's JWT */
   const KEY = "session";
 
   /** Replace the contents of session storage. */
@@ -32,20 +42,24 @@ export namespace Session {
     window.location.href = window.location.origin;
   }
 
+  /** Fetch a *boolean* value from localstorage. */
   export function getBool(key: BooleanSetting): boolean {
-    let output = JSON.parse(get(localStorage, key, "false"));
-    return !output;
+    return JSON.parse(localStorage.getItem(key) || "false");
   }
 
+  /** Store a boolean value in `localStorage` */
   export function setBool(key: BooleanSetting, val: boolean): void {
     localStorage.setItem(key, JSON.stringify(val));
   }
 
+  /** Extract numeric settings from `localStorage`. Returns `undefined` when
+   * none are found. */
   export function getNum(key: NumericSetting): number | undefined {
     let output = JSON.parse(get(localStorage, key, "null"));
     return (isNumber(output)) ? output : undefined;
   }
 
+  /** Set a numeric value in `localStorage`. */
   export function setNum(key: NumericSetting, val: number): void {
     localStorage.setItem(key, JSON.stringify(val));
   }

--- a/webpack/session.ts
+++ b/webpack/session.ts
@@ -1,16 +1,30 @@
 import { AuthState } from "./auth/interfaces";
 import { box } from "boxed_value";
+import { get, isNumber } from "lodash";
+
+export enum BooleanSetting {
+  X_AXIS_INVERTED = "x_axis_inverted",
+  Y_AXIS_INVERTED = "y_axis_inverted",
+  Z_AXIS_INVERTED = "z_axis_inverted",
+  RAW_ENCODERS = "raw_encoders",
+  SCALED_ENCODERS = "scaled_encoders"
+}
+
+export enum NumericSetting {
+  BOT_ORIGIN_QUADRANT = "bot_origin_quadrant",
+  ZOOM_LEVEL = "zoom_level",
+}
 
 export namespace Session {
   const KEY = "session";
 
   /** Replace the contents of session storage. */
-  export function put(nextState: AuthState) {
+  export function replace(nextState: AuthState) {
     localStorage[KEY] = JSON.stringify(nextState);
   }
 
   /** Fetch the previous session. */
-  export function get(): AuthState | undefined {
+  export function getAll(): AuthState | undefined {
     try {
       let v: AuthState = JSON.parse(localStorage[KEY]);
       if (box(v).kind === "object") {
@@ -24,9 +38,27 @@ export namespace Session {
   }
 
   /** Clear localstorage and sessionstorage. */
-  export function clear(_redirectToFrontPage = false) {
+  export function clear() {
     localStorage.clear();
     sessionStorage.clear();
     window.location.href = window.location.origin;
+  }
+
+  export function getBool(key: BooleanSetting): boolean {
+    let output = JSON.parse(get(localStorage, key, "false"));
+    return !output;
+  }
+
+  export function setBool(key: BooleanSetting, val: boolean): void {
+    localStorage.setItem(key, JSON.stringify(val));
+  }
+
+  export function getNum(key: NumericSetting): number | undefined {
+    let output = JSON.parse(get(localStorage, key, "null"));
+    return (isNumber(output)) ? output : undefined;
+  }
+
+  export function setNum(key: NumericSetting, val: number): void {
+    localStorage.setItem(key, JSON.stringify(val));
   }
 }

--- a/webpack/session.ts
+++ b/webpack/session.ts
@@ -24,7 +24,7 @@ export namespace Session {
   /** Fetch the previous session. */
   export function getAll(): AuthState | undefined {
     try {
-      let v: AuthState = JSON.parse(localStorage[KEY]);
+      const v: AuthState = JSON.parse(localStorage[KEY]);
       if (box(v).kind === "object") {
         return v;
       } else {
@@ -52,10 +52,14 @@ export namespace Session {
     localStorage.setItem(key, JSON.stringify(val));
   }
 
+  export function invertBool(key: BooleanSetting) {
+    Session.setBool(key, !Session.getBool(key));
+  }
+
   /** Extract numeric settings from `localStorage`. Returns `undefined` when
    * none are found. */
   export function getNum(key: NumericSetting): number | undefined {
-    let output = JSON.parse(get(localStorage, key, "null"));
+    const output = JSON.parse(get(localStorage, key, "null"));
     return (isNumber(output)) ? output : undefined;
   }
 

--- a/webpack/session.ts
+++ b/webpack/session.ts
@@ -1,19 +1,7 @@
 import { AuthState } from "./auth/interfaces";
 import { box } from "boxed_value";
 import { get, isNumber } from "lodash";
-
-export enum BooleanSetting {
-  X_AXIS_INVERTED = "x_axis_inverted",
-  Y_AXIS_INVERTED = "y_axis_inverted",
-  Z_AXIS_INVERTED = "z_axis_inverted",
-  RAW_ENCODERS = "raw_encoders",
-  SCALED_ENCODERS = "scaled_encoders"
-}
-
-export enum NumericSetting {
-  BOT_ORIGIN_QUADRANT = "bot_origin_quadrant",
-  ZOOM_LEVEL = "zoom_level",
-}
+import { BooleanSetting, NumericSetting } from "./session_keys";
 
 export namespace Session {
   const KEY = "session";

--- a/webpack/session_keys.ts
+++ b/webpack/session_keys.ts
@@ -1,0 +1,12 @@
+export enum BooleanSetting {
+  X_AXIS_INVERTED = "x_axis_inverted",
+  Y_AXIS_INVERTED = "y_axis_inverted",
+  Z_AXIS_INVERTED = "z_axis_inverted",
+  RAW_ENCODERS = "raw_encoders",
+  SCALED_ENCODERS = "scaled_encoders"
+}
+
+export enum NumericSetting {
+  BOT_ORIGIN_QUADRANT = "bot_origin_quadrant",
+  ZOOM_LEVEL = "zoom_level"
+}

--- a/webpack/session_keys.ts
+++ b/webpack/session_keys.ts
@@ -3,7 +3,8 @@ export enum BooleanSetting {
   Y_AXIS_INVERTED = "y_axis_inverted",
   Z_AXIS_INVERTED = "z_axis_inverted",
   RAW_ENCODERS = "raw_encoders",
-  SCALED_ENCODERS = "scaled_encoders"
+  SCALED_ENCODERS = "scaled_encoders",
+  DISABLE_I18N = "disable_i18n"
 }
 
 export enum NumericSetting {

--- a/webpack/tos_update/index.tsx
+++ b/webpack/tos_update/index.tsx
@@ -52,7 +52,7 @@ export class Wow extends React.Component<Props, Partial<State>> {
     axios
       .post(API.current.tokensPath, payload)
       .then((resp: HttpData<AuthState>) => {
-        Session.put(resp.data);
+        Session.replace(resp.data);
         window.location.href = "/app/controls";
       })
       .catch(error => {

--- a/webpack/ui/fallback_img.tsx
+++ b/webpack/ui/fallback_img.tsx
@@ -41,8 +41,8 @@ export class FallbackImg extends React.Component<Props, State> {
   }
 
   dontFallback = () => {
-    let imgProps = defensiveClone(this.props);
-    delete (imgProps as any).fallback; // React will complain otherwise.
+    let imgProps: Props = defensiveClone(this.props);
+    delete imgProps.fallback;
     return (
       <div className="webcam-stream-valid">
         <img

--- a/webpack/util.ts
+++ b/webpack/util.ts
@@ -146,16 +146,6 @@ export function safeStringFetch(obj: any, key: string): string {
   }
 }
 
-export function localStorageNumFetch(key: string): number | undefined {
-  let output = JSON.parse(_.get(localStorage, key, "null"));
-  return (_.isNumber(output)) ? output : undefined;
-}
-
-export function localStorageBoolFetch(key: string): boolean {
-  let output = JSON.parse(_.get(localStorage, key, "false"));
-  return !output;
-}
-
 /** We don't support IE. This method stops users from trying to use the site.
  * It's unfortunate that we need to do this, but the site simply won't work on
  * old browsers and our error logs were getting full of IE related bugs. */

--- a/webpack/verification.ts
+++ b/webpack/verification.ts
@@ -13,7 +13,7 @@ export async function verify() {
   const url = API.fetchBrowserLocation();
   try {
     let r: HttpData<AuthState> = await axios.put(url + "/api/users/verify/" + token);
-    Session.put(r.data);
+    Session.replace(r.data);
     window.location.href = window.location.origin + "/app/controls";
   } catch (e) {
     document.write(`

--- a/yarn.lock
+++ b/yarn.lock
@@ -5804,9 +5804,9 @@ tslib@^1.5.0, tslib@^1.7.1:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.7.1.tgz#bc8004164691923a79fe8378bbeb3da2017538ec"
 
-tslint@^5.6.0:
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.6.0.tgz#088aa6c6026623338650b2900828ab3edf59f6cf"
+tslint@^5.7.0:
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.7.0.tgz#c25e0d0c92fa1201c2bc30e844e08e682b4f3552"
   dependencies:
     babel-code-frame "^6.22.0"
     colors "^1.1.2"
@@ -5817,15 +5817,15 @@ tslint@^5.6.0:
     resolve "^1.3.2"
     semver "^5.3.0"
     tslib "^1.7.1"
-    tsutils "^2.7.1"
+    tsutils "^2.8.1"
 
 tsutils@^1.1.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-1.9.1.tgz#b9f9ab44e55af9681831d5f28d0aeeaf5c750cb0"
 
-tsutils@^2.7.1:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.8.0.tgz#0160173729b3bf138628dd14a1537e00851d814a"
+tsutils@^2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.8.1.tgz#3771404e7ca9f0bedf5d919a47a4b1890a68efff"
   dependencies:
     tslib "^1.7.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1954,9 +1954,9 @@ farmbot-toastr@^1.0.0, farmbot-toastr@^1.0.3:
     farmbot-toastr "^1.0.0"
     typescript "^2.3.4"
 
-farmbot@4.3.9:
-  version "4.3.9"
-  resolved "https://registry.yarnpkg.com/farmbot/-/farmbot-4.3.9.tgz#fdf1ac0f6165a52ab7f6b2d4cd4dfdc21f5b7892"
+farmbot@4.3.10:
+  version "4.3.10"
+  resolved "https://registry.yarnpkg.com/farmbot/-/farmbot-4.3.10.tgz#ace9de814964dc3de33bcecae0637fb5fbf0d6b0"
   dependencies:
     mqtt "^1.7.4"
     typescript "^2.4.2"


### PR DESCRIPTION
# Why?

Some translation files are incomplete, leading to an application that is half English, half local. This PR allows users the ability to disable i18n entirely and revert to English if such a situation is undesirable.

# What's New?

 * Ability to disable/enable i18n
 * DRY up code in `Session` namespace.
 * TSDoc comments for `Session` namespace.
 * Unit tests.

![image](https://user-images.githubusercontent.com/1388608/29751649-dc057678-8b15-11e7-848e-a2aa828d4b1c.png)
![image](https://user-images.githubusercontent.com/1388608/29751664-fe56fa62-8b15-11e7-94d5-8078e2c61a1c.png)
