### PR TITLE
Photo widget improvements

### DIFF
--- a/webpack/api/crud.ts
+++ b/webpack/api/crud.ts
@@ -188,7 +188,8 @@ const MUST_CONFIRM_LIST: ResourceName[] = [
   "farm_events",
   "points",
   "sequences",
-  "regimens"
+  "regimens",
+  "images"
 ];
 
 const confirmationChecker = (resource: TaggedResource) =>

--- a/webpack/css/global.scss
+++ b/webpack/css/global.scss
@@ -213,7 +213,7 @@ fieldset {
 
 .webcam-stream-unavailable img {
   width: 100%;
-  opacity: 0.20;
+  opacity: 0.40;
 }
 
 .webcam-stream-valid img {

--- a/webpack/css/image_flipper.scss
+++ b/webpack/css/image_flipper.scss
@@ -39,16 +39,20 @@
 }
 
 .no-flipper-image-container {
+  img {
+    opacity: 0.4;
+  }
   p {
     position: absolute;
-    text-shadow: 0 0 25px rgba(0, 0, 0, 1), 0 0 25px rgba(0, 0, 0, 1);
-    color: $white;
-    font-size: 1.8rem;
+    font-size: 1.5rem;
     text-align: center;
-    padding: 10% 10rem 0;
+    padding: 20% 1rem 0;
     line-height: 2.4rem;
     left: 0;
     right: 0;
+    z-index: 1;
+    margin-left: 50px;
+    margin-right: 50px;
   }
 }
 

--- a/webpack/farmware/images/__tests__/image_flipper_test.tsx
+++ b/webpack/farmware/images/__tests__/image_flipper_test.tsx
@@ -1,29 +1,131 @@
 import "../../../unmock_i18next";
+import * as React from "react";
+import { mount } from "enzyme";
 import { ImageFlipper } from "../image_flipper";
 import { fakeImages } from "../../../__test_support__/fake_state/images";
 import { TaggedImage } from "../../../resources/tagged_resources";
 import { defensiveClone } from "../../../util";
 
 describe("<ImageFlipper/>", () => {
-  const images: TaggedImage[] = [];
-
-  fakeImages.forEach((item, index) => {
-    const image = defensiveClone(item);
-    image.uuid = `Position ${index}`;
-    images.push(image);
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
-  it("defaults to index 0", () => {
+  function prepareImages(data: TaggedImage[]): TaggedImage[] {
+    const images: TaggedImage[] = [];
+    data.forEach((item, index) => {
+      const image = defensiveClone(item);
+      image.uuid = `Position ${index}`;
+      images.push(image);
+    });
+    return images;
+  }
+
+  it("defaults to index 0 and flips up", () => {
     const onFlip = jest.fn();
     const x = new ImageFlipper();
     const currentImage = undefined;
+    const images = prepareImages(fakeImages);
     x.props = { images, currentImage, onFlip };
     const up = x.go(1);
     up();
     expect(onFlip).toHaveBeenCalledWith(images[1].uuid);
   });
 
-  it("stops at end");
-  it("Flips down");
-  it("Flips up");
+  it("flips down", () => {
+    const onFlip = jest.fn();
+    const x = new ImageFlipper();
+    const images = prepareImages(fakeImages);
+    const currentImage = images[1];
+    x.props = { images, currentImage, onFlip };
+    const down = x.go(-1);
+    down();
+    expect(onFlip).toHaveBeenCalledWith(images[0].uuid);
+  });
+
+  it("stops at upper end", () => {
+    const onFlip = jest.fn();
+    const x = new ImageFlipper();
+    const images = prepareImages(fakeImages);
+    const currentImage = images[2];
+    x.props = { images, currentImage, onFlip };
+    const up = x.go(1);
+    up();
+    expect(onFlip).not.toHaveBeenCalled();
+  });
+
+  it("stops at lower end", () => {
+    const onFlip = jest.fn();
+    const x = new ImageFlipper();
+    const images = prepareImages(fakeImages);
+    const currentImage = images[0];
+    x.props = { images, currentImage, onFlip };
+    const down = x.go(-1);
+    down();
+    expect(onFlip).not.toHaveBeenCalled();
+  });
+
+  it("disables flippers when no images", () => {
+    const onFlip = jest.fn();
+    const images = prepareImages([]);
+    const currentImage = undefined;
+    const props = { images, currentImage, onFlip };
+    const wrapper = mount(<ImageFlipper {...props} />);
+    expect(wrapper.find("button").first().props().disabled).toBeTruthy();
+    expect(wrapper.find("button").last().props().disabled).toBeTruthy();
+  });
+
+  it("disables flippers when only one image", () => {
+    const onFlip = jest.fn();
+    const images = prepareImages([fakeImages[0]]);
+    const currentImage = undefined;
+    const props = { images, currentImage, onFlip };
+    const wrapper = mount(<ImageFlipper {...props} />);
+    expect(wrapper.find("button").first().props().disabled).toBeTruthy();
+    expect(wrapper.find("button").last().props().disabled).toBeTruthy();
+  });
+
+  it("disables next flipper on load", () => {
+    const onFlip = jest.fn();
+    const images = prepareImages(fakeImages);
+    const currentImage = undefined;
+    const props = { images, currentImage, onFlip };
+    const wrapper = mount(<ImageFlipper {...props} />);
+    expect(wrapper.find("button").first().props().disabled).toBeFalsy();
+    expect(wrapper.find("button").last().props().disabled).toBeTruthy();
+  });
+
+  it("disables flipper at lower end", () => {
+    const onFlip = jest.fn();
+    const images = prepareImages(fakeImages);
+    const currentImage = images[1];
+    const props = { images, currentImage, onFlip };
+    const wrapper = mount(<ImageFlipper {...props} />);
+    wrapper.setState({ disableNext: false });
+    const nextButton = wrapper.find("button").last();
+    expect(nextButton.text().toLowerCase()).toBe("next");
+    expect(nextButton.props().disabled).toBeFalsy();
+    nextButton.simulate("click");
+    expect(onFlip).toHaveBeenLastCalledWith(images[0].uuid);
+    expect(nextButton.props().disabled).toBeTruthy();
+    nextButton.simulate("click");
+    expect(onFlip).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables flipper at upper end", () => {
+    const onFlip = jest.fn();
+    const images = prepareImages(fakeImages);
+    const currentImage = images[1];
+    const props = { images, currentImage, onFlip };
+    const wrapper = mount(<ImageFlipper {...props} />);
+    const prevButton = wrapper.find("button").first();
+    expect(prevButton.text().toLowerCase()).toBe("prev");
+    expect(prevButton.props().disabled).toBeFalsy();
+    prevButton.simulate("click");
+    expect(onFlip).toHaveBeenCalledWith(images[2].uuid);
+    expect(prevButton.props().disabled).toBeTruthy();
+    prevButton.simulate("click");
+    expect(onFlip).toHaveBeenCalledTimes(1);
+  });
+
 });

--- a/webpack/farmware/images/__tests__/photos_test.tsx
+++ b/webpack/farmware/images/__tests__/photos_test.tsx
@@ -1,0 +1,43 @@
+jest.mock("../../../api/crud", () => ({
+  destroy: jest.fn(),
+}));
+
+const mockOk = jest.fn();
+jest.mock("farmbot-toastr", () => ({ success: mockOk }));
+
+import * as React from "react";
+import { mount } from "enzyme";
+import { Photos } from "../photos";
+import { TaggedImage } from "../../../resources/tagged_resources";
+import { fakeImages } from "../../../__test_support__/fake_state/images";
+import { defensiveClone } from "../../../util";
+import { destroy } from "../../../api/crud";
+
+describe("<Photos/>", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function prepareImages(data: TaggedImage[]): TaggedImage[] {
+    const images: TaggedImage[] = [];
+    data.forEach((item, index) => {
+      const image = defensiveClone(item);
+      image.uuid = `Position ${index}`;
+      images.push(image);
+    });
+    return images;
+  }
+
+  it("deletes photo", () => {
+    const { mock } = destroy as jest.Mock<{}>;
+    const dispatch = jest.fn(() => { return Promise.resolve(); });
+    const images = prepareImages(fakeImages);
+    const currentImage = images[1];
+    const props = { images, currentImage, dispatch };
+    const wrapper = mount(<Photos {...props} />);
+    const deleteButton = wrapper.find("button").at(1);
+    expect(deleteButton.text().toLowerCase()).toBe("delete photo");
+    deleteButton.simulate("click");
+    expect(mock.calls[0][0]).toBe("Position 1");
+  });
+});

--- a/webpack/farmware/images/image_flipper.tsx
+++ b/webpack/farmware/images/image_flipper.tsx
@@ -7,7 +7,11 @@ export const PLACEHOLDER_FARMBOT = "/placeholder_farmbot.jpg";
 export class ImageFlipper extends
   React.Component<ImageFlipperProps, Partial<ImageFlipperState>> {
 
-  state: ImageFlipperState = { isLoaded: false };
+  state: ImageFlipperState = {
+    isLoaded: false,
+    disableNext: true,
+    disablePrev: false
+  };
 
   imageJSX = () => {
     if (this.props.images.length > 0) {
@@ -44,23 +48,33 @@ export class ImageFlipper extends
     const uuids = images.map(x => x.uuid);
     const currentIndex = currentImage ? uuids.indexOf(currentImage.uuid) : 0;
     const nextIndex = currentIndex + increment;
-    const tooHigh = nextIndex > (uuids.length - 1);
-    const tooLow = nextIndex < 0;
-    if (!tooHigh && !tooLow) { this.props.onFlip(uuids[nextIndex]); }
+    const tooHigh = (index: number): boolean => index > (uuids.length - 1);
+    const tooLow = (index: number): boolean => index < 0;
+    if (!tooHigh(nextIndex) && !tooLow(nextIndex)) {
+      this.props.onFlip(uuids[nextIndex]);
+    }
+    const indexAfterNext = currentIndex + (increment * 2);
+    this.setState({
+      disableNext: tooLow(indexAfterNext),
+      disablePrev: tooHigh(indexAfterNext)
+    });
   }
 
   render() {
     const image = this.imageJSX();
+    const multipleImages = this.props.images.length > 1;
     return (
       <div className="image-flipper">
         {image}
         <button
           onClick={this.go(1)}
+          disabled={!multipleImages || this.state.disablePrev}
           className="image-flipper-left fb-button">
           {t("Prev")}
         </button>
         <button
           onClick={this.go(-1)}
+          disabled={!multipleImages || this.state.disableNext}
           className="image-flipper-right fb-button">
           {t("Next")}
         </button>

--- a/webpack/farmware/images/interfaces.ts
+++ b/webpack/farmware/images/interfaces.ts
@@ -22,6 +22,8 @@ export interface ImageFlipperProps {
 
 export interface ImageFlipperState {
   isLoaded: boolean;
+  disablePrev: boolean;
+  disableNext: boolean;
 }
 
 export interface PhotosProps {

--- a/webpack/farmware/images/photos.tsx
+++ b/webpack/farmware/images/photos.tsx
@@ -11,6 +11,7 @@ import { ToolTips } from "../../constants";
 import { selectImage } from "./actions";
 import { WidgetFooter } from "../../ui/widget_footer";
 import { safeStringFetch } from "../../util";
+import { destroy } from "../../api/crud";
 
 interface MetaInfoProps {
   /** Default conversion is `attr_name ==> Attr Name`.
@@ -53,6 +54,15 @@ export class Photos extends React.Component<PhotosProps, {}> {
     }
   }
 
+  destroy = () => {
+    const img = this.props.currentImage || this.props.images[0];
+    if (img && img.uuid) {
+      this.props.dispatch(destroy(img.uuid))
+        .then(() => success("Image Deleted.", "Success"))
+        .catch(() => error("Could not delete image.", "Error"));
+    }
+  }
+
   render() {
     const image = this.props.currentImage;
     return (
@@ -62,6 +72,11 @@ export class Photos extends React.Component<PhotosProps, {}> {
             className="fb-button gray"
             onClick={this.takePhoto}>
             {t("Take Photo")}
+          </button>
+          <button
+            className="fb-button red"
+            onClick={() => this.destroy()}>
+            {t("Delete Photo")}
           </button>
         </WidgetHeader>
         <WidgetBody>

--- a/webpack/farmware/weed_detector/farmbot_picker.tsx
+++ b/webpack/farmware/weed_detector/farmbot_picker.tsx
@@ -22,7 +22,7 @@ export class FarmbotColorPicker extends React.Component<FarmbotPickerProps, {}> 
     return {
       position: "relative",
       width: "100%",
-      paddingBottom: "10%",
+      paddingBottom: "4rem",
       overflow: "hidden"
     };
   }
@@ -31,7 +31,7 @@ export class FarmbotColorPicker extends React.Component<FarmbotPickerProps, {}> 
     return {
       position: "relative",
       width: "100%",
-      paddingBottom: "35%",
+      paddingBottom: "12rem",
       overflow: "hidden"
     };
   }
@@ -76,7 +76,7 @@ export class FarmbotColorPicker extends React.Component<FarmbotPickerProps, {}> 
       hsl: { h: H_AVG, s: 0, l: 0 }
     };
     return <div>
-      <div style={{ width: "100%", paddingBottom: "15%" }} />
+      <div style={{ width: "100%", paddingBottom: "5rem" }} />
       <div style={this.hueCSS()}>
         <Hue
           {...dontTouchThis}
@@ -84,7 +84,7 @@ export class FarmbotColorPicker extends React.Component<FarmbotPickerProps, {}> 
           onChange={_.noop} />
         <div style={this.hueboxCSS()} />
       </div>
-      <div style={{ width: "100%", paddingBottom: "2%" }} />
+      <div style={{ width: "100%", paddingBottom: "1rem" }} />
       <div style={this.saturationCSS()}>
         <Saturation
           {...dontTouchThis}

--- a/webpack/resources/reducer.ts
+++ b/webpack/resources/reducer.ts
@@ -141,6 +141,7 @@ export let resourceReducer = generateReducer
       case "tools":
       case "users":
       case "webcam_feed":
+      case "images":
         removeFromIndex(s.index, resource);
         break;
       default:


### PR DESCRIPTION
- Disable the `NEXT` or `PREV` button if there are no more images to flip through in that direction.
- Add `DELETE PHOTO` button to delete the current photo after confirmation.
- Modify style to improve consistency.
- As always, add tests for new features.