### PR TITLE
Display FarmBot home and max limits in Farm Designer map

### DIFF
--- a/webpack/devices/interfaces.ts
+++ b/webpack/devices/interfaces.ts
@@ -82,6 +82,8 @@ export type Axis = Xyz | "all";
 export type BotPosition = Record<Xyz, (number | undefined)>;
 export type BotLocationData = Record<LocationName, BotPosition> | undefined;
 
+export type StepsPerMmXY = Record<"x" | "y", (number | undefined)>;
+
 export interface CalibrationButtonProps {
   disabled: boolean;
   axis: Axis;

--- a/webpack/farm_designer/__tests__/farm_designer_test.tsx
+++ b/webpack/farm_designer/__tests__/farm_designer_test.tsx
@@ -4,6 +4,7 @@ import { mount } from "enzyme";
 import { Props } from "../interfaces";
 import { store } from "../../redux/store";
 import { GardenMapLegendProps } from "../map/interfaces";
+import { bot } from "../../__test_support__/fake_state/bot";
 
 describe("<FarmDesigner/>", () => {
   function fakeProps(): Props {
@@ -24,7 +25,9 @@ describe("<FarmDesigner/>", () => {
       plants: [],
       toolSlots: [],
       crops: [],
-      botPosition: { x: undefined, y: undefined, z: undefined }
+      botPosition: { x: undefined, y: undefined, z: undefined },
+      botMcuParams: bot.hardware.mcu_params,
+      stepsPerMmXY: { x: undefined, y: undefined }
     };
   }
 

--- a/webpack/farm_designer/index.tsx
+++ b/webpack/farm_designer/index.tsx
@@ -142,6 +142,8 @@ export class FarmDesigner extends React.Component<Props, Partial<State>> {
           points={this.props.points}
           toolSlots={this.props.toolSlots}
           botPosition={this.props.botPosition}
+          botMcuParams={this.props.botMcuParams}
+          stepsPerMmXY={this.props.stepsPerMmXY}
           hoveredPlant={this.props.hoveredPlant}
           zoomLvl={Math.round(zoomLevel * 10) / 10}
           botOriginQuadrant={botOriginQuadrant} />

--- a/webpack/farm_designer/interfaces.ts
+++ b/webpack/farm_designer/interfaces.ts
@@ -11,8 +11,9 @@ import {
 } from "../resources/tagged_resources";
 import { PlantPointer } from "../interfaces";
 import { SlotWithTool } from "../resources/interfaces";
-import { BotPosition } from "../devices/interfaces";
+import { BotPosition, StepsPerMmXY } from "../devices/interfaces";
 import { isNumber } from "lodash";
+import { McuParams } from "farmbot/dist";
 
 /** TODO: Use Enums */
 export type BotOriginQuadrant = 1 | 2 | 3 | 4;
@@ -44,6 +45,8 @@ export interface Props {
   toolSlots: SlotWithTool[];
   crops: TaggedCrop[];
   botPosition: BotPosition;
+  botMcuParams: McuParams;
+  stepsPerMmXY: StepsPerMmXY;
 }
 
 export type TimeUnit =
@@ -160,6 +163,8 @@ export interface GardenMapProps {
   hoveredPlant: TaggedPlantPointer | undefined;
   crops: TaggedCrop[];
   botPosition: BotPosition;
+  botMcuParams: McuParams;
+  stepsPerMmXY: StepsPerMmXY;
   zoomLvl: number;
   botOriginQuadrant: BotOriginQuadrant;
 }

--- a/webpack/farm_designer/map/__tests__/bot_extents_test.tsx
+++ b/webpack/farm_designer/map/__tests__/bot_extents_test.tsx
@@ -1,0 +1,120 @@
+import * as React from "react";
+import { BotExtents, BotExtentsProps } from "../bot_extents";
+import { shallow } from "enzyme";
+import { bot } from "../../../__test_support__/fake_state/bot";
+
+describe("<VirtualFarmBot/>", () => {
+  function fakeProps(): BotExtentsProps {
+    const mcuParams = bot.hardware.mcu_params;
+    mcuParams.movement_axis_nr_steps_x = 0;
+    mcuParams.movement_axis_nr_steps_y = 0;
+    mcuParams.movement_stop_at_home_x = 1;
+    mcuParams.movement_stop_at_home_y = 1;
+    mcuParams.movement_stop_at_max_x = 1;
+    mcuParams.movement_stop_at_max_y = 1;
+    return {
+      quadrant: 2,
+      botMcuParams: mcuParams,
+      stepsPerMmXY: { x: 5, y: 5 }
+    };
+  }
+
+  it("renders home lines", () => {
+    const p = fakeProps();
+    const wrapper = shallow(<BotExtents {...p } />);
+    const homeLines = wrapper.find("#home-lines").find("line");
+    expect(homeLines.at(0).props()).toEqual({ "x1": 2, "x2": 2, "y1": 2, "y2": 1500 });
+    expect(homeLines.at(1).props()).toEqual({ "x1": 2, "x2": 3000, "y1": 2, "y2": 2 });
+    const maxLines = wrapper.find("#max-lines").find("line");
+    expect(maxLines.at(0).html()).toBeFalsy();
+    expect(maxLines.at(1).html()).toBeFalsy();
+  });
+
+  it("still renders full home lines", () => {
+    const p = fakeProps();
+    p.botMcuParams.movement_stop_at_max_x = 0;
+    p.botMcuParams.movement_stop_at_max_y = 0;
+    p.botMcuParams.movement_axis_nr_steps_x = 500;
+    p.botMcuParams.movement_axis_nr_steps_y = 500;
+    const wrapper = shallow(<BotExtents {...p } />);
+    const homeLines = wrapper.find("#home-lines").find("line");
+    expect(homeLines.at(0).props()).toEqual({ "x1": 2, "x2": 2, "y1": 2, "y2": 1500 });
+    expect(homeLines.at(1).props()).toEqual({ "x1": 2, "x2": 3000, "y1": 2, "y2": 2 });
+    const maxLines = wrapper.find("#max-lines").find("line");
+    expect(maxLines.at(0).html()).toBeFalsy();
+    expect(maxLines.at(1).html()).toBeFalsy();
+  });
+
+  it("renders home and max lines", () => {
+    const p = fakeProps();
+    p.botMcuParams.movement_axis_nr_steps_x = 500;
+    p.botMcuParams.movement_axis_nr_steps_y = 500;
+    const wrapper = shallow(<BotExtents {...p } />);
+    const homeLines = wrapper.find("#home-lines").find("line");
+    expect(homeLines.at(0).props()).toEqual({ "x1": 2, "x2": 2, "y1": 2, "y2": 100 });
+    expect(homeLines.at(1).props()).toEqual({ "x1": 2, "x2": 100, "y1": 2, "y2": 2 });
+    const maxLines = wrapper.find("#max-lines").find("line");
+    expect(maxLines.at(0).props()).toEqual({ "x1": 100, "x2": 100, "y1": 2, "y2": 100 });
+    expect(maxLines.at(1).props()).toEqual({ "x1": 2, "x2": 100, "y1": 100, "y2": 100 });
+  });
+
+  it("renders home and max lines for one axis only", () => {
+    const p = fakeProps();
+    p.botMcuParams.movement_stop_at_max_x = 0;
+    p.botMcuParams.movement_stop_at_home_x = 0;
+    p.botMcuParams.movement_axis_nr_steps_x = 500;
+    p.botMcuParams.movement_axis_nr_steps_y = 500;
+    const wrapper = shallow(<BotExtents {...p } />);
+    const homeLines = wrapper.find("#home-lines").find("line");
+    expect(homeLines.at(0).props()).toEqual({ "x1": 2, "x2": 3000, "y1": 2, "y2": 2 });
+    expect(homeLines.at(1).html()).toBeFalsy();
+    const maxLines = wrapper.find("#max-lines").find("line");
+    expect(maxLines.at(0).props()).toEqual({ "x1": 2, "x2": 3000, "y1": 100, "y2": 100 });
+    expect(maxLines.at(1).html()).toBeFalsy();
+  });
+
+  it("renders max lines", () => {
+    const p = fakeProps();
+    p.botMcuParams.movement_stop_at_home_x = 0;
+    p.botMcuParams.movement_stop_at_home_y = 0;
+    p.botMcuParams.movement_axis_nr_steps_x = 500;
+    p.botMcuParams.movement_axis_nr_steps_y = 500;
+    const wrapper = shallow(<BotExtents {...p } />);
+    const homeLines = wrapper.find("#home-lines").find("line");
+    expect(homeLines.at(0).html()).toBeFalsy();
+    expect(homeLines.at(1).html()).toBeFalsy();
+    const maxLines = wrapper.find("#max-lines").find("line");
+    expect(maxLines.at(0).props()).toEqual({ "x1": 100, "x2": 100, "y1": 2, "y2": 100 });
+    expect(maxLines.at(1).props()).toEqual({ "x1": 2, "x2": 100, "y1": 100, "y2": 100 });
+  });
+
+  it("renders home and max lines in correct location for quadrant 1", () => {
+    const p = fakeProps();
+    p.quadrant = 1;
+    p.botMcuParams.movement_axis_nr_steps_x = 500;
+    p.botMcuParams.movement_axis_nr_steps_y = 500;
+    const wrapper = shallow(<BotExtents {...p } />);
+    const homeLines = wrapper.find("#home-lines").find("line");
+    expect(homeLines.at(0).props()).toEqual({ "x1": 2998, "x2": 2998, "y1": 2, "y2": 100 });
+    expect(homeLines.at(1).props()).toEqual({ "x1": 2998, "x2": 2900, "y1": 2, "y2": 2 });
+    const maxLines = wrapper.find("#max-lines").find("line");
+    expect(maxLines.at(0).props()).toEqual({ "x1": 2900, "x2": 2900, "y1": 2, "y2": 100 });
+    expect(maxLines.at(1).props()).toEqual({ "x1": 2998, "x2": 2900, "y1": 100, "y2": 100 });
+  });
+
+  it("renders no lines", () => {
+    const p = fakeProps();
+    p.botMcuParams.movement_stop_at_home_x = 0;
+    p.botMcuParams.movement_stop_at_home_y = 0;
+    p.botMcuParams.movement_stop_at_max_x = 0;
+    p.botMcuParams.movement_stop_at_max_y = 0;
+    const wrapper = shallow(<BotExtents {...p } />);
+    const homeLines = wrapper.find("#home-lines").find("line");
+    expect(homeLines.at(0).html()).toBeFalsy();
+    expect(homeLines.at(1).html()).toBeFalsy();
+    const maxLines = wrapper.find("#max-lines").find("line");
+    expect(maxLines.at(0).html()).toBeFalsy();
+    expect(maxLines.at(1).html()).toBeFalsy();
+  });
+
+});

--- a/webpack/farm_designer/map/__tests__/virtual_farmbot_test.tsx
+++ b/webpack/farm_designer/map/__tests__/virtual_farmbot_test.tsx
@@ -1,0 +1,53 @@
+import * as React from "react";
+import { VirtualFarmBot, VFBProps } from "../virtual_farmbot";
+import { shallow } from "enzyme";
+
+describe("<VirtualFarmBot/>", () => {
+  function fakeProps(): VFBProps {
+    return {
+      botPosition: { x: 0, y: 0, z: 0 },
+      quadrant: 2,
+    };
+  }
+
+  it("shows in correct location for quadrant 1", () => {
+    const p = fakeProps();
+    p.quadrant = 1;
+    const result = shallow(<VirtualFarmBot {...p } />);
+    expect(result.html()).toContain("<rect x=\"2990\" y=\"0\" width=\"20\" height=\"1500\"");
+    expect(result.html()).toContain("<circle cx=\"3000\" cy=\"0\" r=\"35\"");
+  });
+
+  it("shows in correct location for quadrant 2", () => {
+    const p = fakeProps();
+    p.quadrant = 2;
+    const result = shallow(<VirtualFarmBot {...p } />);
+    expect(result.html()).toContain("<rect x=\"-10\" y=\"0\" width=\"20\" height=\"1500\"");
+    expect(result.html()).toContain("<circle cx=\"0\" cy=\"0\" r=\"35\"");
+  });
+
+  it("shows in correct location for quadrant 3", () => {
+    const p = fakeProps();
+    p.quadrant = 3;
+    const result = shallow(<VirtualFarmBot {...p } />);
+    expect(result.html()).toContain("<rect x=\"-10\" y=\"0\" width=\"20\" height=\"1500\"");
+    expect(result.html()).toContain("<circle cx=\"0\" cy=\"1500\" r=\"35\"");
+  });
+
+  it("shows in correct location for quadrant 4", () => {
+    const p = fakeProps();
+    p.quadrant = 4;
+    const result = shallow(<VirtualFarmBot {...p } />);
+    expect(result.html()).toContain("<rect x=\"2990\" y=\"0\" width=\"20\" height=\"1500\"");
+    expect(result.html()).toContain("<circle cx=\"3000\" cy=\"1500\" r=\"35\"");
+  });
+
+  it("changes location", () => {
+    const p = fakeProps();
+    p.quadrant = 2;
+    p.botPosition = { x: 100, y: 200, z: 0 };
+    const result = shallow(<VirtualFarmBot {...p } />);
+    expect(result.html()).toContain("<rect x=\"90\" y=\"0\" width=\"20\" height=\"1500\"");
+    expect(result.html()).toContain("<circle cx=\"100\" cy=\"200\" r=\"35\"");
+  });
+});

--- a/webpack/farm_designer/map/bot_extents.tsx
+++ b/webpack/farm_designer/map/bot_extents.tsx
@@ -1,0 +1,57 @@
+import * as React from "react";
+import { getXYFromQuadrant } from "./util";
+import { BotOriginQuadrant } from "../interfaces";
+import { McuParams } from "farmbot/dist";
+import { StepsPerMmXY } from "../../devices/interfaces";
+
+export interface BotExtentsProps {
+  quadrant: BotOriginQuadrant;
+  botMcuParams: McuParams;
+  stepsPerMmXY: StepsPerMmXY;
+}
+
+interface BotExtentsState {
+}
+
+export class BotExtents extends
+  React.Component<BotExtentsProps, Partial<BotExtentsState>> {
+
+  render() {
+    const { quadrant, botMcuParams, stepsPerMmXY } = this.props;
+    const stopAtHomeX = !!botMcuParams.movement_stop_at_home_x;
+    const stopAtHomeY = !!botMcuParams.movement_stop_at_home_y;
+    const stopAtMaxX = !!botMcuParams.movement_stop_at_max_x;
+    const stopAtMaxY = !!botMcuParams.movement_stop_at_max_y;
+    const axisLengthX = botMcuParams.movement_axis_nr_steps_x || 0;
+    const axisLengthY = botMcuParams.movement_axis_nr_steps_y || 0;
+
+    const useMaxLines =
+      (axisLength: number, stopAtMax: boolean): boolean => axisLength !== 0 && stopAtMax;
+
+    const homeLengthX = stepsPerMmXY.x &&
+      useMaxLines(axisLengthX, stopAtMaxX) ? axisLengthX / stepsPerMmXY.x : 3000;
+    const homeLengthY = stepsPerMmXY.y &&
+      useMaxLines(axisLengthY, stopAtMaxY) ? axisLengthY / stepsPerMmXY.y : 1500;
+    const homeLength = getXYFromQuadrant(homeLengthX, homeLengthY, quadrant);
+    const homeZero = getXYFromQuadrant(2, 2, quadrant);
+
+    return <g id="extents" strokeWidth="5" strokeLinecap="square" stroke="#434343">
+      <g id="home-lines">
+        {stopAtHomeX &&
+          <line x1={homeZero.qx} y1={homeZero.qy} x2={homeZero.qx} y2={homeLength.qy} />
+        }
+        {stopAtHomeY &&
+          <line x1={homeZero.qx} y1={homeZero.qy} x2={homeLength.qx} y2={homeZero.qy} />
+        }
+      </g>
+      <g id="max-lines">
+        {useMaxLines(axisLengthX, stopAtMaxX) &&
+          <line x1={homeLength.qx} y1={homeZero.qy} x2={homeLength.qx} y2={homeLength.qy} />
+        }
+        {useMaxLines(axisLengthY, stopAtMaxY) &&
+          <line x1={homeZero.qx} y1={homeLength.qy} x2={homeLength.qx} y2={homeLength.qy} />
+        }
+      </g>
+    </g>;
+  }
+}

--- a/webpack/farm_designer/map/garden_map.tsx
+++ b/webpack/farm_designer/map/garden_map.tsx
@@ -152,7 +152,9 @@ export class GardenMap extends
         <FarmBotLayer
           botOriginQuadrant={this.props.botOriginQuadrant}
           visible={!!this.props.showFarmbot}
-          botPosition={this.props.botPosition} />
+          botPosition={this.props.botPosition}
+          botMcuParams={this.props.botMcuParams}
+          stepsPerMmXY={this.props.stepsPerMmXY} />
         <HoveredPlantLayer
           isEditing={this.isEditing}
           botOriginQuadrant={this.props.botOriginQuadrant}

--- a/webpack/farm_designer/map/layers/__tests__/farmbot_layer_test.tsx
+++ b/webpack/farm_designer/map/layers/__tests__/farmbot_layer_test.tsx
@@ -1,13 +1,16 @@
 import * as React from "react";
 import { FarmBotLayer, FarmBotLayerProps } from "../farmbot_layer";
 import { shallow } from "enzyme";
+import { bot } from "../../../../__test_support__/fake_state/bot";
 
 describe("<FarmBotLayer/>", () => {
   function fakeProps(): FarmBotLayerProps {
     return {
       visible: true,
       botPosition: { x: 0, y: 0, z: 0 },
-      botOriginQuadrant: 2
+      botOriginQuadrant: 2,
+      botMcuParams: bot.hardware.mcu_params,
+      stepsPerMmXY: { x: undefined, y: undefined }
     };
   }
   it("toggles visibility off", () => {
@@ -15,46 +18,5 @@ describe("<FarmBotLayer/>", () => {
     p.visible = false;
     const result = shallow(<FarmBotLayer {...p } />);
     expect(result.html()).toEqual("<g></g>");
-  });
-
-  it("shows in correct location for quadrant 1", () => {
-    const p = fakeProps();
-    p.botOriginQuadrant = 1;
-    const result = shallow(<FarmBotLayer {...p } />);
-    expect(result.html()).toContain("<rect x=\"2990\" y=\"0\" width=\"20\" height=\"1500\"");
-    expect(result.html()).toContain("<circle cx=\"3000\" cy=\"0\" r=\"35\"");
-  });
-
-  it("shows in correct location for quadrant 2", () => {
-    const p = fakeProps();
-    p.botOriginQuadrant = 2;
-    const result = shallow(<FarmBotLayer {...p } />);
-    expect(result.html()).toContain("<rect x=\"-10\" y=\"0\" width=\"20\" height=\"1500\"");
-    expect(result.html()).toContain("<circle cx=\"0\" cy=\"0\" r=\"35\"");
-  });
-
-  it("shows in correct location for quadrant 3", () => {
-    const p = fakeProps();
-    p.botOriginQuadrant = 3;
-    const result = shallow(<FarmBotLayer {...p } />);
-    expect(result.html()).toContain("<rect x=\"-10\" y=\"0\" width=\"20\" height=\"1500\"");
-    expect(result.html()).toContain("<circle cx=\"0\" cy=\"1500\" r=\"35\"");
-  });
-
-  it("shows in correct location for quadrant 4", () => {
-    const p = fakeProps();
-    p.botOriginQuadrant = 4;
-    const result = shallow(<FarmBotLayer {...p } />);
-    expect(result.html()).toContain("<rect x=\"2990\" y=\"0\" width=\"20\" height=\"1500\"");
-    expect(result.html()).toContain("<circle cx=\"3000\" cy=\"1500\" r=\"35\"");
-  });
-
-  it("changes location", () => {
-    const p = fakeProps();
-    p.botOriginQuadrant = 2;
-    p.botPosition = { x: 100, y: 200, z: 0 };
-    const result = shallow(<FarmBotLayer {...p } />);
-    expect(result.html()).toContain("<rect x=\"90\" y=\"0\" width=\"20\" height=\"1500\"");
-    expect(result.html()).toContain("<circle cx=\"100\" cy=\"200\" r=\"35\"");
   });
 });

--- a/webpack/farm_designer/map/layers/farmbot_layer.tsx
+++ b/webpack/farm_designer/map/layers/farmbot_layer.tsx
@@ -1,19 +1,27 @@
 import * as React from "react";
-import { VirtualFarmBot } from "../farmbot_position_point";
+import { VirtualFarmBot } from "../virtual_farmbot";
+import { BotExtents } from "../bot_extents";
 import { BotOriginQuadrant } from "../../interfaces";
-import { BotPosition } from "../../../devices/interfaces";
+import { BotPosition, StepsPerMmXY } from "../../../devices/interfaces";
+import { McuParams } from "farmbot/dist";
 
 export interface FarmBotLayerProps {
   visible: boolean;
   botOriginQuadrant: BotOriginQuadrant;
   botPosition: BotPosition;
+  botMcuParams: McuParams;
+  stepsPerMmXY: StepsPerMmXY;
 }
 
 export function FarmBotLayer(props: FarmBotLayerProps) {
-  const { visible, botOriginQuadrant } = props;
+  const { visible, botOriginQuadrant, botMcuParams, stepsPerMmXY } = props;
   return visible ? <g>
     <VirtualFarmBot
       quadrant={botOriginQuadrant}
       botPosition={props.botPosition} />
+    <BotExtents
+      quadrant={botOriginQuadrant}
+      botMcuParams={botMcuParams}
+      stepsPerMmXY={stepsPerMmXY} />
   </g> : <g />; // fallback
 }

--- a/webpack/farm_designer/map/virtual_farmbot.tsx
+++ b/webpack/farm_designer/map/virtual_farmbot.tsx
@@ -3,7 +3,7 @@ import { getXYFromQuadrant } from "./util";
 import { BotOriginQuadrant } from "../interfaces";
 import { BotPosition } from "../../devices/interfaces";
 
-interface VFBProps {
+export interface VFBProps {
   quadrant: BotOriginQuadrant;
   botPosition: BotPosition;
 }

--- a/webpack/farm_designer/state_to_props.ts
+++ b/webpack/farm_designer/state_to_props.ts
@@ -6,7 +6,8 @@ import {
   joinToolsAndSlot,
   findPlant
 } from "../resources/selectors";
-import { BotPosition } from "../devices/interfaces";
+import { BotPosition, StepsPerMmXY } from "../devices/interfaces";
+import { isNumber } from "lodash";
 
 export function mapStateToProps(props: Everything) {
 
@@ -28,6 +29,14 @@ export function mapStateToProps(props: Everything) {
     botPosition = { x: undefined, y: undefined, z: undefined };
   }
 
+  function stepsPerMmXY(): StepsPerMmXY {
+    const config = props.bot.hardware.configuration;
+    if (isNumber(config.steps_per_mm_x) && isNumber(config.steps_per_mm_y)) {
+      return { x: config.steps_per_mm_x, y: config.steps_per_mm_y };
+    }
+    return { x: undefined, y: undefined };
+  }
+
   return {
     crops: selectAllCrops(props.resources.index),
     dispatch: props.dispatch,
@@ -38,6 +47,8 @@ export function mapStateToProps(props: Everything) {
     toolSlots: joinToolsAndSlot(props.resources.index),
     hoveredPlant,
     plants,
-    botPosition
+    botPosition,
+    botMcuParams: props.bot.hardware.mcu_params,
+    stepsPerMmXY: stepsPerMmXY()
   };
 }


### PR DESCRIPTION
- Show limit lines (movement bounds) on map if `STOP AT HOME` or `STOP AT MAX` are enabled. _Displays where FarmBot can and cannot move by visualizing the hardware settings._