### PR TITLE
Farm Designer map plant spread overlap indicator

### DIFF
--- a/webpack/farm_designer/interfaces.ts
+++ b/webpack/farm_designer/interfaces.ts
@@ -179,6 +179,7 @@ export interface GardenMapState {
   pageX: number | undefined;
   pageY: number | undefined;
   activeDragXY: BotPosition | undefined;
+  activeDragSpread: number | undefined;
 }
 
 export type PlantOptions = Partial<PlantPointer>;

--- a/webpack/farm_designer/map/__tests__/garden_plant_test.tsx
+++ b/webpack/farm_designer/map/__tests__/garden_plant_test.tsx
@@ -17,6 +17,7 @@ describe("<GardenPlant/>", () => {
       dispatch: jest.fn(),
       zoomLvl: 1.8,
       activeDragXY: { x: undefined, y: undefined, z: undefined },
+      activeDragSpread: undefined,
       plantAreaOffset: { x: 100, y: 100 }
     };
   }

--- a/webpack/farm_designer/map/__tests__/spread_overlap_test.tsx
+++ b/webpack/farm_designer/map/__tests__/spread_overlap_test.tsx
@@ -1,0 +1,94 @@
+import * as React from "react";
+import { SpreadOverlapHelper } from "../spread_overlap_helper";
+import { shallow } from "enzyme";
+import { SpreadOverlapHelperProps } from "../interfaces";
+import { fakePlant } from "../../../__test_support__/fake_state/resources";
+
+describe("<SpreadOverlapHelper/>", () => {
+  function fakeProps(): SpreadOverlapHelperProps {
+    const plant = fakePlant();
+    plant.body.x = 100;
+    plant.body.y = 100;
+    return {
+      mapTransformProps: {
+        quadrant: 2, gridSize: { x: 3000, y: 1500 }
+      },
+      plant,
+      dragging: false,
+      zoomLvl: 1,
+      activeDragXY: { x: undefined, y: undefined, z: undefined },
+      activeDragSpread: undefined
+    };
+  }
+
+  it("renders no overlap indicator: 0%", () => {
+    const p = fakeProps();
+    p.activeDragXY = { x: 1000, y: 100, z: 0 };
+    // Center distance: 900mm (inactive plant at x=100, y=100)
+    // Overlap: -650mm (default spread = radius * 10 = 250mm)
+    // Percentage overlap of inactive plant: 0%
+    const wrapper = shallow(<SpreadOverlapHelper {...p } />);
+    expect(wrapper.find(".overlap-circle").props().fill).toEqual("none");
+  });
+
+  it("renders gray overlap indicator: 4%", () => {
+    const p = fakeProps();
+    p.activeDragXY = { x: 340, y: 100, z: 0 };
+    // Center distance: 240mm (inactive plant at x=100, y=100)
+    // Overlap: 10mm (default spread = radius * 10 = 250mm)
+    // Percentage overlap of inactive plant: 4%
+    const wrapper = shallow(<SpreadOverlapHelper {...p } />);
+    expect(wrapper.find(".overlap-circle").props().fill).toEqual("gray");
+  });
+
+  it("renders yellow overlap indicator: 20%", () => {
+    const p = fakeProps();
+    p.activeDragXY = { x: 300, y: 100, z: 0 };
+    // Center distance: 200mm (inactive plant at x=100, y=100)
+    // Overlap: 50mm (default spread = radius * 10 = 250mm)
+    // Percentage overlap of inactive plant: 20%
+    const wrapper = shallow(<SpreadOverlapHelper {...p } />);
+    expect(wrapper.find(".overlap-circle").props().fill).toEqual("yellow");
+  });
+
+  it("renders orange overlap indicator: 40%", () => {
+    const p = fakeProps();
+    p.activeDragXY = { x: 250, y: 100, z: 0 };
+    // Center distance: 150mm (inactive plant at x=100, y=100)
+    // Overlap: 100mm (default spread = radius * 10 = 250mm)
+    // Percentage overlap of inactive plant: 40%
+    const wrapper = shallow(<SpreadOverlapHelper {...p } />);
+    expect(wrapper.find(".overlap-circle").props().fill).toEqual("orange");
+  });
+
+  it("renders red overlap indicator: 50%", () => {
+    const p = fakeProps();
+    p.activeDragXY = { x: 225, y: 100, z: 0 };
+    // Center distance: 125mm (inactive plant at x=100, y=100)
+    // Overlap: 125mm (default spread = radius * 10 = 250mm)
+    // Percentage overlap of inactive plant: 50%
+    const wrapper = shallow(<SpreadOverlapHelper {...p } />);
+    expect(wrapper.find(".overlap-circle").props().fill).toEqual("red");
+  });
+
+  it("renders red overlap indicator: 80%", () => {
+    const p = fakeProps();
+    p.activeDragXY = { x: 150, y: 100, z: 0 };
+    // Center distance: 50mm (inactive plant at x=100, y=100)
+    // Overlap: 200mm (default spread = radius * 10 = 250mm)
+    // Percentage overlap of inactive plant: 80%
+    const wrapper = shallow(<SpreadOverlapHelper {...p } />);
+    expect(wrapper.find(".overlap-circle").props().fill).toEqual("red");
+  });
+
+  it("renders red overlap indicator: 100%", () => {
+    const p = fakeProps();
+    p.activeDragXY = { x: 100, y: 100, z: 0 };
+    // Center distance: 0mm (inactive plant at x=100, y=100)
+    // Overlap: 250mm (default spread = radius * 10 = 250mm)
+    // Percentage overlap of inactive plant: 100%
+    const wrapper = shallow(<SpreadOverlapHelper {...p } />);
+    expect(wrapper.find(".overlap-circle").props().fill).toEqual("red");
+  });
+
+});

--- a/webpack/farm_designer/map/__tests__/util_test.ts
+++ b/webpack/farm_designer/map/__tests__/util_test.ts
@@ -1,13 +1,11 @@
-import { scale, round, translateScreenToGarden, getBotSize, getMapSize, getXYFromQuadrant } from "../util";
+import {
+  round, translateScreenToGarden, getBotSize, getMapSize, getXYFromQuadrant
+} from "../util";
 import { McuParams } from "farmbot";
 import { AxisNumberProperty, BotSize } from "../interfaces";
 import { StepsPerMmXY } from "../../../devices/interfaces";
 
 describe("Utils", () => {
-  it("scales a number", () => {
-    expect(Math.round(scale(100))).toEqual(490);
-  });
-
   it("rounds a number", () => {
     expect(round(44)).toEqual(40);
     expect(round(98)).toEqual(100);

--- a/webpack/farm_designer/map/garden_plant.tsx
+++ b/webpack/farm_designer/map/garden_plant.tsx
@@ -4,6 +4,7 @@ import { cachedCrop, DEFAULT_ICON, svgToUrl } from "../../open_farm/index";
 import { Circle } from "./circle";
 import { round, getXYFromQuadrant } from "./util";
 import { DragHelpers } from "./drag_helpers";
+import { SpreadOverlapHelper } from "./spread_overlap_helper";
 
 export class GardenPlant extends
   React.Component<GardenPlantProps, Partial<GardenPlantState>> {
@@ -20,7 +21,8 @@ export class GardenPlant extends
 
   render() {
     const { selected, dragging, plant, onClick, dispatch,
-      zoomLvl, activeDragXY, mapTransformProps, plantAreaOffset } = this.props;
+      zoomLvl, activeDragXY, mapTransformProps, plantAreaOffset,
+      activeDragSpread } = this.props;
     const { quadrant, gridSize } = mapTransformProps;
     const { radius, x, y } = plant.body;
     const { icon } = this.state;
@@ -30,6 +32,14 @@ export class GardenPlant extends
     const alpha = dragging ? 0.4 : 1.0;
 
     return <g>
+
+      <SpreadOverlapHelper
+        dragging={dragging}
+        plant={plant}
+        mapTransformProps={mapTransformProps}
+        zoomLvl={zoomLvl}
+        activeDragXY={activeDragXY}
+        activeDragSpread={activeDragSpread} />
 
       <Circle
         className="plant-indicator"

--- a/webpack/farm_designer/map/interfaces.ts
+++ b/webpack/farm_designer/map/interfaces.ts
@@ -17,6 +17,7 @@ export interface PlantLayerProps {
   mapTransformProps: MapTransformProps;
   zoomLvl: number;
   activeDragXY: BotPosition | undefined;
+  activeDragSpread: number | undefined;
   plantAreaOffset: AxisNumberProperty;
 }
 
@@ -51,6 +52,7 @@ export interface GardenPlantProps {
   onClick: (plant: Readonly<TaggedPlantPointer>) => void;
   zoomLvl: number;
   activeDragXY: BotPosition | undefined;
+  activeDragSpread: number | undefined;
   plantAreaOffset: AxisNumberProperty;
 }
 
@@ -99,4 +101,13 @@ export interface VirtualFarmBotProps {
 
 export interface FarmBotLayerProps extends VirtualFarmBotProps, BotExtentsProps {
   visible: boolean;
+}
+
+export interface SpreadOverlapHelperProps {
+  dragging: boolean;
+  plant: Readonly<TaggedPlantPointer>;
+  mapTransformProps: MapTransformProps;
+  zoomLvl: number;
+  activeDragXY: BotPosition | undefined;
+  activeDragSpread: number | undefined;
 }

--- a/webpack/farm_designer/map/layers/plant_layer.tsx
+++ b/webpack/farm_designer/map/layers/plant_layer.tsx
@@ -61,6 +61,7 @@ export function PlantLayer(props: PlantLayerProps) {
               dispatch={props.dispatch}
               zoomLvl={props.zoomLvl}
               activeDragXY={props.activeDragXY}
+              activeDragSpread={props.activeDragSpread}
               plantAreaOffset={plantAreaOffset} />
           </Link>;
         })}

--- a/webpack/farm_designer/map/layers/spread_layer.tsx
+++ b/webpack/farm_designer/map/layers/spread_layer.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Component } from "react";
 import { TaggedPlantPointer } from "../../../resources/tagged_resources";
-import { round, scale, getXYFromQuadrant } from "../util";
+import { round, getXYFromQuadrant } from "../util";
 import { cachedCrop } from "../../../open_farm/index";
 import { MapTransformProps } from "../interfaces";
 
@@ -59,7 +59,9 @@ export class SpreadCircle extends
         id={"spread-" + id}
         cx={qx}
         cy={qy}
-        r={scale(this.state.spread || radius)}
+        // Convert `spread` from diameter in cm to radius in mm.
+        // `radius * 10` is the default value for spread.
+        r={(this.state.spread || radius) / 2 * 10}
         fillOpacity={0.2}
         fill={"green"}
         stroke={"green"}

--- a/webpack/farm_designer/map/spread_overlap_helper.tsx
+++ b/webpack/farm_designer/map/spread_overlap_helper.tsx
@@ -1,0 +1,124 @@
+import * as React from "react";
+import { SpreadOverlapHelperProps } from "./interfaces";
+import { round, getXYFromQuadrant } from "./util";
+import { isUndefined } from "util";
+import { BotPosition } from "../../devices/interfaces";
+import { cachedCrop } from "../../open_farm/index";
+
+enum Overlap {
+  NONE = "none",
+  SOME = "gray",
+  SMALL = "yellow",
+  MEDIUM = "orange",
+  LARGE = "red",
+}
+
+type OverlapData = {
+  color: Overlap,
+  value: number
+};
+
+interface SpreadCircleState {
+  inactiveSpread: number | undefined;
+}
+
+export class SpreadOverlapHelper extends
+  React.Component<SpreadOverlapHelperProps, SpreadCircleState> {
+  state: SpreadCircleState = { inactiveSpread: undefined };
+
+  componentDidMount() {
+    cachedCrop(this.props.plant.body.openfarm_slug)
+      .then(({ spread }) =>
+        this.setState({ inactiveSpread: (spread || 0) * 10 }));
+  }
+
+  render() {
+    function evaluateOverlap(overlap: number, spreadRadius: number): OverlapData {
+      if (overlap > spreadRadius * 0.9) {
+        return { color: Overlap.LARGE, value: overlap };
+      }
+      if (overlap > spreadRadius * 0.6) {
+        return { color: Overlap.MEDIUM, value: overlap };
+      }
+      if (overlap > spreadRadius * 0.3) {
+        return { color: Overlap.SMALL, value: overlap };
+      }
+      if (overlap > 0) {
+        return { color: Overlap.SOME, value: overlap };
+      }
+      return { color: Overlap.NONE, value: overlap };
+    }
+
+    function getOverlap
+      (activeXYZ: BotPosition | undefined, plantXYZ: BotPosition): OverlapData {
+      if (activeXYZ && !isUndefined(activeXYZ.x) && !isUndefined(activeXYZ.y)
+        && plantXYZ && !isUndefined(plantXYZ.x) && !isUndefined(plantXYZ.y)) {
+        // Plant editing (dragging) is occuring
+        const activeXY = { x: round(activeXYZ.x), y: round(activeXYZ.y) };
+        const distance = Math.sqrt(
+          Math.pow((activeXY.x - plantXYZ.x), 2) +
+          Math.pow((activeXY.y - plantXYZ.y), 2));
+        const overlap = round(Math.abs(
+          Math.min(0, distance - inactiveSpreadRadius - activeSpreadRadius)));
+
+        // Overlap is evaluated against the inactive plant since evaluating
+        // against the active plant would require keeping a list of all plants
+        // overlapping the active plant. Therefore, the spread overlap helper
+        // should be thought of as a tool checking the inactive plants, not
+        // the plant being edited. Dragging a plant with a small spread into
+        // the area of a plant with large spread will illustrate this point.
+        return evaluateOverlap(overlap, inactiveSpreadRadius);
+      }
+      return { color: Overlap.NONE, value: 0 };
+    }
+
+    function overlapValues() {
+      // Display spread overlap percentages for debugging purposes
+      const activeSpread = activeSpreadRadius * 2;
+      const inactiveSpread = inactiveSpreadRadius * 2;
+      const percentage = (spread: number) =>
+        round(Math.min(100, Math.min(Math.min(activeSpread, inactiveSpread),
+          overlapData.value) / spread * 100));
+      if (overlapData.value > 0) {
+        return <g id="overlap-values">
+          <text x={qx} y={qy} dy={-75}>
+            {"Active: " + percentage(activeSpread) + "%"}
+          </text>
+          <text x={qx} y={qy} dy={-50}>
+            {"Inactive: " + percentage(inactiveSpread) + "%"}
+          </text>
+        </g>;
+      } else {
+        return <g />;
+      }
+    }
+
+    const { dragging, plant, activeDragXY, activeDragSpread, mapTransformProps } = this.props;
+    const { quadrant, gridSize } = mapTransformProps;
+    const { radius, x, y } = plant.body;
+    const { qx, qy } = getXYFromQuadrant(round(x), round(y), quadrant, gridSize);
+    const gardenCoord: BotPosition = { x: round(x), y: round(y), z: 0 };
+
+    // Convert `spread` from diameter in cm to radius in mm.
+    // `radius * 10` is the default value for spread.
+    const activeSpreadRadius = (activeDragSpread || radius * 10) / 2;
+    const inactiveSpreadRadius = (this.state.inactiveSpread || radius * 10) / 2;
+
+    const overlapData = getOverlap(activeDragXY, gardenCoord);
+    const debug = false; // change to true to show % overlap values
+
+    return <g id="overlap-circle">
+      {!dragging && // Non-active plants
+        <circle
+          className="overlap-circle"
+          cx={qx}
+          cy={qy}
+          r={inactiveSpreadRadius}
+          fill={overlapData.color}
+          stroke={overlapData.color}
+          fillOpacity="0.3" />}
+      {debug && !dragging &&
+        overlapValues()}
+    </g>;
+  }
+}

--- a/webpack/farm_designer/map/util.ts
+++ b/webpack/farm_designer/map/util.ts
@@ -7,13 +7,8 @@ import { StepsPerMmXY } from "../../devices/interfaces";
 import { CheckedAxisLength, AxisNumberProperty, BotSize } from "./interfaces";
 
 const SNAP = 10;
-const SCALE_FACTOR = 9.8;
 const LEFT_MENU_WIDTH = 320;
 const TOP_NAV_HEIGHT = 110;
-
-export function scale(radius = 0) {
-  return (radius * SCALE_FACTOR / 2);
-}
 
 /**
  * Used for snapping.


### PR DESCRIPTION
Further development of @roryaronson's initial concept: https://github.com/FarmBot/Farmbot-Web-App/commit/fdf7b58af4d311bacf54a38f07658c604f6d35ce

**Farm Designer:**
- Add plant spread overlap indicators while dragging (editing) plants in the map. Change the color of the adjacent plant spread circles to indicate the degree that the dragged plant's spread is overlapping them.