### PR TITLE
Farm Designer Map Improvements

### DIFF
--- a/webpack/__test_support__/fake_state/resources.ts
+++ b/webpack/__test_support__/fake_state/resources.ts
@@ -2,7 +2,8 @@ import { Everything } from "../../interfaces";
 import { buildResourceIndex } from "../resource_index_builder";
 import {
   TaggedFarmEvent, TaggedSequence, TaggedRegimen, TaggedImage,
-  TaggedTool, TaggedToolSlotPointer, TaggedUser, TaggedWebcamFeed, TaggedPlantPointer
+  TaggedTool, TaggedToolSlotPointer, TaggedUser, TaggedWebcamFeed,
+  TaggedPlantPointer, TaggedGenericPointer
 } from "../../resources/tagged_resources";
 import { ExecutableType } from "../../farm_designer/interfaces";
 import { fakeResource } from "../fake_resource";
@@ -95,6 +96,19 @@ export function fakePlant(): TaggedPlantPointer {
     radius: 25,
     meta: {},
     openfarm_slug: "strawberry"
+  });
+}
+
+export function fakePoint(): TaggedGenericPointer {
+  return fakeResource("points", {
+    id: idCounter++,
+    name: "Point 1",
+    pointer_type: "GenericPointer",
+    x: 200,
+    y: 400,
+    z: 0,
+    radius: 100,
+    meta: { created_by: "plant-detection" }
   });
 }
 

--- a/webpack/farm_designer/map/__tests__/circle_test.tsx
+++ b/webpack/farm_designer/map/__tests__/circle_test.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+import { Circle, CircleProps } from "../circle";
+import { shallow } from "enzyme";
+
+describe("<Circle/>", () => {
+  function fakeProps(): CircleProps {
+    return {
+      x: 10,
+      y: 20,
+      r: 30,
+      selected: true
+    };
+  }
+
+  it("renders selected plant indicator", () => {
+    const wrapper = shallow(<Circle {...fakeProps() } />);
+    expect(wrapper.props().cx).toEqual(10);
+    expect(wrapper.props().cy).toEqual(20);
+    expect(wrapper.props().r).toEqual(36);
+  });
+
+  it("hides selected plant indicator", () => {
+    const p = fakeProps();
+    p.selected = false;
+    const wrapper = shallow(<Circle {...p } />);
+    expect(wrapper.props().cx).toEqual(10);
+    expect(wrapper.props().cy).toEqual(20);
+    expect(wrapper.props().r).toEqual(0);
+  });
+
+});

--- a/webpack/farm_designer/map/__tests__/garden_point_test.tsx
+++ b/webpack/farm_designer/map/__tests__/garden_point_test.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+import { GardenPoint } from "../garden_point";
+import { shallow } from "enzyme";
+import { GardenPointProps } from "../interfaces";
+import { fakePoint } from "../../../__test_support__/fake_state/resources";
+
+describe("<GardenPoint/>", () => {
+  function fakeProps(): GardenPointProps {
+    return {
+      mapTransformProps: {
+        quadrant: 2, gridSize: { x: 3000, y: 1500 }
+      },
+      point: fakePoint()
+    };
+  }
+
+  it("renders point", () => {
+    const wrapper = shallow(<GardenPoint {...fakeProps() } />);
+    expect(wrapper.find("#point-radius").props().r).toEqual(100);
+    expect(wrapper.find("#point-center").props().r).toEqual(2);
+  });
+
+});

--- a/webpack/farm_designer/map/__tests__/grid_test.tsx
+++ b/webpack/farm_designer/map/__tests__/grid_test.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+import { Grid } from "../grid";
+import { shallow } from "enzyme";
+import { GridProps } from "../interfaces";
+
+describe("<Grid/>", () => {
+  function fakeProps(): GridProps {
+    return {
+      mapTransformProps: {
+        quadrant: 2, gridSize: { x: 3000, y: 1500 }
+      }
+    };
+  }
+
+  it("renders grid", () => {
+    const wrapper = shallow(<Grid {...fakeProps() } />);
+    expect(wrapper.find("#major-grid").props().width).toEqual(3000);
+    expect(wrapper.find("#minor-grid").props().width).toEqual(3000);
+    expect(wrapper.find("#axis-arrows").find("line").first().props())
+      .toEqual({ x1: 0, x2: 25, y1: 0, y2: 0 });
+    expect(wrapper.find("#axis-values").find("text").length).toEqual(43);
+  });
+
+});

--- a/webpack/farm_designer/map/__tests__/map_background_test.tsx
+++ b/webpack/farm_designer/map/__tests__/map_background_test.tsx
@@ -1,0 +1,22 @@
+import * as React from "react";
+import { MapBackground } from "../map_background";
+import { shallow } from "enzyme";
+import { MapBackgroundProps } from "../interfaces";
+
+describe("<MapBackground/>", () => {
+  function fakeProps(): MapBackgroundProps {
+    return {
+      mapTransformProps: {
+        quadrant: 2, gridSize: { x: 3000, y: 1500 }
+      },
+      plantAreaOffset: { x: 100, y: 100 }
+    };
+  }
+
+  it("renders map background", () => {
+    const wrapper = shallow(<MapBackground {...fakeProps() } />);
+    expect(wrapper.find("#bed-interior").props().width).toEqual(3180);
+    expect(wrapper.find("#bed-border").props().width).toEqual(3200);
+  });
+
+});

--- a/webpack/farm_designer/map/__tests__/spread_overlap_test.tsx
+++ b/webpack/farm_designer/map/__tests__/spread_overlap_test.tsx
@@ -28,7 +28,8 @@ describe("<SpreadOverlapHelper/>", () => {
     // Overlap: -650mm (default spread = radius * 10 = 250mm)
     // Percentage overlap of inactive plant: 0%
     const wrapper = shallow(<SpreadOverlapHelper {...p } />);
-    expect(wrapper.find(".overlap-circle").props().fill).toEqual("none");
+    const indicator = wrapper.find(".overlap-circle").props();
+    expect(indicator.fill).toEqual("none");
   });
 
   it("renders gray overlap indicator: 4%", () => {
@@ -38,7 +39,8 @@ describe("<SpreadOverlapHelper/>", () => {
     // Overlap: 10mm (default spread = radius * 10 = 250mm)
     // Percentage overlap of inactive plant: 4%
     const wrapper = shallow(<SpreadOverlapHelper {...p } />);
-    expect(wrapper.find(".overlap-circle").props().fill).toEqual("gray");
+    const indicator = wrapper.find(".overlap-circle").props();
+    expect(indicator.fill).toEqual("rgb(41, 141, 0)"); // "green"
   });
 
   it("renders yellow overlap indicator: 20%", () => {
@@ -48,7 +50,8 @@ describe("<SpreadOverlapHelper/>", () => {
     // Overlap: 50mm (default spread = radius * 10 = 250mm)
     // Percentage overlap of inactive plant: 20%
     const wrapper = shallow(<SpreadOverlapHelper {...p } />);
-    expect(wrapper.find(".overlap-circle").props().fill).toEqual("yellow");
+    const indicator = wrapper.find(".overlap-circle").props();
+    expect(indicator.fill).toEqual("rgb(204, 255, 0)"); // "yellow"
   });
 
   it("renders orange overlap indicator: 40%", () => {
@@ -58,7 +61,8 @@ describe("<SpreadOverlapHelper/>", () => {
     // Overlap: 100mm (default spread = radius * 10 = 250mm)
     // Percentage overlap of inactive plant: 40%
     const wrapper = shallow(<SpreadOverlapHelper {...p } />);
-    expect(wrapper.find(".overlap-circle").props().fill).toEqual("orange");
+    const indicator = wrapper.find(".overlap-circle").props();
+    expect(indicator.fill).toEqual("rgb(255, 102, 0)"); // "orange"
   });
 
   it("renders red overlap indicator: 50%", () => {
@@ -68,7 +72,8 @@ describe("<SpreadOverlapHelper/>", () => {
     // Overlap: 125mm (default spread = radius * 10 = 250mm)
     // Percentage overlap of inactive plant: 50%
     const wrapper = shallow(<SpreadOverlapHelper {...p } />);
-    expect(wrapper.find(".overlap-circle").props().fill).toEqual("red");
+    const indicator = wrapper.find(".overlap-circle").props();
+    expect(indicator.fill).toEqual("rgb(255, 20, 0)"); // "red"
   });
 
   it("renders red overlap indicator: 80%", () => {
@@ -78,7 +83,8 @@ describe("<SpreadOverlapHelper/>", () => {
     // Overlap: 200mm (default spread = radius * 10 = 250mm)
     // Percentage overlap of inactive plant: 80%
     const wrapper = shallow(<SpreadOverlapHelper {...p } />);
-    expect(wrapper.find(".overlap-circle").props().fill).toEqual("red");
+    const indicator = wrapper.find(".overlap-circle").props();
+    expect(indicator.fill).toEqual("rgb(255, 0, 0)"); // "red"
   });
 
   it("renders red overlap indicator: 100%", () => {
@@ -88,7 +94,8 @@ describe("<SpreadOverlapHelper/>", () => {
     // Overlap: 250mm (default spread = radius * 10 = 250mm)
     // Percentage overlap of inactive plant: 100%
     const wrapper = shallow(<SpreadOverlapHelper {...p } />);
-    expect(wrapper.find(".overlap-circle").props().fill).toEqual("red");
+    const indicator = wrapper.find(".overlap-circle").props();
+    expect(indicator.fill).toEqual("rgb(255, 0, 0)"); // "red"
   });
 
 });

--- a/webpack/farm_designer/map/__tests__/tool_slot_point_test.tsx
+++ b/webpack/farm_designer/map/__tests__/tool_slot_point_test.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+import { ToolSlotPoint, TSPProps } from "../tool_slot_point";
+import { shallow } from "enzyme";
+import { fakeToolSlot, fakeTool } from "../../../__test_support__/fake_state/resources";
+
+describe("<ToolSlotPoint/>", () => {
+  function fakeProps(): TSPProps {
+    return {
+      mapTransformProps: {
+        quadrant: 2, gridSize: { x: 3000, y: 1500 }
+      },
+      slot: { toolSlot: fakeToolSlot(), tool: fakeTool() }
+    };
+  }
+
+  it("renders tool slot point", () => {
+    const wrapper = shallow(<ToolSlotPoint {...fakeProps() } />);
+    const props = wrapper.find("circle").last().props();
+    expect(props.r).toEqual(35);
+    expect(props.cx).toEqual(10);
+    expect(props.cy).toEqual(10);
+  });
+
+  it("displays tool name", () => {
+    const wrapper = shallow(<ToolSlotPoint {...fakeProps() } />);
+    wrapper.setState({ hovered: true });
+    expect(wrapper.find("text").props().visibility).toEqual("visible");
+    expect(wrapper.find("text").text()).toEqual("Foo");
+  });
+
+  it("doesn't display tool name", () => {
+    const wrapper = shallow(<ToolSlotPoint {...fakeProps() } />);
+    expect(wrapper.find("text").props().visibility).toEqual("hidden");
+  });
+
+});

--- a/webpack/farm_designer/map/__tests__/virtual_farmbot_test.tsx
+++ b/webpack/farm_designer/map/__tests__/virtual_farmbot_test.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { VirtualFarmBot } from "../virtual_farmbot";
 import { shallow } from "enzyme";
 import { VirtualFarmBotProps } from "../interfaces";
+import { BotOriginQuadrant } from "../../interfaces";
 
 describe("<VirtualFarmBot/>", () => {
   function fakeProps(): VirtualFarmBotProps {
@@ -14,44 +15,52 @@ describe("<VirtualFarmBot/>", () => {
     };
   }
 
-  it("shows in correct location for quadrant 1", () => {
-    const p = fakeProps();
-    p.mapTransformProps.quadrant = 1;
-    const result = shallow(<VirtualFarmBot {...p } />);
-    expect(result.html()).toContain("<rect x=\"2990\" y=\"-100\" width=\"20\" height=\"1700\"");
-    expect(result.html()).toContain("<circle cx=\"3000\" cy=\"0\" r=\"35\"");
-  });
+  function checkPositionForQuadrant(
+    quadrant: BotOriginQuadrant,
+    expected: { x: number, y: number }) {
+    it(`shows in correct location for quadrant ${quadrant}`, () => {
+      const p = fakeProps();
+      p.mapTransformProps.quadrant = quadrant;
+      const result = shallow(<VirtualFarmBot {...p } />);
 
-  it("shows in correct location for quadrant 2", () => {
-    const p = fakeProps();
-    p.mapTransformProps.quadrant = 2;
-    const result = shallow(<VirtualFarmBot {...p } />);
-    expect(result.html()).toContain("<rect x=\"-10\" y=\"-100\" width=\"20\" height=\"1700\"");
-    expect(result.html()).toContain("<circle cx=\"0\" cy=\"0\" r=\"35\"");
-  });
+      const expectedGantryProps = {
+        id: "gantry",
+        x: expected.x - 10,
+        y: -100,
+        width: 20,
+        height: 1700,
+        fill: "#434343",
+        fillOpacity: 0.75
+      };
+      const gantryProps = result.find("rect").props();
+      expect(gantryProps).toEqual(expectedGantryProps);
 
-  it("shows in correct location for quadrant 3", () => {
-    const p = fakeProps();
-    p.mapTransformProps.quadrant = 3;
-    const result = shallow(<VirtualFarmBot {...p } />);
-    expect(result.html()).toContain("<rect x=\"-10\" y=\"-100\" width=\"20\" height=\"1700\"");
-    expect(result.html()).toContain("<circle cx=\"0\" cy=\"1500\" r=\"35\"");
-  });
+      const expectedUTMProps = {
+        id: "UTM",
+        cx: expected.x,
+        cy: expected.y,
+        r: 35,
+        fill: "#434343",
+        fillOpacity: 0.75
+      };
+      const UTMProps = result.find("circle").props();
+      expect(UTMProps).toEqual(expectedUTMProps);
+    });
+  }
 
-  it("shows in correct location for quadrant 4", () => {
-    const p = fakeProps();
-    p.mapTransformProps.quadrant = 4;
-    const result = shallow(<VirtualFarmBot {...p } />);
-    expect(result.html()).toContain("<rect x=\"2990\" y=\"-100\" width=\"20\" height=\"1700\"");
-    expect(result.html()).toContain("<circle cx=\"3000\" cy=\"1500\" r=\"35\"");
-  });
+  checkPositionForQuadrant(1, { x: 3000, y: 0 });
+  checkPositionForQuadrant(2, { x: 0, y: 0 });
+  checkPositionForQuadrant(3, { x: 0, y: 1500 });
+  checkPositionForQuadrant(4, { x: 3000, y: 1500 });
 
   it("changes location", () => {
     const p = fakeProps();
     p.mapTransformProps.quadrant = 2;
     p.botPosition = { x: 100, y: 200, z: 0 };
     const result = shallow(<VirtualFarmBot {...p } />);
-    expect(result.html()).toContain("<rect x=\"90\" y=\"-100\" width=\"20\" height=\"1700\"");
-    expect(result.html()).toContain("<circle cx=\"100\" cy=\"200\" r=\"35\"");
+    expect(result.find("#gantry").props().x).toEqual(90);
+    const UTM = result.find("circle").props();
+    expect(UTM.cx).toEqual(100);
+    expect(UTM.cy).toEqual(200);
   });
 });

--- a/webpack/farm_designer/map/circle.tsx
+++ b/webpack/farm_designer/map/circle.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-interface CircleProps {
+export interface CircleProps {
   x: number;
   y: number;
   r: number;
@@ -16,7 +16,7 @@ export function Circle(props: CircleProps) {
     className={"is-chosen-" + !!selected + " " + (cn ? cn : "")}
     cx={x}
     cy={y}
-    r={selected ? r*1.2 : 0}
+    r={selected ? r * 1.2 : 0}
     stroke="rgba(256,256,256,0.7)"
     strokeWidth={selected ? 2 : 0}
     strokeDasharray={selected ? 5 : 0}

--- a/webpack/farm_designer/map/garden_map.tsx
+++ b/webpack/farm_designer/map/garden_map.tsx
@@ -153,7 +153,6 @@ export class GardenMap extends
     };
     return <div
       className="drop-area"
-      id="drop-area"
       style={{
         height: mapSize.y + "px", maxHeight: mapSize.y + "px",
         width: mapSize.x + "px", maxWidth: mapSize.x + "px"

--- a/webpack/farm_designer/map/garden_plant.tsx
+++ b/webpack/farm_designer/map/garden_plant.tsx
@@ -5,6 +5,7 @@ import { Circle } from "./circle";
 import { round, getXYFromQuadrant } from "./util";
 import { DragHelpers } from "./drag_helpers";
 import { SpreadOverlapHelper } from "./spread_overlap_helper";
+import { SpreadCircle } from "./layers/spread_layer";
 
 export class GardenPlant extends
   React.Component<GardenPlantProps, Partial<GardenPlantState>> {
@@ -24,14 +25,14 @@ export class GardenPlant extends
       zoomLvl, activeDragXY, mapTransformProps, plantAreaOffset,
       activeDragSpread } = this.props;
     const { quadrant, gridSize } = mapTransformProps;
-    const { radius, x, y } = plant.body;
+    const { id, radius, x, y } = plant.body;
     const { icon } = this.state;
 
     const action = { type: "TOGGLE_HOVERED_PLANT", payload: { plant, icon } };
     const { qx, qy } = getXYFromQuadrant(round(x), round(y), quadrant, gridSize);
     const alpha = dragging ? 0.4 : 1.0;
 
-    return <g>
+    return <g id={"plant-" + id}>
 
       <circle
         className="soil-cloud"
@@ -49,6 +50,12 @@ export class GardenPlant extends
         activeDragXY={activeDragXY}
         activeDragSpread={activeDragSpread} />
 
+      {selected &&
+        <SpreadCircle
+          plant={plant}
+          key={plant.uuid}
+          mapTransformProps={mapTransformProps} />}
+
       <Circle
         className="plant-indicator"
         x={qx}
@@ -56,17 +63,19 @@ export class GardenPlant extends
         r={radius}
         selected={selected} />
 
-      <image
-        className={"plant-image is-chosen-" + selected}
-        opacity={alpha}
-        xlinkHref={this.state.icon}
-        onClick={() => onClick(this.props.plant)}
-        onMouseEnter={() => dispatch(action)}
-        onMouseLeave={() => dispatch(action)}
-        height={radius * 2}
-        width={radius * 2}
-        x={qx - radius}
-        y={qy - radius} />
+      <g id="plant-icon">
+        <image
+          className={"plant-image is-chosen-" + selected}
+          opacity={alpha}
+          xlinkHref={this.state.icon}
+          onClick={() => onClick(this.props.plant)}
+          onMouseEnter={() => dispatch(action)}
+          onMouseLeave={() => dispatch(action)}
+          height={radius * 2}
+          width={radius * 2}
+          x={qx - radius}
+          y={qy - radius} />
+      </g>
 
       <DragHelpers
         dragging={dragging}

--- a/webpack/farm_designer/map/garden_point.tsx
+++ b/webpack/farm_designer/map/garden_point.tsx
@@ -13,12 +13,12 @@ const POINT_STYLES = {
 export function GardenPoint(props: GardenPointProps) {
   const { point, mapTransformProps } = props;
   const { quadrant, gridSize } = mapTransformProps;
-  const { x, y } = point.body;
+  const { id, x, y } = point.body;
   const styles = defensiveClone(POINT_STYLES);
   styles.stroke = point.body.meta.color || "green";
   const { qx, qy } = getXYFromQuadrant(x, y, quadrant, gridSize);
-  return <g>
-    <circle cx={qx} cy={qy} r={point.body.radius} {...styles} />
-    <circle cx={qx} cy={qy} r={2} {...styles} />
+  return <g id={"point-" + id}>
+    <circle id="point-radius" cx={qx} cy={qy} r={point.body.radius} {...styles} />
+    <circle id="point-center" cx={qx} cy={qy} r={2} {...styles} />
   </g>;
 }

--- a/webpack/farm_designer/map/grid.tsx
+++ b/webpack/farm_designer/map/grid.tsx
@@ -9,60 +9,58 @@ export function Grid(props: GridProps) {
   const arrowEnd = getXYFromQuadrant(25, 25, quadrant, gridSize);
   const xLabel = getXYFromQuadrant(15, -10, quadrant, gridSize);
   const yLabel = getXYFromQuadrant(-11, 18, quadrant, gridSize);
-  return <g>
-    <g id="map-background">
-      <defs>
-        <pattern id="minor_grid" width={10} height={10} patternUnits="userSpaceOnUse">
-          <path d="M10,0 L0,0 L0,10" strokeWidth={1}
-            fill="none" stroke="rgba(0, 0, 0, 0.15)" />
-        </pattern>
+  return <g id="drop-area-background">
+    <defs>
+      <pattern id="minor_grid" width={10} height={10} patternUnits="userSpaceOnUse">
+        <path d="M10,0 L0,0 L0,10" strokeWidth={1}
+          fill="none" stroke="rgba(0, 0, 0, 0.15)" />
+      </pattern>
 
-        <pattern id={"major_grid"} width={100} height={100} patternUnits="userSpaceOnUse">
-          <path d="M100,0 L0,0 0,100" strokeWidth={2}
-            fill="none" stroke="rgba(0, 0, 0, 0.15)" />
-        </pattern>
+      <pattern id={"major_grid"} width={100} height={100} patternUnits="userSpaceOnUse">
+        <path d="M100,0 L0,0 0,100" strokeWidth={2}
+          fill="none" stroke="rgba(0, 0, 0, 0.15)" />
+      </pattern>
 
-        <marker id="arrow"
-          markerWidth={10} markerHeight={10} refX={0} refY={2} orient="auto"
-          markerUnits="strokeWidth">
-          <path d="M0,0 L0,4 L5,2 z" fill="#333" />
-        </marker>
-      </defs>
+      <marker id="arrow"
+        markerWidth={10} markerHeight={10} refX={0} refY={2} orient="auto"
+        markerUnits="strokeWidth">
+        <path d="M0,0 L0,4 L5,2 z" fill="#333" />
+      </marker>
+    </defs>
 
-      <g id="grid">
-        <rect id="fill" width={gridSize.x} height={gridSize.y} fill="#CA8" />
-        <rect id="minor-grid" width={gridSize.x} height={gridSize.y} fill="url(#minor_grid)" />
-        <rect id="major-grid" width={gridSize.x} height={gridSize.y} fill="url(#major_grid)" />
-        <rect id="border" width={gridSize.x} height={gridSize.y} fill="none"
-          stroke="rgba(0,0,0,0.3)" strokeWidth={2} />
+    <g id="grid">
+      <rect id="fill" width={gridSize.x} height={gridSize.y} fill="#CA8" />
+      <rect id="minor-grid" width={gridSize.x} height={gridSize.y} fill="url(#minor_grid)" />
+      <rect id="major-grid" width={gridSize.x} height={gridSize.y} fill="url(#major_grid)" />
+      <rect id="border" width={gridSize.x} height={gridSize.y} fill="none"
+        stroke="rgba(0,0,0,0.3)" strokeWidth={2} />
+    </g>
+
+    <g id="origin-marker">
+      <circle cx={origin.qx} cy={origin.qy} r={4} fill="#333" />
+      <g id="axis-labels" fontFamily="Arial" fontSize="10"
+        textAnchor="middle" dominantBaseline="central">
+        <text x={xLabel.qx} y={xLabel.qy}>X</text>
+        <text x={yLabel.qx} y={yLabel.qy}>Y</text>
       </g>
-
-      <g id="origin-marker">
-        <circle cx={origin.qx} cy={origin.qy} r={4} fill="#333" />
-        <g id="axis-labels" fontFamily="Arial" fontSize="10"
-          textAnchor="middle" dominantBaseline="central">
-          <text x={xLabel.qx} y={xLabel.qy}>X</text>
-          <text x={yLabel.qx} y={yLabel.qy}>Y</text>
-        </g>
-        <g id="axis-arrows" stroke="#333" strokeWidth="3" markerEnd="url(#arrow)">
-          <line x1={origin.qx} y1={origin.qy} x2={arrowEnd.qx} y2={origin.qy} />
-          <line x1={origin.qx} y1={origin.qy} x2={origin.qx} y2={arrowEnd.qy} />
-        </g>
+      <g id="axis-arrows" stroke="#333" strokeWidth="3" markerEnd="url(#arrow)">
+        <line x1={origin.qx} y1={origin.qy} x2={arrowEnd.qx} y2={origin.qy} />
+        <line x1={origin.qx} y1={origin.qy} x2={origin.qx} y2={arrowEnd.qy} />
       </g>
+    </g>
 
-      <g id="axis-values" fontFamily="Arial" fontSize="10"
-        textAnchor="middle" dominantBaseline="central" fill="rgba(0, 0, 0, 0.3)">
-        {_.range(100, gridSize.x, 100).map((i) => {
-          const location = getXYFromQuadrant(i, -10, quadrant, gridSize);
-          return <text key={"x-label-" + i}
-            x={location.qx} y={location.qy}>{i}</text>;
-        })}
-        {_.range(100, gridSize.y, 100).map((i) => {
-          const location = getXYFromQuadrant(-15, i, quadrant, gridSize);
-          return <text key={"y-label-" + i}
-            x={location.qx} y={location.qy}>{i}</text>;
-        })}
-      </g>
+    <g id="axis-values" fontFamily="Arial" fontSize="10"
+      textAnchor="middle" dominantBaseline="central" fill="rgba(0, 0, 0, 0.3)">
+      {_.range(100, gridSize.x, 100).map((i) => {
+        const location = getXYFromQuadrant(i, -10, quadrant, gridSize);
+        return <text key={"x-label-" + i}
+          x={location.qx} y={location.qy}>{i}</text>;
+      })}
+      {_.range(100, gridSize.y, 100).map((i) => {
+        const location = getXYFromQuadrant(-15, i, quadrant, gridSize);
+        return <text key={"y-label-" + i}
+          x={location.qx} y={location.qy}>{i}</text>;
+      })}
     </g>
   </g>;
 }

--- a/webpack/farm_designer/map/layers/__tests__/farmbot_layer_test.tsx
+++ b/webpack/farm_designer/map/layers/__tests__/farmbot_layer_test.tsx
@@ -19,10 +19,19 @@ describe("<FarmBotLayer/>", () => {
       plantAreaOffset: { x: 100, y: 100 }
     };
   }
+
+  it("shows layer elements", () => {
+    const p = fakeProps();
+    const result = shallow(<FarmBotLayer {...p } />);
+    const layer = result.find("#farmbot-layer");
+    expect(layer.find("#virtual-farmbot")).toBeTruthy();
+    expect(layer.find("#extents")).toBeTruthy();
+  });
+
   it("toggles visibility off", () => {
     const p = fakeProps();
     p.visible = false;
     const result = shallow(<FarmBotLayer {...p } />);
-    expect(result.html()).toEqual("<g></g>");
+    expect(result.html()).toEqual("<g id=\"farmbot-layer\"></g>");
   });
 });

--- a/webpack/farm_designer/map/layers/__tests__/hovered_plant_layer_test.tsx
+++ b/webpack/farm_designer/map/layers/__tests__/hovered_plant_layer_test.tsx
@@ -1,0 +1,41 @@
+import * as React from "react";
+import { HoveredPlantLayer, HoveredPlantLayerProps } from "../hovered_plant_layer";
+import { shallow } from "enzyme";
+
+describe("<HoveredPlantLayer/>", () => {
+  function fakeProps(): HoveredPlantLayerProps {
+    return {
+      currentPlant: undefined,
+      designer: {
+        selectedPlant: undefined,
+        hoveredPlant: {
+          plantUUID: undefined,
+          icon: ""
+        },
+        cropSearchQuery: "",
+        cropSearchResults: []
+      },
+      hoveredPlant: undefined,
+      dispatch: jest.fn(),
+      isEditing: false,
+      mapTransformProps: {
+        quadrant: 1, gridSize: { x: 3000, y: 1500 }
+      }
+    };
+  }
+
+  it("shows hovered plant icon", () => {
+    const p = fakeProps();
+    const wrapper = shallow(<HoveredPlantLayer {...p } />);
+    wrapper.setState({ isHovered: true });
+    const icon = wrapper.find("image");
+    expect(icon.props().style).toEqual({ "transform": "scale(1.3, 1.3)" });
+  });
+
+  it("doesn't show hovered plant icon", () => {
+    const p = fakeProps();
+    const wrapper = shallow(<HoveredPlantLayer {...p } />);
+    const icon = wrapper.find("image").props();
+    expect(icon.style).toEqual({ "transform": "scale(1, 1)" });
+  });
+});

--- a/webpack/farm_designer/map/layers/__tests__/point_layer_test.tsx
+++ b/webpack/farm_designer/map/layers/__tests__/point_layer_test.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+import { PointLayer, PointLayerProps } from "../point_layer";
+import { shallow } from "enzyme";
+import { fakePoint } from "../../../../__test_support__/fake_state/resources";
+
+describe("<PointLayer/>", () => {
+  function fakeProps(): PointLayerProps {
+    return {
+      visible: true,
+      points: [fakePoint()],
+      mapTransformProps: {
+        quadrant: 2, gridSize: { x: 3000, y: 1500 }
+      }
+    };
+  }
+
+  it("shows points", () => {
+    const p = fakeProps();
+    const wrapper = shallow(<PointLayer {...p } />);
+    const layer = wrapper.find("#point-layer");
+    expect(layer.find("GardenPoint").html()).toContain("r=\"100\"");
+  });
+
+  it("toggles visibility off", () => {
+    const p = fakeProps();
+    p.visible = false;
+    const wrapper = shallow(<PointLayer {...p } />);
+    const layer = wrapper.find("#point-layer");
+    expect(layer.find("GardenPoint").length).toEqual(0);
+  });
+});

--- a/webpack/farm_designer/map/layers/__tests__/spread_layer_test.tsx
+++ b/webpack/farm_designer/map/layers/__tests__/spread_layer_test.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+import { SpreadLayer, SpreadLayerProps } from "../spread_layer";
+import { shallow } from "enzyme";
+import { fakePlant } from "../../../../__test_support__/fake_state/resources";
+
+describe("<SpreadLayer/>", () => {
+  function fakeProps(): SpreadLayerProps {
+    return {
+      visible: true,
+      plants: [fakePlant()],
+      currentPlant: undefined,
+      mapTransformProps: {
+        quadrant: 2, gridSize: { x: 3000, y: 1500 }
+      }
+    };
+  }
+
+  it("shows spread", () => {
+    const p = fakeProps();
+    const wrapper = shallow(<SpreadLayer {...p } />);
+    const layer = wrapper.find("#spread-layer");
+    expect(layer.find("SpreadCircle").html()).toContain("r=\"125\"");
+  });
+
+  it("toggles visibility off", () => {
+    const p = fakeProps();
+    p.visible = false;
+    const wrapper = shallow(<SpreadLayer {...p } />);
+    const layer = wrapper.find("#spread-layer");
+    expect(layer.find("SpreadCircle").length).toEqual(0);
+  });
+});

--- a/webpack/farm_designer/map/layers/farmbot_layer.tsx
+++ b/webpack/farm_designer/map/layers/farmbot_layer.tsx
@@ -7,7 +7,7 @@ export function FarmBotLayer(props: FarmBotLayerProps) {
   const {
     visible, stopAtHome, botSize, plantAreaOffset, mapTransformProps
    } = props;
-  return visible ? <g>
+  return visible ? <g id="farmbot-layer">
     <VirtualFarmBot
       mapTransformProps={mapTransformProps}
       botPosition={props.botPosition}
@@ -16,5 +16,5 @@ export function FarmBotLayer(props: FarmBotLayerProps) {
       mapTransformProps={mapTransformProps}
       stopAtHome={stopAtHome}
       botSize={botSize} />
-  </g> : <g />; // fallback
+  </g> : <g id="farmbot-layer" />;
 }

--- a/webpack/farm_designer/map/layers/hovered_plant_layer.tsx
+++ b/webpack/farm_designer/map/layers/hovered_plant_layer.tsx
@@ -17,7 +17,7 @@ import { MapTransformProps } from "../interfaces";
  * achieve this effect.
  */
 
-interface HoveredPlantLayerProps {
+export interface HoveredPlantLayerProps {
   currentPlant: TaggedPlantPointer | undefined;
   designer: DesignerState;
   hoveredPlant: TaggedPlantPointer | undefined;
@@ -61,17 +61,19 @@ export class HoveredPlantLayer extends
     const { qx, qy } = getXYFromQuadrant(round(x), round(y), quadrant, gridSize);
     const scaleFactor = (this.state.isHovered) ? "1.3, 1.3" : "1, 1";
 
-    return <image
-      visibility={this.props.isEditing ? "visible" : "hidden"}
-      style={{ transform: "scale(" + scaleFactor + ")" }}
-      className={"hovered-plant-copy"}
-      x={qx - (this.plantInfo.radius)}
-      y={qy - (this.plantInfo.radius)}
-      onMouseEnter={this.toggle("isHovered")}
-      onMouseLeave={this.toggle("isHovered")}
-      onClick={this.onClick}
-      width={this.plantInfo.radius * 2}
-      height={this.plantInfo.radius * 2}
-      xlinkHref={icon} />;
+    return <g id="hovered-plant-icon">
+      <image
+        visibility={this.props.isEditing ? "visible" : "hidden"}
+        style={{ transform: "scale(" + scaleFactor + ")" }}
+        className={"hovered-plant-copy"}
+        x={qx - (this.plantInfo.radius)}
+        y={qy - (this.plantInfo.radius)}
+        onMouseEnter={this.toggle("isHovered")}
+        onMouseLeave={this.toggle("isHovered")}
+        onClick={this.onClick}
+        width={this.plantInfo.radius * 2}
+        height={this.plantInfo.radius * 2}
+        xlinkHref={icon} />
+    </g>;
   }
 }

--- a/webpack/farm_designer/map/layers/plant_layer.tsx
+++ b/webpack/farm_designer/map/layers/plant_layer.tsx
@@ -28,9 +28,9 @@ export function PlantLayer(props: PlantLayerProps) {
   const maybeNoPointer = history.getCurrentLocation().pathname.split("/")[6] == "add"
     ? { "pointerEvents": "none" } : {};
 
-  if (visible) {
-    return <g>
-      {plants
+  return <g id="plant-layer">
+    {visible &&
+      plants
         .filter(x => !!x.body.id)
         .map(p => defensiveClone(p))
         .map(p => {
@@ -65,8 +65,5 @@ export function PlantLayer(props: PlantLayerProps) {
               plantAreaOffset={plantAreaOffset} />
           </Link>;
         })}
-    </g>;
-  } else {
-    return <g />;
-  }
+  </g>;
 }

--- a/webpack/farm_designer/map/layers/point_layer.tsx
+++ b/webpack/farm_designer/map/layers/point_layer.tsx
@@ -3,7 +3,7 @@ import { TaggedGenericPointer } from "../../../resources/tagged_resources";
 import { GardenPoint } from "../garden_point";
 import { MapTransformProps } from "../interfaces";
 
-interface PointLayerProps {
+export interface PointLayerProps {
   visible: boolean;
   points: TaggedGenericPointer[];
   mapTransformProps: MapTransformProps;
@@ -11,12 +11,13 @@ interface PointLayerProps {
 
 export function PointLayer(props: PointLayerProps) {
   const { visible, points, mapTransformProps } = props;
-  return visible ? <g>
-    {points.map(p =>
-      <GardenPoint
-        point={p}
-        key={p.body.id}
-        mapTransformProps={mapTransformProps} />
-    )}
-  </g> : <g />; // fallback
+  return <g id="point-layer">
+    {visible &&
+      points.map(p =>
+        <GardenPoint
+          point={p}
+          key={p.body.id}
+          mapTransformProps={mapTransformProps} />
+      )}
+  </g>;
 }

--- a/webpack/farm_designer/map/layers/spread_layer.tsx
+++ b/webpack/farm_designer/map/layers/spread_layer.tsx
@@ -5,7 +5,7 @@ import { round, getXYFromQuadrant } from "../util";
 import { cachedCrop } from "../../../open_farm/index";
 import { MapTransformProps } from "../interfaces";
 
-interface SpreadLayerProps {
+export interface SpreadLayerProps {
   visible: boolean;
   plants: TaggedPlantPointer[];
   currentPlant: TaggedPlantPointer | undefined;
@@ -13,24 +13,22 @@ interface SpreadLayerProps {
 }
 
 export function SpreadLayer(props: SpreadLayerProps) {
-  const { plants, visible, currentPlant, mapTransformProps } = props;
+  const { plants, visible, mapTransformProps } = props;
   return (
-    <g>
+    <g id="spread-layer">
       <defs>
         <radialGradient id="SpreadGradient">
-          <stop offset="90%" stopColor="rgba(0, 0, 0, 0.08)" />
-          <stop offset="100%" stopColor="rgba(0, 0, 0, 0)" />
+          <stop offset="90%" stopColor="rgba(85, 50, 10, 0.1)" />
+          <stop offset="100%" stopColor="rgba(85, 50, 10, 0)" />
         </radialGradient>
       </defs>
 
-      {
+      {visible &&
         plants.map((p, index) => {
-          const isSelected = p === currentPlant;
-          return (visible || isSelected) ?
-            <SpreadCircle
-              plant={p}
-              key={p.uuid}
-              mapTransformProps={mapTransformProps} /> : <g key={p.uuid} />;
+          return <SpreadCircle
+            plant={p}
+            key={p.uuid}
+            mapTransformProps={mapTransformProps} />;
         })
       }
     </g>
@@ -60,7 +58,7 @@ export class SpreadCircle extends
     const { radius, x, y, id } = this.props.plant.body;
     const { quadrant, gridSize } = this.props.mapTransformProps;
     const { qx, qy } = getXYFromQuadrant(round(x), round(y), quadrant, gridSize);
-    return <g>
+    return <g id={"spread-" + id}>
       <circle
         className="spread"
         id={"spread-" + id}
@@ -70,6 +68,6 @@ export class SpreadCircle extends
         // `radius * 10` is the default value for spread.
         r={(this.state.spread || radius) / 2 * 10}
         fill={"url(#SpreadGradient)"} />
-      </g>;
+    </g>;
   }
 }

--- a/webpack/farm_designer/map/layers/tool_slot_layer.tsx
+++ b/webpack/farm_designer/map/layers/tool_slot_layer.tsx
@@ -11,12 +11,13 @@ export interface ToolSlotLayerProps {
 
 export function ToolSlotLayer(props: ToolSlotLayerProps) {
   const { slots, visible, mapTransformProps } = props;
-  return visible ? <g>
-    {slots.map(slot =>
-      <ToolSlotPoint
-        key={slot.toolSlot.uuid}
-        slot={slot}
-        mapTransformProps={mapTransformProps} />
-    )}
-  </g> : <g />; // fallback
+  return <g id="toolslot-layer">
+    {visible &&
+      slots.map(slot =>
+        <ToolSlotPoint
+          key={slot.toolSlot.uuid}
+          slot={slot}
+          mapTransformProps={mapTransformProps} />
+      )}
+  </g>;
 }

--- a/webpack/farm_designer/map/map_background.tsx
+++ b/webpack/farm_designer/map/map_background.tsx
@@ -7,22 +7,20 @@ export function MapBackground(props: MapBackgroundProps) {
   const boardWidth = 20;
   const mapWidth = gridSize.x + plantAreaOffset.x * 2;
   const mapHeight = gridSize.y + plantAreaOffset.y * 2;
-  return <g>
-    <g id="map-background">
-      <defs>
-        <pattern id="diagonalHatch" width={8} height={8} patternUnits="userSpaceOnUse">
-          <path d="M-1,1 l4,-4 M0,8 l8,-8 M7,9 l4,-4" strokeWidth={0.5}
-            stroke="rgba(0,0,0,0.07)" />
-        </pattern>
-      </defs>
+  return <g id="map-background">
+    <defs>
+      <pattern id="diagonalHatch" width={8} height={8} patternUnits="userSpaceOnUse">
+        <path d="M-1,1 l4,-4 M0,8 l8,-8 M7,9 l4,-4" strokeWidth={0.5}
+          stroke="rgba(0,0,0,0.07)" />
+      </pattern>
+    </defs>
 
-      <rect x={0} y={0} width={mapWidth} height={mapHeight} fill="#c39f7a" />
-      <rect x={boardWidth / 2} y={boardWidth / 2}
-        width={mapWidth - boardWidth} height={mapHeight - boardWidth}
-        fill="#c39f7a" stroke="rgba(120,63,4,0.25)" strokeWidth={boardWidth} />
-      <rect id="no-access-perimeter" x={boardWidth} y={boardWidth}
-        width={mapWidth - boardWidth * 2} height={mapHeight - boardWidth * 2}
-        fill="url(#diagonalHatch)" />
-    </g>
+    <rect id="bed-border" x={0} y={0} width={mapWidth} height={mapHeight} fill="#c39f7a" />
+    <rect id="bed-interior" x={boardWidth / 2} y={boardWidth / 2}
+      width={mapWidth - boardWidth} height={mapHeight - boardWidth}
+      fill="#c39f7a" stroke="rgba(120,63,4,0.25)" strokeWidth={boardWidth} />
+    <rect id="no-access-perimeter" x={boardWidth} y={boardWidth}
+      width={mapWidth - boardWidth * 2} height={mapHeight - boardWidth * 2}
+      fill="url(#diagonalHatch)" />
   </g>;
 }

--- a/webpack/farm_designer/map/spread_overlap_helper.tsx
+++ b/webpack/farm_designer/map/spread_overlap_helper.tsx
@@ -7,7 +7,7 @@ import { cachedCrop } from "../../open_farm/index";
 
 enum Overlap {
   NONE = "none",
-  SOME = "gray",
+  SOME = "green",
   SMALL = "yellow",
   MEDIUM = "orange",
   LARGE = "red",
@@ -87,6 +87,9 @@ export class SpreadOverlapHelper extends
           <text x={qx} y={qy} dy={-50}>
             {"Inactive: " + percentage(inactiveSpread) + "%"}
           </text>
+          <text x={qx} y={qy} dy={25}>
+            {overlapData.color}
+          </text>
         </g>;
       } else {
         return <g />;
@@ -107,16 +110,35 @@ export class SpreadOverlapHelper extends
     const overlapData = getOverlap(activeDragXY, gardenCoord);
     const debug = false; // change to true to show % overlap values
 
+    function getColor() {
+      // Smoothly vary color based on overlap from dark green > yellow > orange > red
+      if (overlapData.value > 0) {
+        const normalized = Math.round(
+          Math.max(0, Math.min(inactiveSpreadRadius, overlapData.value))
+          / (inactiveSpreadRadius) * 255 * 2);
+        if (normalized < 255) { // green to yellow
+          const r = Math.min(normalized, 255);
+          const g = Math.min(100 + normalized, 255); // dark instead of bright green
+          return `rgb(${r}, ${g}, 0)`;
+        } else { // yellow to red
+          const g = Math.min(255 * 2 - normalized, 255);
+          return `rgb(255, ${g}, 0)`;
+        }
+      } else {
+        return "none";
+      }
+    }
+
     return <g id="overlap-circle">
       {!dragging && // Non-active plants
         <circle
           className="overlap-circle"
           cx={qx}
           cy={qy}
-          r={inactiveSpreadRadius}
-          fill={overlapData.color}
-          stroke={overlapData.color}
-          fillOpacity="0.3" />}
+          r={inactiveSpreadRadius * 0.95}
+          fill={getColor()}
+
+          fillOpacity={0.3} />}
       {debug && !dragging &&
         overlapValues()}
     </g>;

--- a/webpack/farm_designer/map/tool_slot_point.tsx
+++ b/webpack/farm_designer/map/tool_slot_point.tsx
@@ -4,7 +4,7 @@ import { getXYFromQuadrant } from "./util";
 import { MapTransformProps } from "./interfaces";
 import * as _ from "lodash";
 
-interface TSPProps {
+export interface TSPProps {
   slot: SlotWithTool;
   mapTransformProps: MapTransformProps;
 }
@@ -23,14 +23,14 @@ export class ToolSlotPoint extends
   get slot() { return this.props.slot; }
 
   render() {
-    const { x, y } = this.slot.toolSlot.body;
+    const { id, x, y } = this.slot.toolSlot.body;
     const { quadrant, gridSize } = this.props.mapTransformProps;
     const { qx, qy } = getXYFromQuadrant(x, y, quadrant, gridSize);
     const toolName = this.slot.tool ? this.slot.tool.body.name : "no tool";
     const seedBin = _.includes(toolName.toLowerCase(), "seed bin");
     const seedTray = _.includes(toolName.toLowerCase(), "seed tray");
     const seedTrayRect = getXYFromQuadrant(x, y, quadrant, gridSize);
-    return <g>
+    return <g id={"toolslot-" + id}>
       <defs>
         <radialGradient id="SeedBinGradient">
           <stop offset="5%" stopColor="rgba(0, 0, 0, 0.3)" />

--- a/webpack/farm_designer/map/virtual_farmbot.tsx
+++ b/webpack/farm_designer/map/virtual_farmbot.tsx
@@ -8,15 +8,15 @@ export function VirtualFarmBot(props: VirtualFarmBotProps) {
   const { quadrant, gridSize } = mapTransformProps;
   const mapSize = getMapSize(gridSize, plantAreaOffset);
   const { qx, qy } = getXYFromQuadrant((x || 0), (y || 0), quadrant, gridSize);
-  return <g>
-    <rect
+  return <g id="virtual-farmbot">
+    <rect id="gantry"
       x={qx - 10}
       y={-plantAreaOffset.y}
       width={20}
       height={mapSize.y}
       fillOpacity={0.75}
       fill={"#434343"} />
-    <circle
+    <circle id="UTM"
       cx={qx}
       cy={qy}
       r={35}


### PR DESCRIPTION
**Farm Designer:**
* Adjust spread style.
* Continuously vary spread overlap indicator color according to severity of overlap.

---

_Refactoring and Tests:_
- _Organize and add `id`s to svg elements to improve html readability._
- _Create more Farm Designer Map tests._