### PR TITLE
Farm Designer map display improvements

### DIFF
--- a/webpack/__test_support__/fake_state/resources.ts
+++ b/webpack/__test_support__/fake_state/resources.ts
@@ -88,6 +88,7 @@ export function fakeToolSlot(): TaggedToolSlotPointer {
 
 export function fakePlant(): TaggedPlantPointer {
   return fakeResource("points", {
+    id: idCounter++,
     name: "Strawberry Plant 1",
     pointer_type: "Plant",
     x: 100,

--- a/webpack/css/farm_designer/farm_designer.scss
+++ b/webpack/css/farm_designer/farm_designer.scss
@@ -217,6 +217,7 @@
 .spread {
   animation: spread-pop 0.2s cubic-bezier(0, 0, 0, 1);
   transform-origin: center;
+  pointer-events: none;
 }
 
 .garden-map-legend {

--- a/webpack/farm_designer/map/__tests__/garden_map_test.tsx
+++ b/webpack/farm_designer/map/__tests__/garden_map_test.tsx
@@ -65,6 +65,9 @@ describe("<GardenPlant/>", () => {
   it("starts drag and sets activeSpread", async () => {
     const wrapper = shallow(<GardenMap {...fakeProps() } />);
     expect(wrapper.state()).toEqual({});
+    Object.defineProperty(location, "pathname", {
+      value: "/edit/"
+    });
     await wrapper.find("#drop-area-svg").simulate("mouseDown");
     expect(wrapper.state()).toEqual({
       activeDragSpread: 1000,

--- a/webpack/farm_designer/map/__tests__/garden_plant_test.tsx
+++ b/webpack/farm_designer/map/__tests__/garden_plant_test.tsx
@@ -13,12 +13,10 @@ describe("<GardenPlant/>", () => {
       plant: fakePlant(),
       selected: false,
       dragging: false,
-      onClick: jest.fn(),
       dispatch: jest.fn(),
       zoomLvl: 1.8,
       activeDragXY: { x: undefined, y: undefined, z: undefined },
-      activeDragSpread: undefined,
-      plantAreaOffset: { x: 100, y: 100 }
+      uuid: ""
     };
   }
 
@@ -26,8 +24,6 @@ describe("<GardenPlant/>", () => {
     const wrapper = shallow(<GardenPlant {...fakeProps() } />);
     expect(wrapper.find("image").length).toEqual(1);
     expect(wrapper.find("image").props().opacity).toEqual(1);
-    expect(wrapper.find("Circle").length).toEqual(1);
-    expect(wrapper.find("Circle").props().selected).toBeFalsy();
     expect(wrapper.find("text").length).toEqual(0);
     expect(wrapper.find("rect").length).toBeLessThanOrEqual(1);
     expect(wrapper.find("use").length).toEqual(0);

--- a/webpack/farm_designer/map/__tests__/layer_toggle_test.tsx
+++ b/webpack/farm_designer/map/__tests__/layer_toggle_test.tsx
@@ -1,0 +1,26 @@
+import * as React from "react";
+import { LayerToggle, LayerToggleProps } from "../layer_toggle";
+import { shallow } from "enzyme";
+
+describe("<LayerToggle/>", () => {
+  const toggle = jest.fn();
+  function fakeProps(): LayerToggleProps {
+    return {
+      label: "toggle label",
+      value: true,
+      onClick: toggle
+    };
+  }
+
+  it("renders", () => {
+    const wrapper = shallow(<LayerToggle {...fakeProps() } />);
+    expect(wrapper.text()).toEqual("toggle label");
+    expect(wrapper.html()).toContain("green");
+  });
+
+  it("toggles", () => {
+    const wrapper = shallow(<LayerToggle {...fakeProps() } />);
+    wrapper.find("button").simulate("click");
+    expect(toggle).toHaveBeenCalled();
+  });
+});

--- a/webpack/farm_designer/map/garden_plant.tsx
+++ b/webpack/farm_designer/map/garden_plant.tsx
@@ -1,11 +1,8 @@
 import * as React from "react";
 import { GardenPlantProps, GardenPlantState } from "./interfaces";
 import { cachedCrop, DEFAULT_ICON, svgToUrl } from "../../open_farm/index";
-import { Circle } from "./circle";
 import { round, getXYFromQuadrant } from "./util";
 import { DragHelpers } from "./drag_helpers";
-import { SpreadOverlapHelper } from "./spread_overlap_helper";
-import { SpreadCircle } from "./layers/spread_layer";
 
 export class GardenPlant extends
   React.Component<GardenPlantProps, Partial<GardenPlantState>> {
@@ -20,15 +17,22 @@ export class GardenPlant extends
       });
   }
 
+  click = () => {
+    this.props.dispatch({ type: "SELECT_PLANT", payload: this.props.uuid });
+    this.props.dispatch({
+      type: "TOGGLE_HOVERED_PLANT", payload: {
+        plantUUID: this.props.uuid, icon: this.state.icon
+      }
+    });
+  };
+
   render() {
-    const { selected, dragging, plant, onClick, dispatch,
-      zoomLvl, activeDragXY, mapTransformProps, plantAreaOffset,
-      activeDragSpread } = this.props;
+    const { selected, dragging, plant, mapTransformProps,
+      activeDragXY, zoomLvl } = this.props;
     const { quadrant, gridSize } = mapTransformProps;
     const { id, radius, x, y } = plant.body;
     const { icon } = this.state;
 
-    const action = { type: "TOGGLE_HOVERED_PLANT", payload: { plant, icon } };
     const { qx, qy } = getXYFromQuadrant(round(x), round(y), quadrant, gridSize);
     const alpha = dragging ? 0.4 : 1.0;
 
@@ -42,48 +46,26 @@ export class GardenPlant extends
         fill="#90612f"
         fillOpacity="0" />
 
-      <SpreadOverlapHelper
-        dragging={dragging}
-        plant={plant}
-        mapTransformProps={mapTransformProps}
-        zoomLvl={zoomLvl}
-        activeDragXY={activeDragXY}
-        activeDragSpread={activeDragSpread} />
-
-      {selected &&
-        <SpreadCircle
-          plant={plant}
-          key={plant.uuid}
-          mapTransformProps={mapTransformProps} />}
-
-      <Circle
-        className="plant-indicator"
-        x={qx}
-        y={qy}
-        r={radius}
-        selected={selected} />
-
       <g id="plant-icon">
         <image
+          visibility={dragging ? "hidden" : "visible"}
           className={"plant-image is-chosen-" + selected}
           opacity={alpha}
-          xlinkHref={this.state.icon}
-          onClick={() => onClick(this.props.plant)}
-          onMouseEnter={() => dispatch(action)}
-          onMouseLeave={() => dispatch(action)}
+          xlinkHref={icon}
+          onClick={this.click}
           height={radius * 2}
           width={radius * 2}
           x={qx - radius}
           y={qy - radius} />
       </g>
 
-      <DragHelpers
+      <DragHelpers // for inactive plants
         dragging={dragging}
         plant={plant}
         mapTransformProps={mapTransformProps}
         zoomLvl={zoomLvl}
         activeDragXY={activeDragXY}
-        plantAreaOffset={plantAreaOffset} />
+        plantAreaOffset={{ x: 0, y: 0 }} />
     </g>;
   }
 }

--- a/webpack/farm_designer/map/interfaces.ts
+++ b/webpack/farm_designer/map/interfaces.ts
@@ -17,8 +17,6 @@ export interface PlantLayerProps {
   mapTransformProps: MapTransformProps;
   zoomLvl: number;
   activeDragXY: BotPosition | undefined;
-  activeDragSpread: number | undefined;
-  plantAreaOffset: AxisNumberProperty;
 }
 
 export interface CropSpreadDict {
@@ -49,11 +47,9 @@ export interface GardenPlantProps {
   plant: Readonly<TaggedPlantPointer>;
   selected: boolean;
   dragging: boolean;
-  onClick: (plant: Readonly<TaggedPlantPointer>) => void;
   zoomLvl: number;
   activeDragXY: BotPosition | undefined;
-  activeDragSpread: number | undefined;
-  plantAreaOffset: AxisNumberProperty;
+  uuid: string;
 }
 
 export interface GardenPlantState {

--- a/webpack/farm_designer/map/layer_toggle.tsx
+++ b/webpack/farm_designer/map/layer_toggle.tsx
@@ -1,13 +1,13 @@
 import * as React from "react";
 
-interface LayerTogleProps {
+export interface LayerToggleProps {
   label: string;
   value: boolean | undefined;
   onClick(): void;
 }
 
 /** A flipper type switch for showing/hiding the layers of the garden map. */
-export function LayerToggle({ label, value, onClick }: LayerTogleProps) {
+export function LayerToggle({ label, value, onClick }: LayerToggleProps) {
   const klassName = "fb-button fb-toggle-button " + (value ? "green" : "red");
   return <fieldset>
     <label>

--- a/webpack/farm_designer/map/layers/__tests__/drag_helper_layer_test.tsx
+++ b/webpack/farm_designer/map/layers/__tests__/drag_helper_layer_test.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+import { DragHelperLayer, DragHelperLayerProps } from "../drag_helper_layer";
+import { shallow } from "enzyme";
+import { fakePlant } from "../../../../__test_support__/fake_state/resources";
+
+describe("<DragHelperLayer/>", () => {
+  function fakeProps(): DragHelperLayerProps {
+    return {
+      currentPlant: fakePlant(),
+      editing: true,
+      mapTransformProps: {
+        quadrant: 2, gridSize: { x: 3000, y: 1500 }
+      },
+      dragging: true,
+      zoomLvl: 1.8,
+      activeDragXY: { x: undefined, y: undefined, z: undefined },
+      plantAreaOffset: { x: 100, y: 100 }
+    };
+  }
+
+  it("shows drag helpers", () => {
+    const p = fakeProps();
+    const wrapper = shallow(<DragHelperLayer {...p } />);
+    expect(wrapper.html()).toContain("drag-helpers");
+    expect(wrapper.html()).toContain("coordinates-tooltip");
+    expect(wrapper.html()).toContain("long-crosshair");
+    expect(wrapper.html()).toContain("short-crosshair");
+  });
+
+  it("doesn't show drag helpers", () => {
+    const p = fakeProps();
+    p.editing = false;
+    const wrapper = shallow(<DragHelperLayer {...p } />);
+    expect(wrapper.html()).toEqual("<g id=\"drag-helper-layer\"></g>");
+  });
+});

--- a/webpack/farm_designer/map/layers/__tests__/hovered_plant_layer_test.tsx
+++ b/webpack/farm_designer/map/layers/__tests__/hovered_plant_layer_test.tsx
@@ -1,10 +1,13 @@
 import * as React from "react";
 import { HoveredPlantLayer, HoveredPlantLayerProps } from "../hovered_plant_layer";
 import { shallow } from "enzyme";
+import { fakePlant } from "../../../../__test_support__/fake_state/resources";
 
 describe("<HoveredPlantLayer/>", () => {
   function fakeProps(): HoveredPlantLayerProps {
     return {
+      visible: true,
+      dragging: false,
       currentPlant: undefined,
       designer: {
         selectedPlant: undefined,
@@ -15,27 +18,41 @@ describe("<HoveredPlantLayer/>", () => {
         cropSearchQuery: "",
         cropSearchResults: []
       },
-      hoveredPlant: undefined,
-      dispatch: jest.fn(),
+      hoveredPlant: fakePlant(),
       isEditing: false,
       mapTransformProps: {
-        quadrant: 1, gridSize: { x: 3000, y: 1500 }
+        quadrant: 2, gridSize: { x: 3000, y: 1500 }
       }
     };
   }
 
   it("shows hovered plant icon", () => {
     const p = fakeProps();
+    p.designer.hoveredPlant.icon = "fake icon";
     const wrapper = shallow(<HoveredPlantLayer {...p } />);
-    wrapper.setState({ isHovered: true });
-    const icon = wrapper.find("image");
-    expect(icon.props().style).toEqual({ "transform": "scale(1.3, 1.3)" });
+    const icon = wrapper.find("image").props();
+    expect(icon.visibility).toBeTruthy();
+    expect(icon.opacity).toEqual(1);
+    expect(icon.x).toEqual(67.5);
+    expect(icon.width).toEqual(65);
+  });
+
+  it("shows selected plant indicators", () => {
+    const p = fakeProps();
+    p.designer.hoveredPlant.icon = "fake icon";
+    p.currentPlant = fakePlant();
+    const wrapper = shallow(<HoveredPlantLayer {...p } />);
+    expect(wrapper.find("#selected-plant-indicators").length).toEqual(1);
+    expect(wrapper.find("Circle").length).toEqual(1);
+    expect(wrapper.find("Circle").props().selected).toBeTruthy();
+    expect(wrapper.find("SpreadCircle").length).toEqual(1);
+    expect(wrapper.find("SpreadCircle").html())
+      .toContain("cx=\"100\" cy=\"200\" r=\"125\"");
   });
 
   it("doesn't show hovered plant icon", () => {
     const p = fakeProps();
     const wrapper = shallow(<HoveredPlantLayer {...p } />);
-    const icon = wrapper.find("image").props();
-    expect(icon.style).toEqual({ "transform": "scale(1, 1)" });
+    expect(wrapper.html()).toEqual("<g id=\"hovered-plant-layer\"></g>");
   });
 });

--- a/webpack/farm_designer/map/layers/__tests__/plant_layer_test.tsx
+++ b/webpack/farm_designer/map/layers/__tests__/plant_layer_test.tsx
@@ -1,0 +1,45 @@
+import * as React from "react";
+import { PlantLayer } from "../plant_layer";
+import { shallow } from "enzyme";
+import { fakePlant } from "../../../../__test_support__/fake_state/resources";
+import { PlantLayerProps } from "../../interfaces";
+
+describe("<PlantLayer/>", () => {
+  function fakeProps(): PlantLayerProps {
+    return {
+      visible: true,
+      plants: [fakePlant()],
+      mapTransformProps: {
+        quadrant: 2, gridSize: { x: 3000, y: 1500 }
+      },
+      currentPlant: undefined,
+      dragging: false,
+      editing: false,
+      crops: [],
+      dispatch: jest.fn(),
+      zoomLvl: 1,
+      activeDragXY: { x: undefined, y: undefined, z: undefined }
+    };
+  }
+
+  it("shows plants", () => {
+    const p = fakeProps();
+    const wrapper = shallow(<PlantLayer {...p } />);
+    const layer = wrapper.find("#plant-layer");
+    expect(layer.find(".plant-link-wrapper").length).toEqual(1);
+    expect(layer.html()).toContain("soil-cloud");
+    expect(layer.html()).toContain("plant-icon");
+    expect(layer.html()).toContain("image visibility=\"visible\"");
+    expect(layer.html()).toContain("/app-resources/img/generic-plant.svg");
+    expect(layer.html()).toContain("height=\"50\" width=\"50\" x=\"75\" y=\"175\"");
+    expect(layer.html()).toContain("drag-helpers");
+    expect(layer.html()).toContain("plant-icon");
+  });
+
+  it("toggles visibility off", () => {
+    const p = fakeProps();
+    p.visible = false;
+    const wrapper = shallow(<PlantLayer {...p } />);
+    expect(wrapper.html()).toEqual("<g id=\"plant-layer\"></g>");
+  });
+});

--- a/webpack/farm_designer/map/layers/__tests__/spread_layer_test.tsx
+++ b/webpack/farm_designer/map/layers/__tests__/spread_layer_test.tsx
@@ -11,7 +11,12 @@ describe("<SpreadLayer/>", () => {
       currentPlant: undefined,
       mapTransformProps: {
         quadrant: 2, gridSize: { x: 3000, y: 1500 }
-      }
+      },
+      dragging: false,
+      zoomLvl: 1.8,
+      activeDragXY: { x: undefined, y: undefined, z: undefined },
+      activeDragSpread: undefined,
+      editing: false
     };
   }
 

--- a/webpack/farm_designer/map/layers/drag_helper_layer.tsx
+++ b/webpack/farm_designer/map/layers/drag_helper_layer.tsx
@@ -1,0 +1,48 @@
+import * as React from "react";
+import { TaggedPlantPointer } from "../../../resources/tagged_resources";
+import { MapTransformProps, AxisNumberProperty } from "../interfaces";
+import { DragHelpers } from "../drag_helpers";
+import { BotPosition } from "../../../devices/interfaces";
+
+/**
+ * For showing drag helpers for the selected plant.
+ * This layer must be rendered after the hovered plant layer.
+ */
+
+export interface DragHelperLayerProps {
+  currentPlant: TaggedPlantPointer | undefined;
+  mapTransformProps: MapTransformProps;
+  dragging: boolean;
+  editing: boolean;
+  zoomLvl: number;
+  activeDragXY: BotPosition | undefined;
+  plantAreaOffset: AxisNumberProperty;
+}
+
+export class DragHelperLayer extends
+  React.Component<DragHelperLayerProps, {}> {
+
+  get plantInfo() {
+    if (this.props.currentPlant) {
+      const { x, y, radius } = this.props.currentPlant.body;
+      return { x, y, radius };
+    } else {
+      return { x: 0, y: 0, radius: 0 };
+    }
+  }
+  render() {
+    const { dragging, currentPlant, zoomLvl, activeDragXY,
+      mapTransformProps, plantAreaOffset, editing } = this.props;
+
+    return <g id="drag-helper-layer">
+      {currentPlant && editing &&
+        <DragHelpers // for active plants
+          dragging={dragging}
+          plant={currentPlant}
+          mapTransformProps={mapTransformProps}
+          zoomLvl={zoomLvl}
+          activeDragXY={activeDragXY}
+          plantAreaOffset={plantAreaOffset} />}
+    </g>;
+  }
+}

--- a/webpack/farm_designer/map/layers/hovered_plant_layer.tsx
+++ b/webpack/farm_designer/map/layers/hovered_plant_layer.tsx
@@ -2,78 +2,84 @@ import * as React from "react";
 import { TaggedPlantPointer } from "../../../resources/tagged_resources";
 import { DesignerState } from "../../interfaces";
 import { getXYFromQuadrant, round } from "../util";
-import { push } from "../../../history";
 import { MapTransformProps } from "../interfaces";
+import { SpreadCircle } from "./spread_layer";
+import { Circle } from "../circle";
+import * as _ from "lodash";
 
 /**
- * PROBLEM: The plants are rendered via svg in a certain order. When a user
- * hovers over part of a plant they'd like to select that was rendered *prior*
- * to a different plant, it will cause an overlap and a less-than-desirable ux.
- *
- * SOLUTION: Use props to tell this component what plant is currently being
- * hovered over and make a "copy" to display on top of the rest of the layers.
- *
- * NOTE: This layer MUST be rendered LAST in its parent component to properly
- * achieve this effect.
+ * For showing the map plant hovered in the plant panel.
+ * This layer must be rendered after the plant layer
+ * and before the drag helper layer.
  */
 
 export interface HoveredPlantLayerProps {
+  visible: boolean;
   currentPlant: TaggedPlantPointer | undefined;
   designer: DesignerState;
   hoveredPlant: TaggedPlantPointer | undefined;
-  dispatch: Function;
   isEditing: boolean;
   mapTransformProps: MapTransformProps;
+  dragging: boolean;
 }
 
-interface HoveredPlantLayerState { isHovered: boolean; }
-
 export class HoveredPlantLayer extends
-  React.Component<HoveredPlantLayerProps, Partial<HoveredPlantLayerState>> {
-
-  state: HoveredPlantLayerState = { isHovered: false };
-
-  onClick = () => {
-    const plant = this.props.hoveredPlant;
-    if (plant) {
-      push("/app/designer/plants/" + (plant.body.id));
-      const action = { type: "SELECT_PLANT", payload: plant.uuid };
-      this.props.dispatch(action);
-    }
-  }
-
-  toggle = (bool: keyof HoveredPlantLayerState) => () =>
-    this.setState({ isHovered: !this.state.isHovered })
+  React.Component<HoveredPlantLayerProps, {}> {
 
   /** Safe fallbacks if no hovered plant is found. */
   get plantInfo() {
     if (this.props.hoveredPlant) {
-      const { x, y, radius } = this.props.hoveredPlant.body;
-      return { x, y, radius };
+      const { id, x, y, radius } = this.props.hoveredPlant.body;
+      return { id, x, y, radius };
     } else {
-      return { x: 0, y: 0, radius: 1 };
+      return { id: 0, x: 0, y: 0, radius: 1 };
     }
   }
+
   render() {
     const { icon } = this.props.designer.hoveredPlant;
-    const { quadrant, gridSize } = this.props.mapTransformProps;
-    const { x, y } = this.plantInfo;
+    const { currentPlant, mapTransformProps, dragging, isEditing } = this.props;
+    const { quadrant, gridSize } = mapTransformProps;
+    const { id, x, y, radius } = this.plantInfo;
     const { qx, qy } = getXYFromQuadrant(round(x), round(y), quadrant, gridSize);
-    const scaleFactor = (this.state.isHovered) ? "1.3, 1.3" : "1, 1";
+    const hovered = !!this.props.designer.hoveredPlant.icon;
+    const scaledRadius = radius * 1.3;
+    const alpha = dragging ? 0.4 : 1.0;
 
-    return <g id="hovered-plant-icon">
-      <image
-        visibility={this.props.isEditing ? "visible" : "hidden"}
-        style={{ transform: "scale(" + scaleFactor + ")" }}
-        className={"hovered-plant-copy"}
-        x={qx - (this.plantInfo.radius)}
-        y={qy - (this.plantInfo.radius)}
-        onMouseEnter={this.toggle("isHovered")}
-        onMouseLeave={this.toggle("isHovered")}
-        onClick={this.onClick}
-        width={this.plantInfo.radius * 2}
-        height={this.plantInfo.radius * 2}
-        xlinkHref={icon} />
+    return <g id="hovered-plant-layer">
+      {this.props.visible && hovered &&
+        <g id={"hovered-plant-" + id}>
+          {currentPlant &&
+            <g id="selected-plant-indicators">
+              <SpreadCircle
+                plant={currentPlant}
+                key={currentPlant.uuid}
+                mapTransformProps={mapTransformProps}
+                selected={false} />
+
+              <Circle
+                className="plant-indicator"
+                x={qx}
+                y={qy}
+                r={radius}
+                selected={true} />
+            </g>}
+
+          <g id="hovered-plant-icon">
+            <image
+              visibility={hovered ? "visible" : "hidden"}
+              style={isEditing ? {} : { pointerEvents: "none" }}
+              onClick={_.noop}
+              className="hovered-plant-copy"
+              opacity={alpha}
+              x={qx - scaledRadius}
+              y={qy - scaledRadius}
+              width={scaledRadius * 2}
+              height={scaledRadius * 2}
+              xlinkHref={icon} />
+          </g>
+        </g>
+      }
     </g>;
   }
 }

--- a/webpack/farm_designer/map/layers/plant_layer.tsx
+++ b/webpack/farm_designer/map/layers/plant_layer.tsx
@@ -17,8 +17,7 @@ export function PlantLayer(props: PlantLayerProps) {
     currentPlant,
     dragging,
     editing,
-    mapTransformProps,
-    plantAreaOffset
+    mapTransformProps
   } = props;
 
   crops
@@ -45,7 +44,6 @@ export function PlantLayer(props: PlantLayerProps) {
           };
         })
         .map(p => {
-          const action = { type: "SELECT_PLANT", payload: p.uuid };
           return <Link className="plant-link-wrapper"
             style={maybeNoPointer}
             to={"/app/designer/plants/" + p.plantId}
@@ -53,16 +51,14 @@ export function PlantLayer(props: PlantLayerProps) {
             onClick={_.noop}
             key={p.plantId}>
             <GardenPlant
+              uuid={p.uuid}
               mapTransformProps={mapTransformProps}
               plant={p.plant}
               selected={p.selected}
               dragging={p.selected && dragging && editing}
-              onClick={() => dispatch(action)}
-              dispatch={props.dispatch}
+              dispatch={dispatch}
               zoomLvl={props.zoomLvl}
-              activeDragXY={props.activeDragXY}
-              activeDragSpread={props.activeDragSpread}
-              plantAreaOffset={plantAreaOffset} />
+              activeDragXY={props.activeDragXY} />
           </Link>;
         })}
   </g>;

--- a/webpack/farm_designer/map/spread_overlap_helper.tsx
+++ b/webpack/farm_designer/map/spread_overlap_helper.tsx
@@ -67,7 +67,7 @@ export class SpreadOverlapHelper extends
         // should be thought of as a tool checking the inactive plants, not
         // the plant being edited. Dragging a plant with a small spread into
         // the area of a plant with large spread will illustrate this point.
-        return evaluateOverlap(overlap, inactiveSpreadRadius);
+        return evaluateOverlap(overlap, comparisonRadius);
       }
       return { color: Overlap.NONE, value: 0 };
     }
@@ -108,14 +108,20 @@ export class SpreadOverlapHelper extends
     const inactiveSpreadRadius = (this.state.inactiveSpread || (radius * 10)) / 2;
 
     const overlapData = getOverlap(activeDragXY, gardenCoord);
+    // Radius to use to evaluate overlap severity.
+    // For impact of active plant on inactive plants, use `inactiveSpreadRadius`
+    // For impact of inactive plants on active plant, use `activeSpreadRadius`
+    // For worst case, use `Math.min(activeSpreadRadius, inactiveSpreadRadius)`
+    // For lesser case, use `Math.max(activeSpreadRadius, inactiveSpreadRadius)`
+    const comparisonRadius = inactiveSpreadRadius;
     const debug = false; // change to true to show % overlap values
 
     function getColor() {
       // Smoothly vary color based on overlap from dark green > yellow > orange > red
       if (overlapData.value > 0) {
         const normalized = Math.round(
-          Math.max(0, Math.min(inactiveSpreadRadius, overlapData.value))
-          / (inactiveSpreadRadius) * 255 * 2);
+          Math.max(0, Math.min(comparisonRadius, overlapData.value))
+          / (comparisonRadius) * 255 * 2);
         if (normalized < 255) { // green to yellow
           const r = Math.min(normalized, 255);
           const g = Math.min(100 + normalized, 255); // dark instead of bright green
@@ -130,7 +136,7 @@ export class SpreadOverlapHelper extends
       }
     }
 
-    return <g id="overlap-circle">
+    return <g id="overlap-indicator">
       {!dragging && // Non-active plants
         <circle
           className="overlap-circle"

--- a/webpack/farm_designer/plants/__tests__/plant_info_test.tsx
+++ b/webpack/farm_designer/plants/__tests__/plant_info_test.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+import { PlantInfo } from "../plant_info";
+import { mount } from "enzyme";
+import { fakePlant } from "../../../__test_support__/fake_state/resources";
+import { createStore } from "redux";
+import { reducers } from "../../../redux/root_reducer";
+
+describe("<PlantInfo />", () => {
+  it("redirects", () => {
+    const dispatch = jest.fn();
+    const wrapper = mount(
+      <PlantInfo
+        push={jest.fn()}
+        dispatch={() => dispatch}
+        findPlant={fakePlant} />,
+      { context: { store: createStore(reducers) } });
+    expect(wrapper.text()).toEqual("Redirecting...");
+  });
+});

--- a/webpack/farm_designer/plants/__tests__/plant_inventory_item_test.tsx
+++ b/webpack/farm_designer/plants/__tests__/plant_inventory_item_test.tsx
@@ -1,0 +1,46 @@
+import * as React from "react";
+import { PlantInventoryItem } from "../plant_inventory_item";
+import { shallow } from "enzyme";
+import { fakePlant } from "../../../__test_support__/fake_state/resources";
+
+describe("<PlantInventoryItem />", () => {
+  it("renders", () => {
+    const wrapper = shallow(
+      <PlantInventoryItem
+        tpp={fakePlant()}
+        dispatch={jest.fn()} />);
+    expect(wrapper.text()).toEqual("Strawberry Plant 11 days old");
+  });
+
+  it("hover begin", () => {
+    const dispatch = jest.fn();
+    const wrapper = shallow(
+      <PlantInventoryItem
+        tpp={fakePlant()}
+        dispatch={dispatch} />);
+    wrapper.simulate("mouseEnter");
+    expect(dispatch).toBeCalledWith({
+      payload: {
+        icon: "",
+        plantUUID: "points.1.16"
+      },
+      type: "TOGGLE_HOVERED_PLANT"
+    });
+  });
+
+  it("hover end", () => {
+    const dispatch = jest.fn();
+    const wrapper = shallow(
+      <PlantInventoryItem
+        tpp={fakePlant()}
+        dispatch={dispatch} />);
+    wrapper.simulate("mouseLeave");
+    expect(dispatch).toBeCalledWith({
+      payload: {
+        icon: undefined,
+        plantUUID: undefined
+      },
+      type: "TOGGLE_HOVERED_PLANT"
+    });
+  });
+});

--- a/webpack/farm_designer/plants/__tests__/plant_inventory_test.tsx
+++ b/webpack/farm_designer/plants/__tests__/plant_inventory_test.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+import { Plants } from "../plant_inventory";
+import { mount } from "enzyme";
+import { fakePlant } from "../../../__test_support__/fake_state/resources";
+import { createStore } from "redux";
+import { reducers } from "../../../redux/root_reducer";
+
+describe("<PlantInventory />", () => {
+  it("renders", () => {
+    const wrapper = mount(
+      <Plants
+        plants={[fakePlant()]}
+        dispatch={jest.fn()} />,
+      { context: { store: createStore(reducers) } });
+    expect(wrapper.text()).toEqual("DesignerPlantsFarm Events");
+    expect(wrapper.find("input").props().placeholder)
+      .toEqual("Search your plants...");
+  });
+});

--- a/webpack/farm_designer/plants/plant_info.tsx
+++ b/webpack/farm_designer/plants/plant_info.tsx
@@ -11,7 +11,14 @@ import { PlantPanel } from "./plant_panel";
 export class PlantInfo extends PlantInfoBase {
 
   default = (plant_info: TaggedPlantPointer) => {
-    const action = { type: "SELECT_PLANT", payload: undefined };
+    const click = () => {
+      this.props.dispatch({ type: "SELECT_PLANT", payload: undefined });
+      this.props.dispatch({
+        type: "TOGGLE_HOVERED_PLANT", payload: {
+          plantUUID: undefined, icon: undefined
+        }
+      });
+    };
     const info = formatPlantInfo(plant_info);
     const { name, id } = info;
     return <div className="panel-container green-panel" >
@@ -20,7 +27,7 @@ export class PlantInfo extends PlantInfoBase {
           <Link to="/app/designer/plants" className="back-arrow">
             <i
               className="fa fa-arrow-left"
-              onClick={() => this.props.dispatch(action)} />
+              onClick={click} />
           </Link>
           <span className="title">
             {name}

--- a/webpack/farm_designer/plants/plant_inventory_item.tsx
+++ b/webpack/farm_designer/plants/plant_inventory_item.tsx
@@ -27,9 +27,24 @@ export class PlantInventoryItem extends
     const { tpp, dispatch } = this.props;
     const plantId = (plant.id || "ERR_NO_PLANT_ID").toString();
 
-    const toggle = () => {
-      const { icon } = this.state;
-      dispatch({ type: "TOGGLE_HOVERED_PLANT", payload: { plant: tpp, icon } });
+    const toggle = (action: "enter" | "leave") => {
+      switch (action) {
+        case "enter":
+          const { icon } = this.state;
+          dispatch({
+            type: "TOGGLE_HOVERED_PLANT", payload: {
+              plantUUID: tpp.uuid, icon
+            }
+          });
+          break;
+        case "leave":
+          dispatch({
+            type: "TOGGLE_HOVERED_PLANT", payload: {
+              plantUUID: undefined, icon: undefined
+            }
+          });
+          break;
+      }
     };
 
     const click = () => {
@@ -60,8 +75,8 @@ export class PlantInventoryItem extends
     return <div
       className="plant-search-item"
       key={plantId}
-      onMouseEnter={toggle}
-      onMouseLeave={toggle}
+      onMouseEnter={() => toggle("enter")}
+      onMouseLeave={() => toggle("leave")}
       onClick={click}>
       <img
         className="plant-search-item-image"


### PR DESCRIPTION
**Farm Designer Map:**
* Reduce undesired movement and plant creation bugs.
* Show the current plant icon and indicators on top of other plants.
* Restore map plant icon size increase on list plant hover.
* Fix double spread display bug.
* Move spread overlap indicators behind plant layer.