### PR TITLE
Get rid of Figaro warning.

### DIFF
--- a/config/application.example.yml
+++ b/config/application.example.yml
@@ -68,8 +68,8 @@ SENDGRID_USERNAME: "Used by FarmBot, Inc"
 # For email delivery. Who is your email host?
 SMTP_HOST: "smtp.sendgrid.net"
 # Optional with default of 587
-SMTP_PORT: 587
+SMTP_PORT: "587"
 # Set this if you don't want to deal with email verification of new users.
 # (self hosted users)
-NO_EMAILS: TRUE
+NO_EMAILS: "TRUE"
 


### PR DESCRIPTION
WARNING: Use strings for Figaro configuration. 587 was converted to "587".
WARNING: Use strings for Figaro configuration. true was converted to "true".