### PR TITLE
Fix email change bug

### DIFF
--- a/app/lib/abstract_jwt_token.rb
+++ b/app/lib/abstract_jwt_token.rb
@@ -1,8 +1,8 @@
 class AbstractJwtToken
 
-  PRIVATE_KEY  = KeyGen.current
-  PUBLIC_KEY   = KeyGen.current.public_key
-  ALG          = 'RS256'
+  PRIVATE_KEY = KeyGen.current
+  PUBLIC_KEY  = KeyGen.current.public_key
+  ALG         = 'RS256'
 
   attr_accessor :encoded, :unencoded
 

--- a/app/lib/session_token.rb
+++ b/app/lib/session_token.rb
@@ -22,7 +22,7 @@ class SessionToken < AbstractJwtToken
     end
 
     self.new([{
-             sub:  user.email,
+             sub:  user.id,
              iat:  iat,
              jti:  SecureRandom.uuid, # Used for revokation if need be.
              iss:  iss,

--- a/app/lib/session_token.rb
+++ b/app/lib/session_token.rb
@@ -29,7 +29,6 @@ class SessionToken < AbstractJwtToken
              exp:  exp,
              mqtt: MQTT,
              os_update_server: OS_RELEASE,
-             fw_update_server: FW_RELEASE,
              bot:  "device_#{user.device.id}"}])
   end
 

--- a/app/lib/session_token.rb
+++ b/app/lib/session_token.rb
@@ -1,14 +1,14 @@
 # Generates a JSON Web Token (JWT) for a given user. Typically placed in the
 # `Authorization` header, or used a password to gain access to the MQTT server.
 class SessionToken < AbstractJwtToken
-  MUST_VERIFY = 'Verify account first'
+  MUST_VERIFY = "Verify account first"
   DEFAULT_OS = "https://api.github.com/repos/" \
                "farmbot/farmbot_os/releases/latest"
   DEFAULT_FW = "https://api.github.com/repos/FarmBot/farmbot-arduino-firmware/"\
                "releases/latest"
-  OS_RELEASE   = ENV.fetch('OS_UPDATE_SERVER') { DEFAULT_OS }
-  FW_RELEASE   = ENV.fetch('FW_UPDATE_SERVER') { DEFAULT_FW }
-  MQTT         = ENV.fetch('MQTT_HOST')
+  OS_RELEASE   = ENV.fetch("OS_UPDATE_SERVER") { DEFAULT_OS }
+  FW_RELEASE   = ENV.fetch("FW_UPDATE_SERVER") { DEFAULT_FW }
+  MQTT         = ENV.fetch("MQTT_HOST")
   EXPIRY       = 40.days
 
   def self.issue_to(user,

--- a/app/mutations/auth/from_jwt.rb
+++ b/app/mutations/auth/from_jwt.rb
@@ -9,17 +9,17 @@ module Auth
       claims = token.unencoded
       sub    = claims['sub']
       case sub
-        when Integer then User.find(sub)
-        # HISTORICAL CONTEXT: We once used emails as a `sub` field. At the time,
-        # it seemed nice because it was human readable. The problem was that
-        # emails are mutable. Under this scheme, changing your email address
-        # would invalidate your JWT. Switching it to user_id (that does not
-        # change) gets around this issue. We still need to support emails in
-        # JWTs, atleast for another month or so because it would invalidate
-        # existing tokens otherwise.
-        # TODO: Only use user_id (not email) for validation after 25 OCT 17 - RC
-        when String then User.find_by!(email: sub)
-        else raise "SUB was neither string nor number"
+      when Integer then User.find(sub)
+      # HISTORICAL CONTEXT: We once used emails as a `sub` field. At the time,
+      # it seemed nice because it was human readable. The problem was that
+      # emails are mutable. Under this scheme, changing your email address
+      # would invalidate your JWT. Switching it to user_id (that does not
+      # change) gets around this issue. We still need to support emails in
+      # JWTs, atleast for another month or so because it would invalidate
+      # existing tokens otherwise.
+      # TODO: Only use user_id (not email) for validation after 25 OCT 17 - RC
+      when String then User.find_by!(email: sub)
+      else raise "SUB was neither string nor number"
       end
     rescue JWT::DecodeError
       add_error :jwt, :decode_error, "JSON Web Token is not valid."

--- a/app/mutations/auth/from_jwt.rb
+++ b/app/mutations/auth/from_jwt.rb
@@ -7,7 +7,7 @@ module Auth
     def execute
       token  = SessionToken.decode!(just_the_token)
       claims = token.unencoded
-      sub    = claims['sub']
+      sub    = claims["sub"]
       case sub
       when Integer then User.find(sub)
       # HISTORICAL CONTEXT: We once used emails as a `sub` field. At the time,

--- a/app/mutations/auth/from_jwt.rb
+++ b/app/mutations/auth/from_jwt.rb
@@ -7,8 +7,20 @@ module Auth
     def execute
       token  = SessionToken.decode!(just_the_token)
       claims = token.unencoded
-      email  = claims['sub']
-      User.find_by!(email: email)
+      sub    = claims['sub']
+      case sub
+        when Integer then User.find(sub)
+        # HISTORICAL CONTEXT: We once used emails as a `sub` field. At the time,
+        # it seemed nice because it was human readable. The problem was that
+        # emails are mutable. Under this scheme, changing your email address
+        # would invalidate your JWT. Switching it to user_id (that does not
+        # change) gets around this issue. We still need to support emails in
+        # JWTs, atleast for another month or so because it would invalidate
+        # existing tokens otherwise.
+        # TODO: Only use user_id (not email) for validation after 25 OCT 17 - RC
+        when String then User.find_by!(email: sub)
+        else raise "SUB was neither string nor number"
+      end
     rescue JWT::DecodeError
       add_error :jwt, :decode_error, "JSON Web Token is not valid."
     end

--- a/spec/mutations/auth/from_jwt_spec.rb
+++ b/spec/mutations/auth/from_jwt_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe Auth::FromJWT do
   let(:user)  { FactoryGirl.create(:user) }
   let(:token) { SessionToken.issue_to(user).encoded }
-  fake = lambda (sub) {
+  fake = -> (sub) {
     AbstractJwtToken.new([{ sub:              sub,
                             iat:              Time.now.to_i,
                             jti:              SecureRandom.uuid,

--- a/spec/mutations/auth/from_jwt_spec.rb
+++ b/spec/mutations/auth/from_jwt_spec.rb
@@ -1,33 +1,33 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Auth::FromJWT do
   let(:user)  { FactoryGirl.create(:user) }
   let(:token) { SessionToken.issue_to(user).encoded }
-  fake = ->(sub) {
-    AbstractJwtToken.new([{ sub:  sub,
-    iat:  Time.now.to_i,
-    # Used for revokation if need be.
-    jti:  SecureRandom.uuid,
-    iss:  $API_URL,
-    exp:  40.days.from_now.to_i,
-    mqtt: "//foo.bar",
-    os_update_server: "/foo.bar/baz.json",
-    bot:  "device_123"}]).encoded
+  fake = lambda (sub) {
+    AbstractJwtToken.new([{ sub:              sub,
+                            iat:              Time.now.to_i,
+                            jti:              SecureRandom.uuid,
+                            iss:              $API_URL,
+                            exp:              40.days.from_now.to_i,
+                            mqtt:             "//foo.bar",
+                            os_update_server: "/foo.bar/baz.json",
+                            bot:              "device_123" }]).encoded
   }
-  it 'gets user from jwt' do
-    result = Auth::FromJWT.run!( jwt: token )
+
+  it "gets user from jwt" do
+    result = Auth::FromJWT.run!(jwt: token)
     expect(result).to eq(user)
   end
 
-  it 'allows emails as a `sub` field, but only until 25 OCT 17' do
+  it "allows emails as a `sub` field, but only until 25 OCT 17" do
     t = fake[user.email]
-    result = Auth::FromJWT.run!( jwt: t )
+    result = Auth::FromJWT.run!(jwt: t)
     expect(result).to eq(user)
   end
 
-  it 'crashes when sub is neither string nor Integer' do
+  it "crashes when sub is neither string nor Integer" do
     t       = fake[1.23]
     bad_sub = "SUB was neither string nor number"
-    expect { Auth::FromJWT.run!( jwt: t ) }.to raise_error(bad_sub)
+    expect { Auth::FromJWT.run!(jwt: t) }.to raise_error(bad_sub)
   end
 end

--- a/spec/mutations/auth/from_jwt_spec.rb
+++ b/spec/mutations/auth/from_jwt_spec.rb
@@ -1,11 +1,33 @@
 require 'spec_helper'
 
 describe Auth::FromJWT do
-    let(:user)  { FactoryGirl.create(:user) }
-    let(:token) { SessionToken.issue_to(user).encoded } 
-
+  let(:user)  { FactoryGirl.create(:user) }
+  let(:token) { SessionToken.issue_to(user).encoded }
+  fake = ->(sub) {
+    AbstractJwtToken.new([{ sub:  sub,
+    iat:  Time.now.to_i,
+    # Used for revokation if need be.
+    jti:  SecureRandom.uuid,
+    iss:  $API_URL,
+    exp:  40.days.from_now.to_i,
+    mqtt: "//foo.bar",
+    os_update_server: "/foo.bar/baz.json",
+    bot:  "device_123"}]).encoded
+  }
   it 'gets user from jwt' do
     result = Auth::FromJWT.run!( jwt: token )
     expect(result).to eq(user)
+  end
+
+  it 'allows emails as a `sub` field, but only until 25 OCT 17' do
+    t = fake[user.email]
+    result = Auth::FromJWT.run!( jwt: t )
+    expect(result).to eq(user)
+  end
+
+  it 'crashes when sub is neither string nor Integer' do
+    t       = fake[1.23]
+    bad_sub = "SUB was neither string nor number"
+    expect { Auth::FromJWT.run!( jwt: t ) }.to raise_error(bad_sub)
   end
 end

--- a/webpack/__test_support__/fake_state/token.ts
+++ b/webpack/__test_support__/fake_state/token.ts
@@ -11,8 +11,7 @@ export let auth: Everything["auth"] = {
       "os_update_server": "https://api.github.com/repos/farmbot/" +
       "farmbot_os/releases/latest",
       "fw_update_server": "https://api.github.com/repos/FarmBot/" +
-      "farmbot-arduino-firmware/releases/latest",
-      "bot": "device_403"
+      "farmbot-arduino-firmware/releases/latest"
     },
     "encoded": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJhZG1pbk" +
     "BhZG1pbi5jb20iLCJpYXQiOjE0OTU1NjkwODQsImp0aSI6ImIzODkxNWNhLTNkN2Et" +

--- a/webpack/auth/interfaces.ts
+++ b/webpack/auth/interfaces.ts
@@ -8,8 +8,6 @@ export interface AuthState {
 }
 
 export interface UnencodedToken {
-  // /** SUBJECT - The user's email. STOP USING THIS! */
-  // sub: string;
   /** ISSUED AT */
   iat: number;
   /** JSON TOKEN IDENTIFIER - a serial number for the token. */
@@ -20,8 +18,6 @@ export interface UnencodedToken {
   exp: number;
   /** MQTT server address */
   mqtt: string;
-  /** BOT UNIQUE IDENTIFIER */
-  bot: string;
   /** Where to download RPi software */
   os_update_server: string;
   /** Where to download firmware. */


### PR DESCRIPTION
# Problem
 * Changing your email address in the app would cause a crash

# Solution
 * Use `user.id` instead of `user.email` in the JWT `sub` claim.
 * Implement a workaround for folks who are using old style tokens (to be removed in 30 days)

# Other Things
 * Got rid of the `fw_update_server` claim. We haven't used that in months.

# Next Steps
 * Run email verification on email updates