### PR TITLE
Unremove `fw_update_server`

### DIFF
--- a/app/lib/session_token.rb
+++ b/app/lib/session_token.rb
@@ -29,6 +29,7 @@ class SessionToken < AbstractJwtToken
              exp:  exp,
              mqtt: MQTT,
              os_update_server: OS_RELEASE,
+             fw_update_server: "DEPRECATED",
              bot:  "device_#{user.device.id}"}])
   end
 


### PR DESCRIPTION
# Why?

 * It crashes older versions of FBOS. Need to wait for a major release.
