### PR TITLE
Edge Case Bug Fix

### DIFF
--- a/app/controllers/api/tokens_controller.rb
+++ b/app/controllers/api/tokens_controller.rb
@@ -12,9 +12,7 @@ module Api
         mutate klass
           .run(auth_params)
           .tap { |result| maybe_halt_login(result) }
-          .tap do |result|
-            mark_as_seen(result.result[:user].device) if result.result
-          end
+          .tap { |result| mark_as_seen(result.result[:user].device) if result.result }
       end
     end
 

--- a/app/controllers/api/tokens_controller.rb
+++ b/app/controllers/api/tokens_controller.rb
@@ -12,7 +12,9 @@ module Api
         mutate klass
           .run(auth_params)
           .tap { |result| maybe_halt_login(result) }
-          .tap { |result| mark_as_seen(result.result[:user].device) }
+          .tap do |result|
+            mark_as_seen(result.result[:user].device) if result.result
+          end
       end
     end
 

--- a/app/lib/abstract_jwt_token.rb
+++ b/app/lib/abstract_jwt_token.rb
@@ -8,7 +8,7 @@ class AbstractJwtToken
 
   def initialize(payload)
     @unencoded = payload[0]
-    @encoded   = JWT.encode(payload[0], PRIVATE_KEY, ALG)
+    @encoded   = JWT.encode(payload[0], PRIVATE_KEY, ALG, {typ: "JWT"})
   end
 
   def self.decode!(token)


### PR DESCRIPTION
# Situation

 * In [this pull request](https://github.com/FarmBot/Farmbot-Web-App/pull/466) I added the ability to mark devices as seen when running configurator.

# Problem

 * The code assumes that all requests will succeed.
 * A `noMethodError` is raised when `Auth::CreateToken` fails.

# Solution

 * Make sure `.result` is present.