### PR TITLE
Eager load pointer_type when loading points

### DIFF
--- a/app/controllers/api/points_controller.rb
+++ b/app/controllers/api/points_controller.rb
@@ -58,7 +58,7 @@ module Api
     end
 
     def points
-      Point.where(device_params)
+      Point.includes(:pointer).where(device_params)
     end
 
     def device_params

--- a/app/mutations/points/query.rb
+++ b/app/mutations/points/query.rb
@@ -36,7 +36,7 @@ module Points
         if @points
           @points
         else
-          @points = Point.where(inputs.slice(*WHITELIST))
+          @points = Point.includes(:pointer).where(inputs.slice(*WHITELIST))
           add_meta_fields if meta
           @points
         end

--- a/app/serializers/point_serializer.rb
+++ b/app/serializers/point_serializer.rb
@@ -16,14 +16,6 @@ class PointSerializer < ActiveModel::Serializer
     object.z.round
   end
 
-  def plant?
-    object.pointer.is_a? Plant
-  end
-
-  def tool_slot?
-    object.pointer.is_a? ToolSlot
-  end
-
   def openfarm_slug
     object.pointer.openfarm_slug
   end
@@ -34,5 +26,13 @@ class PointSerializer < ActiveModel::Serializer
 
   def meta
     object.meta || {}
+  end
+
+  def plant?
+    object.pointer.is_a? Plant
+  end
+
+  def tool_slot?
+    object.pointer.is_a? ToolSlot
   end
 end


### PR DESCRIPTION
# What's New?

 * Fix performance issues when hitting the `points#index` endpoint.

# Why?

 * `PointSerializer` was doing a database request for each point serialized. That meant that downloading 200 points created a minimum of `200 + 1` database queries.

# What Changed?

 * Eager load `pointer`.

# What's Next?

 * Keep an eye on performance metrics.