### PR TITLE
Delete Images Asyncronously

### DIFF
--- a/app/controllers/api/images_controller.rb
+++ b/app/controllers/api/images_controller.rb
@@ -22,7 +22,8 @@ module Api
     end
 
     def destroy
-      render json: image.destroy! && ""
+      image.delay.destroy!
+      render json: ""
     end
 
     # Creates a "policy object" + meta data so that users may upload an image to
@@ -76,7 +77,7 @@ module Api
     end
 
     def image
-      Image.where(device: current_device).find(params[:id])
+      @image ||= Image.where(device: current_device).find(params[:id])
     end
   end
 end

--- a/spec/controllers/api/images/images_spec.rb
+++ b/spec/controllers/api/images/images_spec.rb
@@ -55,7 +55,9 @@ describe Api::ImagesController do
         sign_in user
         image = FactoryGirl.create(:image, device: user.device)
         before_count = Image.count
-        delete :destroy, params: { id: image.id }
+        run_jobs_now do
+          delete :destroy, params: { id: image.id }
+        end
         expect(response.status).to eq(200)
         expect(Image.count).to be < before_count
       end

--- a/spec/controllers/api/logs/logs_spec.rb
+++ b/spec/controllers/api/logs/logs_spec.rb
@@ -136,10 +136,12 @@ describe Api::LogsController do
       empty_mail_bag
       Log.destroy_all
       LogDispatch.destroy_all
-      post :create,
-           body: JSON_EXAMPLE,
-           params: {format: :json}
-      expect(last_email).to eq(nil)
+      run_jobs_now do
+        post :create,
+             body: JSON_EXAMPLE,
+             params: {format: :json}
+        expect(last_email).to eq(nil)
+      end
     end
   end
 end

--- a/spec/controllers/api/password_resets/password_resets_spec.rb
+++ b/spec/controllers/api/password_resets/password_resets_spec.rb
@@ -9,11 +9,13 @@ describe Api::PasswordResetsController do
       params = { email: user.email }
 
       old_email_count = ActionMailer::Base.deliveries.length
-      post :create, params: params
-      expect(response.status).to eq(200)
-      expect(ActionMailer::Base.deliveries.length).to be > old_email_count
-      message = last_email.to_s
-      expect(message).to include("password reset")
+      run_jobs_now do
+        post :create, params: params
+        expect(response.status).to eq(200)
+        expect(ActionMailer::Base.deliveries.length).to be > old_email_count
+        message = last_email.to_s
+        expect(message).to include("password reset")
+      end
     end
 
     it 'resets password using a reset token' do

--- a/spec/controllers/api/users/users_controller_spec.rb
+++ b/spec/controllers/api/users/users_controller_spec.rb
@@ -1,5 +1,14 @@
 require 'spec_helper'
 
+BIG_WARNING = <<~HEREDOC
+  MAYBE A WARNING:
+  YOU HAVE CHOSEN TO SKIP TESTS FOR USER VERIFICATION.
+  If you are a self hosted user that does not want email functionality,
+  you can ignore this message.
+  If you *do* want to use email in your farmbot setup, consider this a
+  failure.
+HEREDOC
+
 describe Api::UsersController do
   let(:user) { FactoryGirl.create(:user) }
   include Devise::Test::ControllerHelpers
@@ -84,30 +93,21 @@ describe Api::UsersController do
                   email:                 email,
                   name:                  "Frank" }
       old_email_count = ActionMailer::Base.deliveries.length
-      post :create, params: params
-      user = User.last
-      if User::SKIP_EMAIL_VALIDATION
-        puts <<~HEREDOC
-
-          MAYBE A WARNING:
-          YOU HAVE CHOSEN TO SKIP TESTS FOR USER VERIFICATION.
-
-          If you are a self hosted user that does not want email functionality,
-          you can ignore this message.
-
-          If you *do* want to use email in your farmbot setup, consider this a
-          failure.
-
-        HEREDOC
-      else
-        expect(ActionMailer::Base.deliveries.length).to be > old_email_count
-        msg = ActionMailer::Base.deliveries.last
-        expect(msg.to.first).to eq(email)
-        expect(msg.body.parts.first.to_s).to include(user.verification_token)
-        expect(User.count).to eq(original_count + 1)
-        expect(user.name).to eq("Frank")
-        expect(user.email).to eq(email)
-        expect(user.valid_password?('Password123')).to be_truthy
+      run_jobs_now do
+        post :create, params: params
+        user = User.last
+        if User::SKIP_EMAIL_VALIDATION
+          puts BIG_WARNING
+        else
+          expect(ActionMailer::Base.deliveries.length).to be > old_email_count
+          msg = ActionMailer::Base.deliveries.last
+          expect(msg.to.first).to eq(email)
+          expect(msg.body.parts.first.to_s).to include(user.verification_token)
+          expect(User.count).to eq(original_count + 1)
+          expect(user.name).to eq("Frank")
+          expect(user.email).to eq(email)
+          expect(user.valid_password?('Password123')).to be_truthy
+        end
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,7 +34,7 @@ DatabaseCleaner.clean
 
 RSpec.configure do |config|
   config.color = true
-  config.fail_fast = 1
+  config.fail_fast = 10
   config.backtrace_exclusion_patterns = [/gems/]
 
   config.include Helpers
@@ -50,6 +50,13 @@ RSpec.configure do |config|
       SmarfDoc.finish!
     end
   end
+end
+
+def run_jobs_now
+  delay_jobs = Delayed::Worker.delay_jobs
+  Delayed::Worker.delay_jobs = false
+  yield
+  Delayed::Worker.delay_jobs = delay_jobs
 end
 
 # Reassign constants without getting a bunch of warnings to STDOUT.


### PR DESCRIPTION
# Why?

 * When deleting an image, 4 HTTP requests are made to AWS to destroy hosted images.
 * This is slow

# What Changed?

 * Move image deletion into a background worker.