### PR TITLE
Fixes and Version Bumps

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "deep-freeze": "^0.0.1",
     "enzyme": "^2.9.1",
     "extract-text-webpack-plugin": "^3.0.0",
-    "farmbot": "5.0.1-rc10",
+    "farmbot": "5.0.1-rc11",
     "farmbot-toastr": "^1.0.3",
     "fastclick": "^1.0.6",
     "file-loader": "^0.11.2",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "deep-freeze": "^0.0.1",
     "enzyme": "^2.9.1",
     "extract-text-webpack-plugin": "^3.0.0",
-    "farmbot": "5.0.1-rc9",
+    "farmbot": "5.0.1-rc10",
     "farmbot-toastr": "^1.0.3",
     "fastclick": "^1.0.6",
     "file-loader": "^0.11.2",

--- a/webpack/__tests__/controls_popup_test.tsx
+++ b/webpack/__tests__/controls_popup_test.tsx
@@ -1,9 +1,9 @@
+const mockDevice = {
+  moveRelative: jest.fn(() => { return Promise.resolve(); }),
+};
+
 jest.mock("../device", () => ({
-  devices: {
-    current: {
-      moveRelative: jest.fn(() => { return Promise.resolve(); }),
-    }
-  }
+  getDevice: () => (mockDevice)
 }));
 
 import * as React from "react";

--- a/webpack/__tests__/controls_popup_test.tsx
+++ b/webpack/__tests__/controls_popup_test.tsx
@@ -9,7 +9,7 @@ jest.mock("../device", () => ({
 import * as React from "react";
 import { ControlsPopup } from "../controls_popup";
 import { mount } from "enzyme";
-import { devices } from "../device";
+import { getDevice } from "../device";
 
 describe("<ControlsPopup />", () => {
   beforeEach(function () {
@@ -31,7 +31,7 @@ describe("<ControlsPopup />", () => {
   });
 
   it("x axis is inverted", () => {
-    const { mock } = devices.current.moveRelative as jest.Mock<{}>;
+    const { mock } = getDevice().moveRelative as jest.Mock<{}>;
     const button = wrapper.find("button").first();
     expect(button.props().title).toBe("move x axis");
     button.simulate("click");
@@ -42,7 +42,7 @@ describe("<ControlsPopup />", () => {
   });
 
   it("y axis is not inverted", () => {
-    const { mock } = devices.current.moveRelative as jest.Mock<{}>;
+    const { mock } = getDevice().moveRelative as jest.Mock<{}>;
     const button = wrapper.find("button").at(2);
     expect(button.props().title).toBe("move y axis");
     button.simulate("click");
@@ -53,7 +53,7 @@ describe("<ControlsPopup />", () => {
   });
 
   it("disabled when closed", () => {
-    const { mock } = devices.current.moveRelative as jest.Mock<{}>;
+    const { mock } = getDevice().moveRelative as jest.Mock<{}>;
     wrapper.setState({ isOpen: false });
     [0, 1, 2, 3].map((i) => wrapper.find("button").at(i).simulate("click"));
     expect(mock.calls.length).toBe(0);

--- a/webpack/auth/actions.ts
+++ b/webpack/auth/actions.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { t } from "i18next";
 import { error, success } from "farmbot-toastr";
-import { connectDevice, fetchReleases } from "../devices/actions";
+import { fetchReleases } from "../devices/actions";
 import { push } from "../history";
 import { AuthState } from "./interfaces";
 import { ReduxAction, Thunk } from "../redux/interfaces";
@@ -16,6 +16,7 @@ import {
   requestFulfilled
 } from "../interceptors";
 import { Actions } from "../constants";
+import { connectDevice } from "../connectivity/connect_device";
 
 export function didLogin(authState: AuthState, dispatch: Function) {
   API.setBaseUrl(authState.token.unencoded.iss);
@@ -81,13 +82,7 @@ export function register(name: string,
 
 /** Handle user registration errors. */
 export function onRegistrationErr(dispatch: Function) {
-  return (err: UnsafeError) => {
-    toastErrors(err);
-    dispatch({
-      type: "REGISTRATION_ERROR",
-      payload: err
-    });
-  };
+  return (err: UnsafeError) => toastErrors(err);
 }
 
 /** Build a JSON object in preparation for an HTTP POST
@@ -129,7 +124,7 @@ export function logout() {
   Session.clear();
   // Technically this is unreachable code:
   return {
-    type: "LOGOUT",
+    type: Actions.LOGOUT,
     payload: {}
   };
 }

--- a/webpack/connectivity/__tests__/connect_device.ts/index_test.ts
+++ b/webpack/connectivity/__tests__/connect_device.ts/index_test.ts
@@ -1,0 +1,34 @@
+import { HardwareState } from "../../../devices/interfaces";
+import { incomingStatus, ifToastWorthy } from "../../connect_device";
+import { Actions } from "../../../constants";
+import { Log } from "../../../interfaces";
+import { ALLOWED_CHANNEL_NAMES, ALLOWED_MESSAGE_TYPES } from "farmbot";
+
+describe("incomingStatus", () => {
+  it("creates an action", () => {
+    const stub = {} as HardwareState;
+    const result = incomingStatus(stub);
+    expect(result.type).toEqual(Actions.BOT_CHANGE);
+    expect(result.payload).toEqual(stub);
+  });
+});
+
+describe("ifToast", () => {
+  function log(meta_type: ALLOWED_MESSAGE_TYPES,
+    chan: ALLOWED_CHANNEL_NAMES = "toast"): Log {
+    return {
+      message: "toasty!",
+      meta: { type: meta_type },
+      channels: [chan],
+      created_at: -1
+    };
+  }
+
+  it("skips irrelevant channels like `email`", () => {
+    const callback = jest.fn();
+    ifToastWorthy(log("success", "email"), callback);
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("does not toast others");
+});

--- a/webpack/connectivity/__tests__/connect_device/index_test.ts
+++ b/webpack/connectivity/__tests__/connect_device/index_test.ts
@@ -10,7 +10,7 @@ import { incomingStatus, ifToastWorthy, showLogOnScreen, TITLE } from "../../con
 import { Actions } from "../../../constants";
 import { Log } from "../../../interfaces";
 import { ALLOWED_CHANNEL_NAMES, ALLOWED_MESSAGE_TYPES } from "farmbot";
-import { success, error, info, warning } from "farmbot-toastr";
+import { success, error, info } from "farmbot-toastr";
 
 describe("incomingStatus", () => {
   it("creates an action", () => {

--- a/webpack/connectivity/__tests__/connect_device/index_test.ts
+++ b/webpack/connectivity/__tests__/connect_device/index_test.ts
@@ -1,8 +1,16 @@
+jest.mock("farmbot-toastr", () => ({
+  success: jest.fn(),
+  error: jest.fn(),
+  info: jest.fn(),
+  warning: jest.fn()
+}));
+
 import { HardwareState } from "../../../devices/interfaces";
-import { incomingStatus, ifToastWorthy } from "../../connect_device";
+import { incomingStatus, ifToastWorthy, showLogOnScreen, TITLE } from "../../connect_device";
 import { Actions } from "../../../constants";
 import { Log } from "../../../interfaces";
 import { ALLOWED_CHANNEL_NAMES, ALLOWED_MESSAGE_TYPES } from "farmbot";
+import { success, error, info, warning } from "farmbot-toastr";
 
 describe("incomingStatus", () => {
   it("creates an action", () => {
@@ -13,27 +21,51 @@ describe("incomingStatus", () => {
   });
 });
 
-describe("ifToast", () => {
-  function log(meta_type: ALLOWED_MESSAGE_TYPES,
-    channels: ALLOWED_CHANNEL_NAMES[] = ["toast"]): Log {
-    return {
-      message: "toasty!",
-      meta: { type: meta_type },
-      channels,
-      created_at: -1
-    };
-  }
+function fakeLog(meta_type: ALLOWED_MESSAGE_TYPES,
+  channels: ALLOWED_CHANNEL_NAMES[] = ["toast"]): Log {
+  return {
+    message: "toasty!",
+    meta: { type: meta_type },
+    channels,
+    created_at: -1
+  };
+}
 
+describe("ifToast", () => {
   it("skips irrelevant channels like `email`", () => {
     const callback = jest.fn();
-    ifToastWorthy(log("success", ["email"]), callback);
+    ifToastWorthy(fakeLog("success", ["email"]), callback);
     expect(callback).not.toHaveBeenCalled();
   });
 
   it("executes callback only for `toast` types", () => {
     const callback = jest.fn();
-    const fakeToast = log("success", ["toast", "email"]);
+    const fakeToast = fakeLog("success", ["toast", "email"]);
     ifToastWorthy(fakeToast, callback);
     expect(callback).toHaveBeenCalledWith(fakeToast);
+  });
+});
+
+describe("showLogOnScreen", () => {
+
+  function assertToastr(types: ALLOWED_MESSAGE_TYPES[], toastr: Function) {
+    jest.resetAllMocks();
+    types.map((x) => {
+      const fun = fakeLog(x, ["toast"]);
+      showLogOnScreen(fun);
+      expect(toastr).toHaveBeenCalledWith(fun.message, TITLE);
+    });
+  }
+
+  it("routes `fun`, `info` and all others to toastr.info()", () => {
+    assertToastr(["fun", "info", ("FOO" as ALLOWED_MESSAGE_TYPES)], info);
+  });
+
+  it("routes `busy`, `warn` and `error` to toastr.error()", () => {
+    assertToastr(["busy", "warn", "error"], error);
+  });
+
+  it("routes `success` to toastr.success()", () => {
+    assertToastr(["success"], success);
   });
 });

--- a/webpack/connectivity/__tests__/connect_device/index_test.ts
+++ b/webpack/connectivity/__tests__/connect_device/index_test.ts
@@ -15,20 +15,25 @@ describe("incomingStatus", () => {
 
 describe("ifToast", () => {
   function log(meta_type: ALLOWED_MESSAGE_TYPES,
-    chan: ALLOWED_CHANNEL_NAMES = "toast"): Log {
+    channels: ALLOWED_CHANNEL_NAMES[] = ["toast"]): Log {
     return {
       message: "toasty!",
       meta: { type: meta_type },
-      channels: [chan],
+      channels,
       created_at: -1
     };
   }
 
   it("skips irrelevant channels like `email`", () => {
     const callback = jest.fn();
-    ifToastWorthy(log("success", "email"), callback);
+    ifToastWorthy(log("success", ["email"]), callback);
     expect(callback).not.toHaveBeenCalled();
   });
 
-  it("does not toast others");
+  it("executes callback only for `toast` types", () => {
+    const callback = jest.fn();
+    const fakeToast = log("success", ["toast", "email"]);
+    ifToastWorthy(fakeToast, callback);
+    expect(callback).toHaveBeenCalledWith(fakeToast);
+  });
 });

--- a/webpack/connectivity/connect_device.ts
+++ b/webpack/connectivity/connect_device.ts
@@ -1,0 +1,168 @@
+import { devices } from "../device";
+import { dispatchNetworkUp, dispatchNetworkDown } from "./index";
+import { Log } from "../interfaces";
+import { ALLOWED_CHANNEL_NAMES, ALLOWED_MESSAGE_TYPES, Farmbot, BotStateTree } from "farmbot";
+import { get, set, throttle, noop } from "lodash";
+import { success, error, info, warning } from "farmbot-toastr";
+import { HardwareState } from "../devices/interfaces";
+import { GetState } from "../redux/interfaces";
+import { maybeRefreshToken } from "../refresh_token";
+import { Content, Actions } from "../constants";
+import { t } from "i18next";
+import { isLog, EXPECTED_MAJOR, EXPECTED_MINOR, commandOK, badVersion } from "../devices/actions";
+import { oneOf, bail } from "../util";
+import { init } from "../api/crud";
+import { versionOK } from "../devices/reducer";
+import { Token } from "../auth/interfaces";
+/** Welcome to one of the oldest pieces of FarmBot's software stack. */
+const AUTH_NOT_READY = "Somehow managed to get here before auth was ready.";
+const CHANNELS: keyof Log = "channels";
+const TOAST: ALLOWED_CHANNEL_NAMES = "toast";
+const TITLE = "New message from bot";
+let NEED_VERSION_CHECK = true;
+// Already filtering messages in FarmBot OS and the API- this is just for
+// an additional layer of safety. If sensitive data ever hits a client, it will
+// be reported to Rollbar for investigation.
+type ConnectDeviceReturn = {} | ((dispatch: Function) => void);
+const BAD_WORDS = ["WPA", "PSK", "PASSWORD", "NERVES"];
+let alreadyToldYou = false;
+const mq = "user.mqtt";
+
+function incomingStatus(statusMessage: HardwareState) {
+  return { type: Actions.BOT_CHANGE, payload: statusMessage };
+}
+
+function ifToast(log: Log, cb: (m: ALLOWED_MESSAGE_TYPES) => void) {
+  const chanList = get(log, CHANNELS, ["ERROR FETCHING CHANNELS"]);
+  return chanList.includes(TOAST) ?
+    cb(log.meta.type as ALLOWED_MESSAGE_TYPES) : noop();
+}
+
+function maybeShowLog(log: Log) {
+  ifToast(log, (m) => {
+    switch (m) {
+      case "success":
+        return success(log.message, TITLE);
+      case "busy":
+      case "warn":
+      case "error":
+        return error(log.message, TITLE);
+      case "fun":
+      case "info":
+      default:
+        return info(log.message, TITLE);
+    }
+  });
+}
+
+const bothUp = () => {
+  dispatchNetworkUp("user.mqtt");
+  dispatchNetworkUp("bot.mqtt");
+};
+
+function readStatus() {
+  const noun = "'Read Status' command";
+  return devices
+    .current
+    .readStatus()
+    .then(() => { commandOK(noun); }, () => { });
+}
+
+export function connectDevice(oldToken: string): ConnectDeviceReturn {
+  return (dispatch: Function, getState: GetState) => {
+    const ath = getState().auth;
+    const ok = doConnect(dispatch, getState);
+
+    ath ? (maybeRefreshToken(ath).then(ok)) : bail(AUTH_NOT_READY);
+  };
+}
+
+const onOffline = () => {
+  dispatchNetworkDown("user.mqtt");
+  error(t(Content.MQTT_DISCONNECTED));
+};
+
+const doConnect = (dispatch: Function, getState: GetState) =>
+  ({
+   token }: { token: Token }) => {
+    const secure = location.protocol === "https:";
+    const bot = new Farmbot({ token: token.encoded, secure });
+    bot.on("online", onOnline);
+    bot.on("offline", onOffline);
+    return bot
+      .connect()
+      .then(bootstrapAllTheThings(bot, dispatch, getState), noop);
+  };
+
+function onMalformed() {
+  bothUp();
+  if (!alreadyToldYou) {
+    warning(t(Content.MALFORMED_MESSAGE_REC_UPGRADE));
+    alreadyToldYou = true;
+  }
+}
+
+const onLogs = (dispatch: Function) => (msg: Log) => {
+  bothUp();
+  if (isLog(msg) && !oneOf(BAD_WORDS, msg.message.toUpperCase())) {
+    maybeShowLog(msg);
+    dispatch(init({
+      kind: "logs",
+      specialStatus: undefined,
+      uuid: "MUST_CHANGE",
+      body: msg
+    }));
+    // CORRECT SOLUTION: Give each device its own topic for publishing
+    //                   MQTT last will message.
+    // FAST SOLUTION:    We would need to re-publish FBJS and FBOS to
+    //                   change topic structure. Instead, we will use
+    //                   inband signalling (for now).
+    // TODO:             Make a `bot/device_123/offline` channel.
+    const died =
+      msg.message.includes("is offline") && msg.meta.type === "error";
+    died && dispatchNetworkDown("bot.mqtt");
+  } else {
+    throw new Error("Refusing to display log: " + JSON.stringify(msg));
+  }
+};
+
+const onSent = (/** The MQTT Client Object (bot.client) */ client: {}) =>
+  (any: {}) => {
+    const netState = (get(client, "connected", false));
+    netState ? dispatchNetworkUp(mq) : dispatchNetworkDown(mq);
+  };
+
+const onStatus = (dispatch: Function, getState: GetState) =>
+  (throttle(function (msg: BotStateTree) {
+    bothUp();
+    dispatch(incomingStatus(msg));
+    if (NEED_VERSION_CHECK) {
+      const IS_OK = versionOK(getState()
+        .bot
+        .hardware
+        .informational_settings
+        .controller_version, EXPECTED_MAJOR, EXPECTED_MINOR);
+      if (!IS_OK) { badVersion(); }
+      NEED_VERSION_CHECK = false;
+    }
+  }, 500));
+
+const onOnline = () => dispatchNetworkUp("user.mqtt");
+
+const changeLastClientConnected = (bot: Farmbot) => () => {
+  bot.setUserEnv({
+    "LAST_CLIENT_CONNECTED": JSON.stringify(new Date())
+  });
+};
+
+const bootstrapAllTheThings =
+  (bot: Farmbot, dispatch: Function, getState: GetState) => () => {
+    devices.online = true;
+    devices.current = bot;
+    bot.on("sent", onSent(bot.client));
+    bot.on("logs", onLogs(dispatch));
+    bot.on("status", onStatus(dispatch, getState));
+    bot.on("malformed", onMalformed);
+    readStatus().then(changeLastClientConnected(bot), noop);
+    set(window, "current_bot", bot);
+  };

--- a/webpack/connectivity/connect_device.ts
+++ b/webpack/connectivity/connect_device.ts
@@ -19,7 +19,7 @@ import { Token } from "../auth/interfaces";
 const AUTH_NOT_READY = "Somehow managed to get here before auth was ready.";
 const CHANNELS: keyof Log = "channels";
 const TOAST: ALLOWED_CHANNEL_NAMES = "toast";
-const TITLE = "New message from bot";
+export const TITLE = "New message from bot";
 let NEED_VERSION_CHECK = true;
 // Already filtering messages in FarmBot OS and the API- this is just for
 // an additional layer of safety. If sensitive data ever hits a client, it will

--- a/webpack/controls/__tests__/direction_button_test.tsx
+++ b/webpack/controls/__tests__/direction_button_test.tsx
@@ -1,9 +1,9 @@
+const mockDevice = {
+  moveRelative: jest.fn(() => { return Promise.resolve(); }),
+};
+
 jest.mock("../../device", () => ({
-  devices: {
-    current: {
-      moveRelative: jest.fn(() => { return Promise.resolve(); }),
-    }
-  }
+  getDevice: () => (mockDevice)
 }));
 const mockOk = jest.fn();
 jest.mock("farmbot-toastr", () => ({ success: mockOk }));

--- a/webpack/controls/__tests__/direction_button_test.tsx
+++ b/webpack/controls/__tests__/direction_button_test.tsx
@@ -12,7 +12,7 @@ import * as React from "react";
 import { mount } from "enzyme";
 import { DirectionButton } from "../direction_button";
 import { DirectionButtonProps } from "../interfaces";
-import { devices } from "../../device";
+import { getDevice } from "../../device";
 
 describe("<DirectionButton/>", function () {
   beforeEach(function () {
@@ -28,14 +28,14 @@ describe("<DirectionButton/>", function () {
   };
 
   it("calls move command", () => {
-    const { mock } = devices.current.moveRelative as jest.Mock<{}>;
+    const { mock } = getDevice().moveRelative as jest.Mock<{}>;
     const btn = mount(<DirectionButton {...buttonProps} />);
     btn.simulate("click");
     expect(mock.calls.length).toEqual(1);
   });
 
   it("is disabled", () => {
-    const { mock } = devices.current.moveRelative as jest.Mock<{}>;
+    const { mock } = getDevice().moveRelative as jest.Mock<{}>;
     buttonProps.disabled = true;
     const btn = mount(<DirectionButton {...buttonProps} />);
     btn.simulate("click");
@@ -43,7 +43,7 @@ describe("<DirectionButton/>", function () {
   });
 
   it("call has correct args", () => {
-    const { mock } = devices.current.moveRelative as jest.Mock<{}>;
+    const { mock } = getDevice().moveRelative as jest.Mock<{}>;
     const btn = mount(<DirectionButton {...buttonProps} />);
     btn.simulate("click");
     const argList = mock.calls[0][0];

--- a/webpack/controls/__tests__/jog_buttons_test.tsx
+++ b/webpack/controls/__tests__/jog_buttons_test.tsx
@@ -13,7 +13,7 @@ import * as React from "react";
 import { mount } from "enzyme";
 import { JogButtons } from "../jog_buttons";
 import { JogMovementControlsProps } from "../interfaces";
-import { devices } from "../../device";
+import { getDevice } from "../../device";
 import { bot } from "../../__test_support__/fake_state/bot";
 
 describe("<JogButtons/>", function () {
@@ -30,14 +30,14 @@ describe("<JogButtons/>", function () {
   };
 
   it("calls home command", () => {
-    const { mock } = devices.current.home as jest.Mock<{}>;
+    const { mock } = getDevice().home as jest.Mock<{}>;
     const jogButtons = mount(<JogButtons {...jogButtonProps} />);
     jogButtons.find("button").at(3).simulate("click");
     expect(mock.calls.length).toEqual(1);
   });
 
   it("is disabled", () => {
-    const { mock } = devices.current.home as jest.Mock<{}>;
+    const { mock } = getDevice().home as jest.Mock<{}>;
     jogButtonProps.disabled = true;
     const jogButtons = mount(<JogButtons {...jogButtonProps} />);
     jogButtons.find("button").at(3).simulate("click");
@@ -45,7 +45,7 @@ describe("<JogButtons/>", function () {
   });
 
   it("call has correct args", () => {
-    const { mock } = devices.current.home as jest.Mock<{}>;
+    const { mock } = getDevice().home as jest.Mock<{}>;
     const jogButtons = mount(<JogButtons {...jogButtonProps} />);
     jogButtons.find("button").at(3).simulate("click");
     const argList = mock.calls[0][0];
@@ -54,7 +54,7 @@ describe("<JogButtons/>", function () {
   });
 
   it("takes photo", () => {
-    const takePhoto = devices.current.takePhoto as jest.Mock<{}>;
+    const takePhoto = getDevice().takePhoto as jest.Mock<{}>;
     const jogButtons = mount(<JogButtons {...jogButtonProps} />);
     jogButtons.find("button").at(0).simulate("click");
     expect(takePhoto).toHaveBeenCalled();

--- a/webpack/controls/__tests__/jog_buttons_test.tsx
+++ b/webpack/controls/__tests__/jog_buttons_test.tsx
@@ -1,10 +1,10 @@
+const mockDevice = {
+  home: jest.fn(() => { return Promise.resolve(); }),
+  takePhoto: jest.fn(() => { return Promise.resolve(); }),
+};
+
 jest.mock("../../device", () => ({
-  devices: {
-    current: {
-      home: jest.fn(() => { return Promise.resolve(); }),
-      takePhoto: jest.fn(() => { return Promise.resolve(); }),
-    }
-  }
+  getDevice: () => (mockDevice)
 }));
 const mockOk = jest.fn();
 jest.mock("farmbot-toastr", () => ({ success: mockOk }));

--- a/webpack/controls/jog_buttons.tsx
+++ b/webpack/controls/jog_buttons.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { DirectionButton } from "./direction_button";
 import { homeAll } from "../devices/actions";
 import { JogMovementControlsProps } from "./interfaces";
-import { devices } from "../device";
+import { getDevice } from "../device";
 
 export class JogButtons extends React.Component<JogMovementControlsProps, {}> {
   render() {
@@ -12,7 +12,7 @@ export class JogButtons extends React.Component<JogMovementControlsProps, {}> {
           <td>
             <button
               className="i fa fa-camera arrow-button fb-button"
-              onClick={() => devices.current.takePhoto()} />
+              onClick={() => getDevice().takePhoto()} />
           </td>
           <td />
           <td />

--- a/webpack/controls/peripherals/__tests__/peripheral_list_test.tsx
+++ b/webpack/controls/peripherals/__tests__/peripheral_list_test.tsx
@@ -1,9 +1,8 @@
+const mockDevice = {
+  togglePin: jest.fn(() => { return Promise.resolve(); })
+};
 jest.mock("../../../device", () => ({
-  devices: {
-    current: {
-      togglePin: jest.fn(() => { return Promise.resolve(); })
-    }
-  }
+  getDevice: () => (mockDevice)
 }));
 
 import * as React from "react";

--- a/webpack/controls/peripherals/__tests__/peripheral_list_test.tsx
+++ b/webpack/controls/peripherals/__tests__/peripheral_list_test.tsx
@@ -11,7 +11,7 @@ import { mount } from "enzyme";
 import { PeripheralList } from "../peripheral_list";
 import { TaggedPeripheral } from "../../../resources/tagged_resources";
 import { Pins } from "farmbot/dist";
-import { devices } from "../../../device";
+import { getDevice } from "../../../device";
 
 describe("<PeripheralList/>", function () {
   beforeEach(function () {
@@ -73,7 +73,7 @@ describe("<PeripheralList/>", function () {
   });
 
   it("toggles pins", () => {
-    const { mock } = devices.current.togglePin as jest.Mock<{}>;
+    const { mock } = getDevice().togglePin as jest.Mock<{}>;
     const wrapper = mount(<PeripheralList dispatch={() => { }}
       peripherals={peripherals}
       pins={pins}
@@ -88,7 +88,7 @@ describe("<PeripheralList/>", function () {
   });
 
   it("pins toggles are disabled", () => {
-    const { mock } = devices.current.togglePin as jest.Mock<{}>;
+    const { mock } = getDevice().togglePin as jest.Mock<{}>;
     const wrapper = mount(<PeripheralList dispatch={() => { }}
       peripherals={peripherals}
       pins={pins}

--- a/webpack/device.ts
+++ b/webpack/device.ts
@@ -1,25 +1,12 @@
 import { Farmbot } from "farmbot";
+import { bail } from "./util";
+import { set } from "lodash";
 
-interface Devices {
-  online: boolean;
-  current: Farmbot;
+let device: Farmbot;
+
+export const getDevice = (): Farmbot => (device || bail("NO DEVICE SET"));
+
+export function setDevice(bot: Farmbot): Farmbot {
+  set(window, "current_bot", bot);
+  return device = bot;
 }
-
-function NullBot(): Farmbot {
-  // Allow me to explain: I'm following the null object pattern to prevent nil
-  // checks all over the app. That way, all of our "if undefined" logic is in
-  // one place and NullBot satisfies the same interface as a real bot.
-  const funnyConfigObject = {
-    token: `0.${btoa("\"NOT_SET\"")}.0`,
-    secure: false
-  };
-  let bot = new Farmbot(funnyConfigObject);
-  bot.connect = () => Promise.reject(`Tried to connect to null bot.
-    You probably meant to set a bot first.`);
-  return bot;
-}
-
-export var devices: Devices = {
-  online: false,
-  current: NullBot()
-};

--- a/webpack/devices/__tests__/actions_test.ts
+++ b/webpack/devices/__tests__/actions_test.ts
@@ -1,19 +1,21 @@
+const mockDevice = {
+  checkUpdates: jest.fn(() => { return Promise.resolve(); }),
+  powerOff: jest.fn(() => { return Promise.resolve(); }),
+  reboot: jest.fn(() => { return Promise.resolve(); }),
+  checkArduinoUpdates: jest.fn(() => { return Promise.resolve(); }),
+  emergencyLock: jest.fn(() => { return Promise.resolve(); }),
+  emergencyUnlock: jest.fn(() => { return Promise.resolve(); }),
+  execSequence: jest.fn(() => { return Promise.resolve(); }),
+  resetMCU: jest.fn(),
+  updateMcu: jest.fn(() => { return Promise.resolve(); }),
+  togglePin: jest.fn(() => { return Promise.resolve(); }),
+  home: jest.fn(() => { return Promise.resolve(); }),
+  sync: jest.fn(() => { return Promise.resolve(); })
+};
+
 jest.mock("../../device", () => ({
-  devices: {
-    current: {
-      checkUpdates: jest.fn(() => { return Promise.resolve(); }),
-      powerOff: jest.fn(() => { return Promise.resolve(); }),
-      reboot: jest.fn(() => { return Promise.resolve(); }),
-      checkArduinoUpdates: jest.fn(() => { return Promise.resolve(); }),
-      emergencyLock: jest.fn(() => { return Promise.resolve(); }),
-      emergencyUnlock: jest.fn(() => { return Promise.resolve(); }),
-      execSequence: jest.fn(() => { return Promise.resolve(); }),
-      resetMCU: jest.fn(),
-      updateMcu: jest.fn(() => { return Promise.resolve(); }),
-      togglePin: jest.fn(() => { return Promise.resolve(); }),
-      home: jest.fn(() => { return Promise.resolve(); }),
-      sync: jest.fn(() => { return Promise.resolve(); })
-    }
+  getDevice: () => {
+    return mockDevice;
   }
 }));
 const mockOk = jest.fn();

--- a/webpack/devices/__tests__/actions_test.ts
+++ b/webpack/devices/__tests__/actions_test.ts
@@ -21,7 +21,7 @@ const mockInfo = jest.fn();
 jest.mock("farmbot-toastr", () => ({ success: mockOk, info: mockInfo }));
 
 import * as actions from "../actions";
-import { devices } from "../../device";
+import { getDevice } from "../../device";
 import { fakeSequence } from "../../__test_support__/fake_state/resources";
 import { fakeState } from "../../__test_support__/fake_state";
 import { setSyncStatus, changeStepSize } from "../actions";
@@ -34,7 +34,7 @@ describe("checkControllerUpdates()", function () {
   });
 
   it("calls checkUpdates", async () => {
-    const { mock } = devices.current.checkUpdates as jest.Mock<{}>;
+    const { mock } = getDevice().checkUpdates as jest.Mock<{}>;
     await actions.checkControllerUpdates();
     expect(mock.calls.length).toEqual(1);
     expect(mockOk.mock.calls.length).toEqual(1);
@@ -47,7 +47,7 @@ describe("powerOff()", function () {
   });
 
   it("calls powerOff", async () => {
-    const { mock } = devices.current.powerOff as jest.Mock<{}>;
+    const { mock } = getDevice().powerOff as jest.Mock<{}>;
     await actions.powerOff();
     expect(mock.calls.length).toEqual(1);
     expect(mockOk.mock.calls.length).toEqual(1);
@@ -60,7 +60,7 @@ describe("reboot()", function () {
   });
 
   it("calls reboot", async () => {
-    const { mock } = devices.current.reboot as jest.Mock<{}>;
+    const { mock } = getDevice().reboot as jest.Mock<{}>;
     await actions.reboot();
     expect(mock.calls.length).toEqual(1);
     expect(mockOk.mock.calls.length).toEqual(1);
@@ -73,13 +73,13 @@ describe("emergencyLock() / emergencyUnlock", function () {
   });
 
   it("calls emergencyLock", () => {
-    const { mock } = devices.current.emergencyLock as jest.Mock<{}>;
+    const { mock } = getDevice().emergencyLock as jest.Mock<{}>;
     actions.emergencyLock();
     expect(mock.calls.length).toEqual(1);
   });
 
   it("calls emergencyUnlock", () => {
-    const { mock } = devices.current.emergencyUnlock as jest.Mock<{}>;
+    const { mock } = getDevice().emergencyUnlock as jest.Mock<{}>;
     window.confirm = jest.fn(() => true);
     actions.emergencyUnlock();
     expect(mock.calls.length).toEqual(1);
@@ -92,7 +92,7 @@ describe("sync()", function () {
   });
 
   it("doesn't call sync: disconnected", () => {
-    const { mock } = devices.current.sync as jest.Mock<{}>;
+    const { mock } = getDevice().sync as jest.Mock<{}>;
     const getState = () => fakeState();
     actions.sync()(jest.fn(), getState);
     expect(mock.calls.length).toEqual(0);
@@ -107,7 +107,7 @@ describe("execSequence()", function () {
   });
 
   it("calls execSequence", async () => {
-    const { mock } = devices.current.execSequence as jest.Mock<{}>;
+    const { mock } = getDevice().execSequence as jest.Mock<{}>;
     const s = fakeSequence().body;
     await actions.execSequence(s);
     expect(mock.calls.length).toEqual(1);
@@ -116,7 +116,7 @@ describe("execSequence()", function () {
   });
 
   it("implodes when executing unsaved sequences", () => {
-    const { mock } = devices.current.execSequence as jest.Mock<{}>;
+    const { mock } = getDevice().execSequence as jest.Mock<{}>;
     const ok = fakeSequence().body;
     ok.id = undefined;
     expect(() => actions.execSequence(ok)).toThrow();
@@ -130,7 +130,7 @@ describe("MCUFactoryReset()", function () {
   });
 
   it("calls resetMCU", () => {
-    const { mock } = devices.current.resetMCU as jest.Mock<{}>;
+    const { mock } = getDevice().resetMCU as jest.Mock<{}>;
     actions.MCUFactoryReset();
     expect(mock.calls.length).toEqual(1);
   });
@@ -142,7 +142,7 @@ describe("botConfigChange()", function () {
   });
 
   it("calls updateMcu", async () => {
-    const { mock } = devices.current.updateMcu as jest.Mock<{}>;
+    const { mock } = getDevice().updateMcu as jest.Mock<{}>;
     await actions.botConfigChange("encoder_enabled_x", 0);
     expect(mock.calls.length).toEqual(1);
     expect(mock.calls[0][0]).toEqual({ "encoder_enabled_x": 0 });
@@ -156,7 +156,7 @@ describe("pinToggle()", function () {
   });
 
   it("calls togglePin", async () => {
-    const { mock } = devices.current.togglePin as jest.Mock<{}>;
+    const { mock } = getDevice().togglePin as jest.Mock<{}>;
     await actions.pinToggle(5);
     expect(mock.calls.length).toEqual(1);
     const argList = mock.calls[0];
@@ -171,7 +171,7 @@ describe("homeAll()", function () {
   });
 
   it("calls home", async () => {
-    const { mock } = devices.current.home as jest.Mock<{}>;
+    const { mock } = getDevice().home as jest.Mock<{}>;
     await actions.homeAll(100);
     expect(mock.calls.length).toEqual(1);
     const argList = mock.calls[0];

--- a/webpack/devices/actions.ts
+++ b/webpack/devices/actions.ts
@@ -1,4 +1,3 @@
-import { Farmbot } from "farmbot";
 import { t } from "i18next";
 import axios from "axios";
 import * as _ from "lodash";
@@ -11,33 +10,23 @@ import { BotState } from "../devices/interfaces";
 import {
   McuParams,
   Configuration,
-  BotStateTree,
-  ALLOWED_CHANNEL_NAMES,
-  ALLOWED_MESSAGE_TYPES,
   SyncStatus
 } from "farmbot";
 import { Sequence } from "../sequences/interfaces";
-import { HardwareState, ControlPanelState } from "../devices/interfaces";
+import { ControlPanelState } from "../devices/interfaces";
 import { API } from "../api/index";
 import { User } from "../auth/interfaces";
-import { init } from "../api/crud";
 import { getDeviceAccountSettings } from "../resources/selectors";
 import { TaggedDevice } from "../resources/tagged_resources";
 import { versionOK } from "./reducer";
-import { oneOf, HttpData } from "../util";
+import { HttpData } from "../util";
 import { Actions, Content } from "../constants";
 import { mcuParamValidator } from "./update_interceptor";
-import { dispatchNetworkUp, dispatchNetworkDown } from "../connectivity/index";
-import { maybeRefreshToken } from "../refresh_token";
 
 const ON = 1, OFF = 0;
 export type ConfigKey = keyof McuParams;
 export const EXPECTED_MAJOR = 5;
 export const EXPECTED_MINOR = 0;
-
-function incomingStatus(statusMessage: HardwareState) {
-  return { type: "BOT_CHANGE", payload: statusMessage };
-}
 
 export function isLog(x: object): x is Log {
   return _.isObject(x) && _.isString(_.get(x, "message" as keyof Log));
@@ -47,7 +36,7 @@ const commandErr = (noun = "Command") => (x: {}) => {
   console.info("Took longer than 6 seconds: " + noun);
 };
 
-const commandOK = (noun = "Command") => () => {
+export const commandOK = (noun = "Command") => () => {
   const msg = noun + " request sent to device.";
   success(msg, t("Request sent"));
 };
@@ -248,109 +237,6 @@ export function homeAll(speed: number) {
     .then(commandOK(noun), commandErr(noun));
 }
 
-function readStatus() {
-  const noun = "'Read Status' command";
-  return devices
-    .current
-    .readStatus()
-    .then(() => { commandOK(noun); }, () => { });
-}
-
-let NEED_VERSION_CHECK = true;
-const bothUp = () => {
-  dispatchNetworkUp("user.mqtt");
-  dispatchNetworkUp("bot.mqtt");
-};
-// Already filtering messages in FarmBot OS and the API- this is just for
-// an additional layer of safety. If sensitive data ever hits a client, it will
-// be reported to Rollbar for investigation.
-type ConnectDeviceReturn = {} | ((dispatch: Function) => void);
-const BAD_WORDS = ["WPA", "PSK", "PASSWORD", "NERVES"];
-export function connectDevice(oldToken: string): ConnectDeviceReturn {
-  return (dispatch: Function, getState: GetState) => {
-    const ath = getState().auth;
-    if (!ath) {
-      throw new Error("SOmehow managed to get here before auth was ready.");
-    } else {
-      return ath && maybeRefreshToken(ath)
-        .then(({ token }) => {
-          const secure = location.protocol === "https:";
-          const bot = new Farmbot({ token: token.encoded, secure });
-          bot.on("online", () => dispatchNetworkUp("user.mqtt"));
-          bot.on("offline", () => {
-            dispatchNetworkDown("user.mqtt");
-            error(t(Content.MQTT_DISCONNECTED));
-          });
-          return bot
-            .connect()
-            .then(() => {
-              devices.online = true;
-              devices.current = bot;
-              _.set(window, "current_bot", bot);
-              readStatus()
-                .then(() => bot.setUserEnv(
-                  { "LAST_CLIENT_CONNECTED": JSON.stringify(new Date()) }
-                ))
-                .catch(() => { });
-              bot.on("logs", function (msg: Log) {
-                bothUp();
-                if (isLog(msg) && !oneOf(BAD_WORDS, msg.message.toUpperCase())) {
-                  maybeShowLog(msg);
-                  dispatch(init({
-                    kind: "logs",
-                    specialStatus: undefined,
-                    uuid: "MUST_CHANGE",
-                    body: msg
-                  }));
-                  // CORRECT SOLUTION: Give each device its own topic for publishing
-                  //                   MQTT last will message.
-                  // FAST SOLUTION:    We would need to re-publish FBJS and FBOS to
-                  //                   change topic structure. Instead, we will use
-                  //                   inband signalling (for now).
-                  // TODO:             Make a `bot/device_123/offline` channel.
-                  const died =
-                    msg.message.includes("is offline") && msg.meta.type === "error";
-                  died && dispatchNetworkDown("bot.mqtt");
-                } else {
-                  throw new Error("Refusing to display log: " + JSON.stringify(msg));
-                }
-              });
-              bot.on("status", _.throttle(function (msg: BotStateTree) {
-                bothUp();
-                dispatch(incomingStatus(msg));
-                if (NEED_VERSION_CHECK) {
-                  const IS_OK = versionOK(getState()
-                    .bot
-                    .hardware
-                    .informational_settings
-                    .controller_version, EXPECTED_MAJOR, EXPECTED_MINOR);
-                  if (!IS_OK) { badVersion(); }
-                  NEED_VERSION_CHECK = false;
-                }
-
-              }, 500));
-
-              let alreadyToldYou = false;
-              bot.on("malformed", function () {
-                bothUp();
-                if (!alreadyToldYou) {
-                  warning(t(Content.MALFORMED_MESSAGE_REC_UPGRADE));
-                  alreadyToldYou = true;
-                }
-              });
-            }, (err) => dispatch(fetchDeviceErr(err)));
-        });
-    }
-  };
-}
-
-function fetchDeviceErr(err: Error) {
-  return {
-    type: "FETCH_DEVICE_ERR",
-    payload: err
-  };
-}
-
 const startUpdate = () => {
   return {
     type: Actions.SETTING_UPDATE_START,
@@ -407,33 +293,10 @@ export function changeStepSize(integer: number) {
   };
 }
 
-const CHANNELS: keyof Log = "channels";
-const TOAST: ALLOWED_CHANNEL_NAMES = "toast";
-
-function maybeShowLog(log: Log) {
-  const chanList = _.get(log, CHANNELS, ["ERROR FETCHING CHANNELS"]);
-  const m = log.meta.type as ALLOWED_MESSAGE_TYPES;
-  const TITLE = "New message from bot";
-  if (chanList.includes(TOAST)) {
-    switch (m) {
-      case "success":
-        return success(log.message, TITLE);
-      case "busy":
-      case "warn":
-      case "error":
-        return error(log.message, TITLE);
-      case "fun":
-      case "info":
-      default:
-        return info(log.message, TITLE);
-    }
-  }
-}
-
 export function setSyncStatus(payload: SyncStatus) {
   return { type: "SET_SYNC_STATUS", payload };
 }
 
-function badVersion() {
+export function badVersion() {
   info(t("You are running an old version of FarmBot OS."), t("Please Update"), "red");
 }

--- a/webpack/devices/actions.ts
+++ b/webpack/devices/actions.ts
@@ -2,7 +2,7 @@ import { t } from "i18next";
 import axios from "axios";
 import * as _ from "lodash";
 import { success, warning, info, error } from "farmbot-toastr";
-import { devices } from "../device";
+import { getDevice } from "../device";
 import { Log, Everything } from "../interfaces";
 import { GithubRelease, MoveRelProps } from "./interfaces";
 import { Thunk, GetState } from "../redux/interfaces";
@@ -43,16 +43,14 @@ export const commandOK = (noun = "Command") => () => {
 
 export function checkControllerUpdates() {
   const noun = "Check for Updates";
-  devices
-    .current
+  getDevice()
     .checkUpdates()
     .then(commandOK(noun), commandErr(noun));
 }
 
 export function powerOff() {
   const noun = "Power Off Bot";
-  devices
-    .current
+  getDevice()
     .powerOff()
     .then(commandOK(noun), commandErr(noun));
 }
@@ -61,23 +59,19 @@ export function factoryReset() {
   if (!confirm(t(Content.FACTORY_RESET_ALERT))) {
     return;
   }
-  devices
-    .current
-    .resetOS();
+  getDevice().resetOS();
 }
 
 export function reboot() {
   const noun = "Reboot Bot";
-  devices
-    .current
+  getDevice()
     .reboot()
     .then(commandOK(noun), commandErr(noun));
 }
 
 export function emergencyLock() {
   const noun = "Emergency stop";
-  devices
-    .current
+  getDevice()
     .emergencyLock()
     .then(commandOK(noun), commandErr(noun));
 }
@@ -85,8 +79,7 @@ export function emergencyLock() {
 export function emergencyUnlock() {
   const noun = "Emergency unlock";
   if (confirm(`Are you sure you want to unlock the device?`)) {
-    devices
-      .current
+    getDevice()
       .emergencyUnlock()
       .then(commandOK(noun), commandErr(noun));
   }
@@ -102,8 +95,7 @@ export function sync(): Thunk {
       .controller_version, EXPECTED_MAJOR, EXPECTED_MINOR);
     if (IS_OK) {
       dispatch(setSyncStatus("syncing"));
-      devices
-        .current
+      getDevice()
         .sync()
         .then(() => {
           commandOK(noun);
@@ -129,8 +121,7 @@ export function sync(): Thunk {
 export function execSequence(sequence: Sequence) {
   const noun = "Sequence execution";
   if (sequence.id) {
-    return devices
-      .current
+    return getDevice()
       .execSequence(sequence.id)
       .then(commandOK(noun), commandErr(noun));
   } else {
@@ -181,14 +172,13 @@ export function toggleControlPanel(payload: keyof ControlPanelState) {
 }
 
 export function MCUFactoryReset() {
-  return devices.current.resetMCU();
+  return getDevice().resetMCU();
 }
 
 export function botConfigChange(key: ConfigKey, value: number) {
   const noun = "Setting toggle";
 
-  return devices
-    .current
+  return getDevice()
     .updateMcu({ [key]: value })
     .then(_.noop, commandErr(noun));
 }
@@ -198,8 +188,7 @@ export function settingToggle(
 ) {
   if (displayAlert) { alert(displayAlert.replace(/\s+/g, " ")); }
   const noun = "Setting toggle";
-  return devices
-    .current
+  return getDevice()
     .updateMcu({
       [name]: ((bot.hardware.mcu_params)[name] === 0) ? ON : OFF
     })
@@ -207,32 +196,28 @@ export function settingToggle(
 }
 
 export function moveRelative(props: MoveRelProps) {
-  return devices
-    .current
+  return getDevice()
     .moveRelative(props)
     .then(_.noop, commandErr("Relative movement"));
 }
 
 export function moveAbs(props: MoveRelProps) {
   const noun = "Absolute movement";
-  return devices
-    .current
+  return getDevice()
     .moveAbsolute(props)
     .then(_.noop, commandErr(noun));
 }
 
 export function pinToggle(pin_number: number) {
   const noun = "Setting toggle";
-  return devices
-    .current
+  return getDevice()
     .togglePin({ pin_number })
     .then(_.noop, commandErr(noun));
 }
 
 export function homeAll(speed: number) {
   const noun = "'Home All' command";
-  devices
-    .current
+  getDevice()
     .home({ axis: "all", speed })
     .then(commandOK(noun), commandErr(noun));
 }
@@ -261,8 +246,7 @@ export function updateMCU(key: ConfigKey, val: string) {
 
     function proceed() {
       dispatch(startUpdate());
-      devices
-        .current
+      getDevice()
         .updateMcu({ [key]: val })
         .then(() => updateOK(dispatch, noun))
         .catch(() => updateNO(dispatch, noun));
@@ -278,8 +262,7 @@ export function updateMCU(key: ConfigKey, val: string) {
 export function updateConfig(config: Configuration) {
   const noun = "Update Config";
   return function (dispatch: Function) {
-    devices
-      .current
+    getDevice()
       .updateConfig(config)
       .then(() => updateOK(dispatch, noun))
       .catch(() => updateNO(dispatch, noun));

--- a/webpack/devices/components/__tests__/board_type_test.tsx
+++ b/webpack/devices/components/__tests__/board_type_test.tsx
@@ -1,9 +1,9 @@
+const mockDevice = {
+  updateConfig: jest.fn(() => { return Promise.resolve(); })
+};
+
 jest.mock("../../../device", () => ({
-  devices: {
-    current: {
-      updateConfig: jest.fn(() => { return Promise.resolve(); })
-    }
-  }
+  getDevice: () => (mockDevice)
 }));
 const mockToast = jest.fn();
 jest.mock("farmbot-toastr", () => ({

--- a/webpack/devices/components/__tests__/board_type_test.tsx
+++ b/webpack/devices/components/__tests__/board_type_test.tsx
@@ -15,7 +15,7 @@ jest.mock("farmbot-toastr", () => ({
 import * as React from "react";
 import { mount, shallow } from "enzyme";
 import { BoardType } from "../board_type";
-import { devices } from "../../../device";
+import { getDevice } from "../../../device";
 
 describe("<BoardType/>", () => {
   it("Farmduino", () => {
@@ -49,7 +49,7 @@ describe("<BoardType/>", () => {
   });
 
   it("calls updateConfig", () => {
-    const updateConfig = devices.current.updateConfig as jest.Mock<{}>;
+    const updateConfig = getDevice().updateConfig as jest.Mock<{}>;
     const wrapper = shallow(<BoardType
       firmwareVersion={"Arduino Disconnected!"} />);
     wrapper.find("FBSelect").simulate("change",

--- a/webpack/devices/components/__tests__/calibration_row_test.tsx
+++ b/webpack/devices/components/__tests__/calibration_row_test.tsx
@@ -9,14 +9,14 @@ import * as React from "react";
 import { mount } from "enzyme";
 import { CalibrationRow } from "../calibration_row";
 import { bot } from "../../../__test_support__/fake_state/bot";
-import { devices } from "../../../device";
+import { getDevice } from "../../../device";
 
 describe("<HomingRow />", () => {
   beforeEach(function () {
     jest.clearAllMocks();
   });
   it("calls device", () => {
-    const { mock } = devices.current.calibrate as jest.Mock<{}>;
+    const { mock } = getDevice().calibrate as jest.Mock<{}>;
     const result = mount(<CalibrationRow hardware={bot.hardware.mcu_params} />);
     result.find("LockableButton").at(0).simulate("click");
     result.find("LockableButton").at(1).simulate("click");

--- a/webpack/devices/components/__tests__/calibration_row_test.tsx
+++ b/webpack/devices/components/__tests__/calibration_row_test.tsx
@@ -1,9 +1,8 @@
+const mockDevice = {
+  calibrate: jest.fn()
+};
 jest.mock("../../../device", () => ({
-  devices: {
-    current: {
-      calibrate: jest.fn()
-    }
-  }
+  getDevice: () => (mockDevice)
 }));
 import * as React from "react";
 import { mount } from "enzyme";

--- a/webpack/devices/components/__tests__/camera_selection_test.tsx
+++ b/webpack/devices/components/__tests__/camera_selection_test.tsx
@@ -1,9 +1,8 @@
+const mockDevice = {
+  setUserEnv: jest.fn(() => { return Promise.resolve(); }),
+};
 jest.mock("../../../device", () => ({
-  devices: {
-    current: {
-      setUserEnv: jest.fn(() => { return Promise.resolve(); }),
-    }
-  }
+  getDevice: () => (mockDevice)
 }));
 const mockInfo = jest.fn();
 const mockError = jest.fn();

--- a/webpack/devices/components/__tests__/camera_selection_test.tsx
+++ b/webpack/devices/components/__tests__/camera_selection_test.tsx
@@ -11,7 +11,7 @@ jest.mock("farmbot-toastr", () => ({ info: mockInfo, error: mockError }));
 
 import * as React from "react";
 import { mount, shallow } from "enzyme";
-import { devices } from "../../../device";
+import { getDevice } from "../../../device";
 import { CameraSelection } from "../camera_selection";
 
 describe("<CameraSelection/>", () => {
@@ -32,7 +32,7 @@ describe("<CameraSelection/>", () => {
   });
 
   it("changes camera", () => {
-    const { mock } = devices.current.setUserEnv as jest.Mock<{}>;
+    const { mock } = getDevice().setUserEnv as jest.Mock<{}>;
     const cameraSelection = shallow(<CameraSelection
       env={{}} />);
     cameraSelection.find("FBSelect")

--- a/webpack/devices/components/__tests__/homing_row_test.tsx
+++ b/webpack/devices/components/__tests__/homing_row_test.tsx
@@ -9,7 +9,7 @@ import * as React from "react";
 import { mount } from "enzyme";
 import { HomingRow } from "../homing_row";
 import { bot } from "../../../__test_support__/fake_state/bot";
-import { devices } from "../../../device";
+import { getDevice } from "../../../device";
 
 describe("<HomingRow />", () => {
   beforeEach(function () {
@@ -26,7 +26,7 @@ describe("<HomingRow />", () => {
     });
   });
   it("calls device", () => {
-    const { mock } = devices.current.findHome as jest.Mock<{}>;
+    const { mock } = getDevice().findHome as jest.Mock<{}>;
     const result = mount(<HomingRow hardware={bot.hardware.mcu_params} />);
     result.find("LockableButton").at(0).simulate("click");
     result.find("LockableButton").at(1).simulate("click");

--- a/webpack/devices/components/__tests__/homing_row_test.tsx
+++ b/webpack/devices/components/__tests__/homing_row_test.tsx
@@ -1,9 +1,9 @@
+const mockDevice = {
+  findHome: jest.fn()
+};
+
 jest.mock("../../../device", () => ({
-  devices: {
-    current: {
-      findHome: jest.fn()
-    }
-  }
+  getDevice: () => (mockDevice)
 }));
 import * as React from "react";
 import { mount } from "enzyme";

--- a/webpack/devices/components/__tests__/os_update_button_test.tsx
+++ b/webpack/devices/components/__tests__/os_update_button_test.tsx
@@ -1,9 +1,8 @@
+const mockDevice = {
+  checkUpdates: jest.fn(() => { return Promise.resolve(); }),
+};
 jest.mock("../../../device", () => ({
-  devices: {
-    current: {
-      checkUpdates: jest.fn(() => { return Promise.resolve(); }),
-    }
-  }
+  getDevice: () => (mockDevice)
 }));
 const mockOk = jest.fn();
 jest.mock("farmbot-toastr", () => ({ success: mockOk }));

--- a/webpack/devices/components/__tests__/os_update_button_test.tsx
+++ b/webpack/devices/components/__tests__/os_update_button_test.tsx
@@ -12,7 +12,7 @@ import * as React from "react";
 import { OsUpdateButton } from "../os_update_button";
 import { mount } from "enzyme";
 import { bot } from "../../../__test_support__/fake_state/bot";
-import { devices } from "../../../device";
+import { getDevice } from "../../../device";
 
 describe("<OsUpdateButton/>", () => {
   beforeEach(function () {
@@ -40,7 +40,7 @@ describe("<OsUpdateButton/>", () => {
     expect(osUpdateButton.text()).toBe("UPDATE");
   });
   it("calls checkUpdates", () => {
-    const { mock } = devices.current.checkUpdates as jest.Mock<{}>;
+    const { mock } = getDevice().checkUpdates as jest.Mock<{}>;
     const buttons = mount(<OsUpdateButton bot={bot} />);
     const osUpdateButton = buttons.find("button").last();
     osUpdateButton.simulate("click");
@@ -85,7 +85,7 @@ describe("<OsUpdateButton/>", () => {
     expect(osUpdateButton.text()).toBe("UPDATE");
   });
   it("is disabled", () => {
-    const { mock } = devices.current.checkUpdates as jest.Mock<{}>;
+    const { mock } = getDevice().checkUpdates as jest.Mock<{}>;
     bot.hardware.jobs = { "FBOS_OTA": { status: "working", percent: 10, unit: "percent" } };
     const buttons = mount(<OsUpdateButton bot={bot} />);
     const osUpdateButton = buttons.find("button").last();

--- a/webpack/devices/components/__tests__/zero_row_test.tsx
+++ b/webpack/devices/components/__tests__/zero_row_test.tsx
@@ -1,9 +1,8 @@
+const mockDevice = {
+  setZero: jest.fn()
+};
 jest.mock("../../../device", () => ({
-  devices: {
-    current: {
-      setZero: jest.fn()
-    }
-  }
+  getDevice: () => (mockDevice)
 }));
 import * as React from "react";
 import { mount } from "enzyme";

--- a/webpack/devices/components/__tests__/zero_row_test.tsx
+++ b/webpack/devices/components/__tests__/zero_row_test.tsx
@@ -8,14 +8,14 @@ jest.mock("../../../device", () => ({
 import * as React from "react";
 import { mount } from "enzyme";
 import { ZeroRow } from "../zero_row";
-import { devices } from "../../../device";
+import { getDevice } from "../../../device";
 
 describe("<HomingRow />", () => {
   beforeEach(function () {
     jest.clearAllMocks();
   });
   it("calls device", () => {
-    const { mock } = devices.current.setZero as jest.Mock<{}>;
+    const { mock } = getDevice().setZero as jest.Mock<{}>;
     const result = mount(<ZeroRow />);
     result.find("ZeroButton").at(0).simulate("click");
     result.find("ZeroButton").at(1).simulate("click");

--- a/webpack/devices/components/board_type.tsx
+++ b/webpack/devices/components/board_type.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { Row, Col, DropDownItem } from "../../ui/index";
 import { t } from "i18next";
 import { FBSelect } from "../../ui/new_fb_select";
-import { devices } from "../../device";
+import { getDevice } from "../../device";
 import { info, error } from "farmbot-toastr";
 import { FirmwareHardware } from "farmbot";
 
@@ -70,8 +70,7 @@ export class BoardType
     const firmware_hardware = selectedBoard.value;
     if (selectedBoard && isFwHardwareValue(firmware_hardware)) {
       info(t("Sending firmware configuration..."), t("Sending"));
-      devices
-        .current
+      getDevice()
         .updateConfig({ firmware_hardware })
         .catch(() => error(t("An error occurred during configuration.")));
     }

--- a/webpack/devices/components/calibration_row.tsx
+++ b/webpack/devices/components/calibration_row.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { t } from "i18next";
-import { devices } from "../../device";
+import { getDevice } from "../../device";
 import { Axis } from "../interfaces";
 import { LockableButton } from "./lockable_button";
 import { axisTrackingStatus } from "./axis_tracking_status";
@@ -9,8 +9,7 @@ import { Row, Col } from "../../ui/index";
 import { CalibrationRowProps } from "./interfaces";
 
 function calibrate(axis: Axis) {
-  devices
-    .current
+  getDevice()
     .calibrate({ axis });
 }
 

--- a/webpack/devices/components/camera_selection.tsx
+++ b/webpack/devices/components/camera_selection.tsx
@@ -4,7 +4,7 @@ import { t } from "i18next";
 import { CameraSelectionProps, CameraSelectionState } from "../interfaces";
 import { DropDownItem } from "../../ui/index";
 import { info, success, error } from "farmbot-toastr/dist";
-import { devices } from "../../device";
+import { getDevice } from "../../device";
 import { FBSelect } from "../../ui/new_fb_select";
 
 const CAMERA_CHOICES = [
@@ -42,8 +42,7 @@ export class CameraSelection
   sendOffConfig = (selectedCamera: DropDownItem) => {
     const message = { "camera": JSON.stringify(selectedCamera.value) };
     info(t("Sending camera configuration..."), t("Sending"));
-    devices
-      .current
+    getDevice()
       .setUserEnv(message)
       .then(() => {
         success(t("Successfully configured camera!"));

--- a/webpack/devices/components/homing_row.tsx
+++ b/webpack/devices/components/homing_row.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { t } from "i18next";
-import { devices } from "../../device";
+import { getDevice } from "../../device";
 import { Axis } from "../interfaces";
 import { HomingRowProps } from "./interfaces";
 import { Farmbot } from "farmbot/dist";
@@ -11,7 +11,7 @@ import { SpacePanelToolTip } from "./space_panel_tool_tip";
 import { Row, Col } from "../../ui/index";
 
 const speed = Farmbot.defaults.speed;
-const findHome = (axis: Axis) => devices.current.findHome({ speed, axis });
+const findHome = (axis: Axis) => getDevice().findHome({ speed, axis });
 
 export function HomingRow(props: HomingRowProps) {
   const { hardware } = props;

--- a/webpack/devices/components/zero_row.tsx
+++ b/webpack/devices/components/zero_row.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { t } from "i18next";
-import { devices } from "../../device";
+import { getDevice } from "../../device";
 import { Axis } from "../interfaces";
 import { ToolTips } from "../../constants";
 import { Row, Col } from "../../ui/index";
 
-const zero = (axis: Axis) => devices.current.setZero(axis);
+const zero = (axis: Axis) => getDevice().setZero(axis);
 const AXES: Axis[] = ["x", "y", "z"];
 
 export function ZeroButton({ axis }: { axis: Axis }) {

--- a/webpack/devices/devices.tsx
+++ b/webpack/devices/devices.tsx
@@ -12,7 +12,7 @@ import {
 import { Diagnosis, DiagnosisName } from "./connectivity/diagnosis";
 import { StatusRowProps } from "./connectivity/connectivity_row";
 import { refresh } from "../api/crud";
-import { devices } from "../device";
+import { getDevice } from "../device";
 
 @connect(mapStateToProps)
 export class Devices extends React.Component<Props, {}> {
@@ -45,7 +45,7 @@ export class Devices extends React.Component<Props, {}> {
 
   refresh = () => {
     this.props.dispatch(refresh(this.props.deviceAccount));
-    devices.current.getState();
+    getDevice().getState();
   };
 
   render() {

--- a/webpack/devices/devices.tsx
+++ b/webpack/devices/devices.tsx
@@ -12,6 +12,7 @@ import {
 import { Diagnosis, DiagnosisName } from "./connectivity/diagnosis";
 import { StatusRowProps } from "./connectivity/connectivity_row";
 import { refresh } from "../api/crud";
+import { devices } from "../device";
 
 @connect(mapStateToProps)
 export class Devices extends React.Component<Props, {}> {
@@ -43,9 +44,8 @@ export class Devices extends React.Component<Props, {}> {
   }
 
   refresh = () => {
-    this
-      .props
-      .dispatch(refresh(this.props.deviceAccount));
+    this.props.dispatch(refresh(this.props.deviceAccount));
+    devices.current.getState();
   };
 
   render() {

--- a/webpack/farmware/__tests__/farmware_forms_test.tsx
+++ b/webpack/farmware/__tests__/farmware_forms_test.tsx
@@ -9,7 +9,7 @@ jest.mock("../../device", () => ({
 import * as React from "react";
 import { mount } from "enzyme";
 import { FarmwareForms } from "../farmware_forms";
-import { devices } from "../../device";
+import { getDevice } from "../../device";
 import { FarmwareManifest, Dictionary } from "farmbot";
 
 function fakeFarmwares(): Dictionary<FarmwareManifest | undefined> {
@@ -43,7 +43,7 @@ describe("<FarmwareForms/>", () => {
   });
 
   it("runs", () => {
-    const runFarmware = devices.current.execScript as jest.Mock<{}>;
+    const runFarmware = getDevice().execScript as jest.Mock<{}>;
     const wrapper = mount(<FarmwareForms farmwares={fakeFarmwares()} />);
     const run = wrapper.find("button").first();
     run.simulate("click");

--- a/webpack/farmware/__tests__/farmware_forms_test.tsx
+++ b/webpack/farmware/__tests__/farmware_forms_test.tsx
@@ -1,9 +1,9 @@
+const mockDevice = {
+  execScript: jest.fn()
+};
+
 jest.mock("../../device", () => ({
-  devices: {
-    current: {
-      execScript: jest.fn()
-    }
-  }
+  getDevice: () => (mockDevice)
 }));
 
 import * as React from "react";

--- a/webpack/farmware/__tests__/farmware_panel_test.tsx
+++ b/webpack/farmware/__tests__/farmware_panel_test.tsx
@@ -1,12 +1,12 @@
+const mockDevice = {
+  installFarmware: jest.fn(() => { return Promise.resolve(); }),
+  updateFarmware: jest.fn(() => { return Promise.resolve(); }),
+  removeFarmware: jest.fn(() => { return Promise.resolve(); }),
+  execScript: jest.fn(() => { return Promise.resolve(); })
+};
+
 jest.mock("../../device", () => ({
-  devices: {
-    current: {
-      installFarmware: jest.fn(() => { return Promise.resolve(); }),
-      updateFarmware: jest.fn(() => { return Promise.resolve(); }),
-      removeFarmware: jest.fn(() => { return Promise.resolve(); }),
-      execScript: jest.fn(() => { return Promise.resolve(); })
-    }
-  }
+  getDevice: () => (mockDevice)
 }));
 
 import * as React from "react";

--- a/webpack/farmware/__tests__/farmware_panel_test.tsx
+++ b/webpack/farmware/__tests__/farmware_panel_test.tsx
@@ -11,7 +11,7 @@ jest.mock("../../device", () => ({
 
 import * as React from "react";
 import { mount } from "enzyme";
-import { devices } from "../../device";
+import { getDevice } from "../../device";
 import { FarmwarePanel } from "../farmware_panel";
 
 describe("<FarmwarePanel/>", () => {
@@ -29,7 +29,7 @@ describe("<FarmwarePanel/>", () => {
   }
 
   it("calls install", () => {
-    const { mock } = devices.current.installFarmware as jest.Mock<{}>;
+    const { mock } = getDevice().installFarmware as jest.Mock<{}>;
     const panel = bootstrapTest();
     const buttons = panel.component.find("button");
     expect(buttons.at(0).text()).toEqual("Install");
@@ -40,7 +40,7 @@ describe("<FarmwarePanel/>", () => {
   });
 
   it("calls update", () => {
-    const { mock } = devices.current.updateFarmware as jest.Mock<{}>;
+    const { mock } = getDevice().updateFarmware as jest.Mock<{}>;
     const panel = bootstrapTest();
     const buttons = panel.component.find("button");
     expect(buttons.at(3).text()).toEqual("Update");
@@ -51,7 +51,7 @@ describe("<FarmwarePanel/>", () => {
   });
 
   it("calls remove", () => {
-    const { mock } = devices.current.removeFarmware as jest.Mock<{}>;
+    const { mock } = getDevice().removeFarmware as jest.Mock<{}>;
     const panel = bootstrapTest();
     const buttons = panel.component.find("button");
     expect(buttons.at(2).text()).toEqual("Remove");
@@ -62,7 +62,7 @@ describe("<FarmwarePanel/>", () => {
   });
 
   it("calls run", () => {
-    const { mock } = devices.current.execScript as jest.Mock<{}>;
+    const { mock } = getDevice().execScript as jest.Mock<{}>;
     const panel = bootstrapTest();
     const buttons = panel.component.find("button");
     expect(buttons.at(4).text()).toEqual("Run");

--- a/webpack/farmware/camera_calibration/__tests__/actions_test.ts
+++ b/webpack/farmware/camera_calibration/__tests__/actions_test.ts
@@ -1,9 +1,8 @@
+const mockDevice = {
+  execScript: jest.fn()
+};
 jest.mock("../../../device", () => ({
-  devices: {
-    current: {
-      execScript: jest.fn() // jest.fn() will capture all calls to itself.
-    }
-  }
+  getDevice: () => (mockDevice)
 }));
 
 import { calibrate, scanImage } from "../actions";

--- a/webpack/farmware/camera_calibration/__tests__/actions_test.ts
+++ b/webpack/farmware/camera_calibration/__tests__/actions_test.ts
@@ -7,14 +7,14 @@ jest.mock("../../../device", () => ({
 }));
 
 import { calibrate, scanImage } from "../actions";
-import { devices } from "../../../device";
+import { getDevice } from "../../../device";
 
 describe("scanImage()", () => {
   beforeEach(function () {
     jest.clearAllMocks();
   });
   it("calls out to the device", () => {
-    const { mock } = devices.current.execScript as jest.Mock<{}>;
+    const { mock } = getDevice().execScript as jest.Mock<{}>;
     // Run function to invoke side effects
     const thunk = scanImage(4);
     thunk();
@@ -35,7 +35,7 @@ describe("calibrate()", () => {
     jest.clearAllMocks();
   });
   it("calls out to the device", () => {
-    const { mock } = devices.current.execScript as jest.Mock<{}>;
+    const { mock } = getDevice().execScript as jest.Mock<{}>;
     // Run function to invoke side effects
     const thunk = calibrate();
     thunk();

--- a/webpack/farmware/camera_calibration/actions.ts
+++ b/webpack/farmware/camera_calibration/actions.ts
@@ -1,15 +1,14 @@
-import { devices } from "../../device";
+import { getDevice } from "../../device";
 
 export function calibrate() {
   return function () {
-    devices.current.execScript("camera-calibration");
+    getDevice().execScript("camera-calibration");
   };
 }
 
 export function scanImage(imageId: number) {
   return function () {
-    devices
-      .current
+    getDevice()
       .execScript("historical-camera-calibration", [{
         kind: "pair", args: {
           label: "CAMERA_CALIBRATION_selected_image",

--- a/webpack/farmware/farmware_forms.tsx
+++ b/webpack/farmware/farmware_forms.tsx
@@ -3,7 +3,7 @@ import { Widget, WidgetHeader, WidgetBody, Col } from "../ui/index";
 import { t } from "i18next";
 import { FarmwareManifest, Dictionary } from "farmbot";
 import { betterCompact } from "../util";
-import { devices } from "../device";
+import { getDevice } from "../device";
 
 interface FarmwareFormsProps {
   farmwares: Dictionary<FarmwareManifest | undefined>;
@@ -38,7 +38,7 @@ export function FarmwareForms(props: FarmwareFormsProps): JSX.Element {
                 + farmware.meta.version : ""}>
               <button
                 className="fb-button gray"
-                onClick={() => devices.current.execScript(farmware.name)}>
+                onClick={() => getDevice().execScript(farmware.name)}>
                 {t("Run")}
               </button>
             </WidgetHeader>

--- a/webpack/farmware/farmware_panel.tsx
+++ b/webpack/farmware/farmware_panel.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import * as _ from "lodash";
 import { t } from "i18next";
-import { devices } from "../device";
+import { getDevice } from "../device";
 import { FWProps, FWState } from "./interfaces";
 import { MustBeOnline } from "../devices/must_be_online";
 import { ToolTips } from "../constants";
@@ -30,32 +30,28 @@ export class FarmwarePanel extends React.Component<FWProps, Partial<FWState>> {
 
   update = () => {
     this
-      .ifFarmwareSelected(label => devices
-        .current
+      .ifFarmwareSelected(label => getDevice()
         .updateFarmware(label)
         .then(() => this.setState({ selectedFarmware: undefined })));
   }
 
   remove = () => {
     this
-      .ifFarmwareSelected(label => devices
-        .current
+      .ifFarmwareSelected(label => getDevice()
         .removeFarmware(label)
         .then(() => this.setState({ selectedFarmware: undefined })));
   }
 
   run = () => {
     this
-      .ifFarmwareSelected(label => devices
-        .current
+      .ifFarmwareSelected(label => getDevice()
         .execScript(label)
         .then(() => this.setState({ selectedFarmware: label })));
   }
 
   install = () => {
     if (this.state.packageUrl) {
-      devices
-        .current
+      getDevice()
         .installFarmware(this.state.packageUrl)
         .then(() => this.setState({ packageUrl: "" }));
     } else {

--- a/webpack/farmware/images/photos.tsx
+++ b/webpack/farmware/images/photos.tsx
@@ -6,7 +6,7 @@ import { success, error } from "farmbot-toastr";
 import { Widget, WidgetHeader, WidgetBody } from "../../ui/index";
 import { ImageFlipper } from "./image_flipper";
 import { PhotosProps } from "./interfaces";
-import { devices } from "../../device";
+import { getDevice } from "../../device";
 import { ToolTips } from "../../constants";
 import { selectImage } from "./actions";
 import { WidgetFooter } from "../../ui/widget_footer";
@@ -39,7 +39,7 @@ export class Photos extends React.Component<PhotosProps, {}> {
   takePhoto = () => {
     const ok = () => success(t("Processing now. Refresh page to see result."));
     const no = () => error(t("Error taking photo"));
-    devices.current.takePhoto().then(ok, no);
+    getDevice().takePhoto().then(ok, no);
   }
 
   metaDatas() {

--- a/webpack/farmware/weed_detector/__tests__/actions_tests.ts
+++ b/webpack/farmware/weed_detector/__tests__/actions_tests.ts
@@ -1,11 +1,10 @@
+const mockDevice = {
+  setUserEnv: jest.fn(),
+  execScript: jest.fn()
+};
 jest.mock("../../../device", () => {
   return {
-    devices: {
-      current: {
-        setUserEnv: jest.fn(),
-        execScript: jest.fn()
-      }
-    }
+    getDevice: () => (mockDevice)
   };
 });
 import { getDevice } from "../../../device";

--- a/webpack/farmware/weed_detector/__tests__/actions_tests.ts
+++ b/webpack/farmware/weed_detector/__tests__/actions_tests.ts
@@ -8,7 +8,7 @@ jest.mock("../../../device", () => {
     }
   };
 });
-import { devices } from "../../../device";
+import { getDevice } from "../../../device";
 import { translateImageWorkspaceAndSave } from "../actions";
 import { scanImage, test } from "../actions";
 
@@ -31,8 +31,8 @@ describe("actions", () => {
       "V_LO": "WEED_DETECTOR_V_LO"
     });
     translator("H_HI", 45);
-    expect(devices.current.setUserEnv).toHaveBeenCalledTimes(1);
-    expect(devices.current.setUserEnv)
+    expect(getDevice().setUserEnv).toHaveBeenCalledTimes(1);
+    expect(getDevice().setUserEnv)
       .toHaveBeenLastCalledWith({ "WEED_DETECTOR_H_HI": "45" });
   });
 });
@@ -42,7 +42,7 @@ describe("scanImage()", () => {
     jest.clearAllMocks();
   });
   it("calls out to the device", () => {
-    const { mock } = devices.current.execScript as jest.Mock<{}>;
+    const { mock } = getDevice().execScript as jest.Mock<{}>;
     // Run function to invoke side effects
     const thunk = scanImage(5);
     thunk();
@@ -63,7 +63,7 @@ describe("test()", () => {
     jest.clearAllMocks();
   });
   it("calls out to the device", () => {
-    const { mock } = devices.current.execScript as jest.Mock<{}>;
+    const { mock } = getDevice().execScript as jest.Mock<{}>;
     // Run function to invoke side effects
     const thunk = test();
     thunk();

--- a/webpack/farmware/weed_detector/actions.tsx
+++ b/webpack/farmware/weed_detector/actions.tsx
@@ -6,7 +6,7 @@ import { Thunk } from "../../redux/interfaces";
 import { API } from "../../api";
 import { Progress, ProgressCallback, HttpData } from "../../util";
 import { GenericPointer } from "../../interfaces";
-import { devices } from "../../device";
+import { getDevice } from "../../device";
 import { WDENVKey } from "./remote_env/interfaces";
 import { NumericValues } from "./image_workspace";
 import { envSave } from "./remote_env/actions";
@@ -64,8 +64,7 @@ const label = "PLANT_DETECTION_selected_image";
 
 export function scanImage(imageId: number) {
   return function () {
-    devices
-      .current
+    getDevice()
       .execScript("historical-plant-detection", [{
         kind: "pair", args: { label: label, value: "" + imageId }
       }]);
@@ -74,6 +73,6 @@ export function scanImage(imageId: number) {
 
 export function test() {
   return function () {
-    devices.current.execScript("plant-detection");
+    getDevice().execScript("plant-detection");
   };
 }

--- a/webpack/farmware/weed_detector/index.tsx
+++ b/webpack/farmware/weed_detector/index.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { connect } from "react-redux";
 import { DetectorState, HSV } from "./interfaces";
 import { TitleBar } from "./title";
-import { devices } from "../../device";
+import { getDevice } from "../../device";
 import { Row, Col, Widget, WidgetBody } from "../../ui/index";
 import { t } from "i18next";
 import { resetWeedDetection, scanImage, test } from "./actions";
@@ -41,7 +41,7 @@ export class WeedDetector
   };
 
   test = () => {
-    devices.current.execScript("plant-detection");
+    getDevice().execScript("plant-detection");
   }
 
   /** Maps <ImageWorkspace/> props to weed detector ENV vars. */

--- a/webpack/farmware/weed_detector/remote_env/__tests__/actions_test.ts
+++ b/webpack/farmware/weed_detector/remote_env/__tests__/actions_test.ts
@@ -1,12 +1,8 @@
 jest.mock("../../../../device", () => {
-  return {
-    devices: {
-      current: {
-        setUserEnv: jest.fn()
-      }
-    }
-  };
+  const mock = { setUserEnv: jest.fn() };
+  return { getDevice: () => mock };
 });
+
 import { envSave } from "../actions";
 import { getDevice } from "../../../../device";
 

--- a/webpack/farmware/weed_detector/remote_env/__tests__/actions_test.ts
+++ b/webpack/farmware/weed_detector/remote_env/__tests__/actions_test.ts
@@ -8,7 +8,7 @@ jest.mock("../../../../device", () => {
   };
 });
 import { envSave } from "../actions";
-import { devices } from "../../../../device";
+import { getDevice } from "../../../../device";
 
 describe("actions", () => {
   it("Saves environment variables", () => {
@@ -16,8 +16,8 @@ describe("actions", () => {
      * triggering side effects. */
     jest.clearAllMocks();
     envSave("CAMERA_CALIBRATION_blur", 24);
-    expect(devices.current.setUserEnv).toHaveBeenCalledTimes(1);
-    expect(devices.current.setUserEnv)
+    expect(getDevice().setUserEnv).toHaveBeenCalledTimes(1);
+    expect(getDevice().setUserEnv)
       .toHaveBeenLastCalledWith({ "CAMERA_CALIBRATION_blur": "24" });
   });
 });

--- a/webpack/farmware/weed_detector/remote_env/actions.ts
+++ b/webpack/farmware/weed_detector/remote_env/actions.ts
@@ -4,6 +4,5 @@ import { formatEnvKey } from "./translators";
 
 /** Send a number to FBOS for storage on the device. */
 export function envSave(key: WDENVKey, value: number) {
-  getDevice()
-    .setUserEnv({ [key]: JSON.stringify(formatEnvKey(key, value)) });
+  getDevice().setUserEnv({ [key]: JSON.stringify(formatEnvKey(key, value)) });
 }

--- a/webpack/farmware/weed_detector/remote_env/actions.ts
+++ b/webpack/farmware/weed_detector/remote_env/actions.ts
@@ -1,10 +1,9 @@
-import { devices } from "../../../device";
+import { getDevice } from "../../../device";
 import { WDENVKey } from "./interfaces";
 import { formatEnvKey } from "./translators";
 
 /** Send a number to FBOS for storage on the device. */
 export function envSave(key: WDENVKey, value: number) {
-  devices
-    .current
+  getDevice()
     .setUserEnv({ [key]: JSON.stringify(formatEnvKey(key, value)) });
 }

--- a/webpack/interceptor_support.ts
+++ b/webpack/interceptor_support.ts
@@ -1,5 +1,5 @@
 import { ResourceName, DataChangeType, Dictionary } from "farmbot/dist";
-import { devices } from "./device";
+import { getDevice } from "./device";
 import { box } from "boxed_value";
 import * as _ from "lodash";
 
@@ -23,7 +23,7 @@ export function notifyBotOfChanges(url: string | undefined, action: DataChangeTy
     url.split("/").filter((chunk: ResourceName) => {
       return RESOURCES.includes(chunk);
     }).map(async function (resource: ResourceName) {
-      devices.current.dataUpdate(action, { [resource]: inferUpdateId(url) });
+      getDevice().dataUpdate(action, { [resource]: inferUpdateId(url) });
     });
   }
 }

--- a/webpack/interfaces.ts
+++ b/webpack/interfaces.ts
@@ -1,7 +1,7 @@
 import { AuthState } from "./auth/interfaces";
 import { ConfigState } from "./config/interfaces";
 import { BotState } from "./devices/interfaces";
-import { Color as FarmBotJsColor } from "farmbot";
+import { Color as FarmBotJsColor, ALLOWED_MESSAGE_TYPES } from "farmbot";
 import { DraggableState } from "./draggable/interfaces";
 import { PeripheralState } from "./controls/peripherals/interfaces";
 import { RestResources } from "./resources/interfaces";
@@ -25,7 +25,7 @@ export interface SelectOptionsParams {
 export interface Log {
   id?: number | undefined;
   message: string;
-  meta: { type: string; };
+  meta: { type: ALLOWED_MESSAGE_TYPES; };
   channels: string[];
   created_at: number;
 }

--- a/webpack/nav/ticker_list.tsx
+++ b/webpack/nav/ticker_list.tsx
@@ -29,7 +29,7 @@ export let TickerList = (props: TickerListProps) => {
   const firstTicker: Log = props.logs.filter(
     log => !log.message.toLowerCase().includes("filtered"))[0];
   const noLogs: Log = {
-    message: "No logs yet.", meta: { type: "" }, channels: [], created_at: NaN
+    message: "No logs yet.", meta: { type: "success" }, channels: [], created_at: NaN
   };
   return (
     <div

--- a/webpack/sequences/step_tiles/tile_move_absolute/handle_select.ts
+++ b/webpack/sequences/step_tiles/tile_move_absolute/handle_select.ts
@@ -4,6 +4,7 @@ import { DropDownItem } from "../../../ui/index";
 import { ResourceIndex } from "../../../resources/interfaces";
 import { KnownGroupTag, LocationData } from "./interfaces";
 import { findPointerByTypeAndId, findToolById } from "../../../resources/selectors";
+import { bail } from "../../../util";
 
 /** Takes a DropDownItem and turns it into data suitable
  * for MoveAbsolute["args"]["location"] */
@@ -32,7 +33,3 @@ export let handleSelect = (index: ResourceIndex, input: DropDownItem): LocationD
       return { kind: "coordinate", args: { x: 0, y: 0, z: 0 } };
   }
 };
-
-function bail(msg: string): never {
-  throw new Error(msg);
-}

--- a/webpack/util.ts
+++ b/webpack/util.ts
@@ -443,3 +443,7 @@ export function bitArray(...values: boolean[]) {
       return res << 1 | x;
     });
 }
+
+export function bail(message: string): never {
+  throw new Error(message);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1976,9 +1976,9 @@ farmbot-toastr@^1.0.0, farmbot-toastr@^1.0.3:
     farmbot-toastr "^1.0.0"
     typescript "^2.3.4"
 
-farmbot@5.0.1-rc9:
-  version "5.0.1-rc9"
-  resolved "https://registry.yarnpkg.com/farmbot/-/farmbot-5.0.1-rc9.tgz#ccdb88d2f72c80e38bf8ddc9e322204714d140e6"
+farmbot@5.0.1-rc10:
+  version "5.0.1-rc10"
+  resolved "https://registry.yarnpkg.com/farmbot/-/farmbot-5.0.1-rc10.tgz#cc53285cdc705b50c606c12c87f7ccb66aa473b8"
   dependencies:
     mqtt "^1.7.4"
     typescript "^2.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1976,9 +1976,9 @@ farmbot-toastr@^1.0.0, farmbot-toastr@^1.0.3:
     farmbot-toastr "^1.0.0"
     typescript "^2.3.4"
 
-farmbot@5.0.1-rc10:
-  version "5.0.1-rc10"
-  resolved "https://registry.yarnpkg.com/farmbot/-/farmbot-5.0.1-rc10.tgz#cc53285cdc705b50c606c12c87f7ccb66aa473b8"
+farmbot@5.0.1-rc11:
+  version "5.0.1-rc11"
+  resolved "https://registry.yarnpkg.com/farmbot/-/farmbot-5.0.1-rc11.tgz#de99739ffb90fcbd8c012ad5d39d57e123399521"
   dependencies:
     mqtt "^1.7.4"
     typescript "^2.4.2"


### PR DESCRIPTION
# What's New?

 * Bump FBJS to `rc11`
 * (finally) get rid of `devices.current`- a legacy API from 2 years ago.
 * Update tests accordingly.