### PR TITLE
Updates to Dev Workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ You will need the following:
  0. Give permission to create a database*
  0. `rake db:create:all db:migrate db:seed`
  0. (optional) Verify installation with `RAILS_ENV=test rake db:create db:migrate && rspec spec` (API) and `npm run test` (Frontend).
- 0. Start server with `npm run dev`. Make sure you set an `MQTT_HOST` entry in `application.yml` pointing to the IP address or domain of  MQTT server. If you are not running the MQTT server on a separate machine, `MQTT_HOST` and `API_HOST` will point to the same server.
+ 0. Start server with `rails api:start`. Make sure you set an `MQTT_HOST` entry in `application.yml` pointing to the IP address or domain of  MQTT server. If you are not running the MQTT server on a separate machine, `MQTT_HOST` and `API_HOST` will point to the same server.
  0. Start MQTT with `rails mqtt:start`. **Important note:** You may be required to enter a sudo because [docker requires root access](https://docs.docker.com/engine/security/security/#docker-daemon-attack-surface).
  0. Open [localhost:3000](http://localhost:3000).
  0. [Raise an issue](https://github.com/FarmBot/Farmbot-Web-App/issues/new?title=Installation%20Failure) if you hit problems with any of these steps. *We can't fix issues we don't know about.*

--- a/lib/tasks/api.rake
+++ b/lib/tasks/api.rake
@@ -1,5 +1,5 @@
 namespace :api do
-  desc "TODO"
+  desc "Run Webpack and Rails"
   task start: :environment do
     sh "PORT=3000 bundle exec foreman start --procfile=Procfile.dev"
   end

--- a/lib/tasks/api.rake
+++ b/lib/tasks/api.rake
@@ -1,0 +1,7 @@
+namespace :api do
+  desc "TODO"
+  task start: :environment do
+    sh "PORT=3000 bundle exec foreman start --procfile=Procfile.dev"
+  end
+
+end

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "TARGET=production bundle exec rake webpack:compile",
     "start": "echo '===We use `npm run dev` now.==='",
     "heroku-postbuild": "webpack --config=./config/webpack.prod.js",
-    "dev": "PORT=3000 bundle exec foreman start --procfile=Procfile.dev",
+    "dev": "rails api:start",
     "webpack": "./node_modules/.bin/webpack-dev-server --config config/webpack.config.js --host 0.0.0.0",
     "test": "jest --coverage --no-cache",
     "typecheck": "tsc --noEmit --jsx preserve"

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   "scripts": {
     "coverage": "cat **/*lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "build": "TARGET=production bundle exec rake webpack:compile",
-    "start": "echo '===We use `npm run dev` now.==='",
+    "start": "echo '===We use `rails api:start` now.==='",
     "heroku-postbuild": "webpack --config=./config/webpack.prod.js",
-    "dev": "rails api:start",
+    "dev": "echo '===We use `rails api:start` now.==='",
     "webpack": "./node_modules/.bin/webpack-dev-server --config config/webpack.config.js --host 0.0.0.0",
     "test": "jest --coverage --no-cache",
     "typecheck": "tsc --noEmit --jsx preserve"


### PR DESCRIPTION
# Why?

 * We recently bundled the MQTT server with the API.
 * We usually run all services within the same `Procfile` for convenience in development mode.
 * In the case of the MQTT server, it was prompting for `sudo` on some machines.
 * This was not convenient.

# What's New?

 * Dev environment is now spun up via `rails app:start` and `rails mqtt:start`
 * `npm run dev` is no longer used.