### PR TITLE
Updates for self hosting and local dev env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,7 @@ verify.*.js*
 rabbitmq/*
 rabbitmq/
 mqtt/conf/rabbitmq.config
+mqtt/jwt_plugin/deps/*
+*.beam
+*.ez
+*.d

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You will need the following:
 
 ### Setup
 
- 1. `git clone https://github.com/FarmBot/Farmbot-Web-App`
+ 1. `git clone https://github.com/FarmBot/Farmbot-Web-App --depth=10`
  0. `cd Farmbot-Web-App`
  0. `bundle install`
  0. `yarn install`

--- a/config/application.example.yml
+++ b/config/application.example.yml
@@ -37,9 +37,8 @@ DATABASE_URL: "postgres://USERNAME:PASSWORD@URL:PORT/DB_NAME"
 DEVISE_SECRET: "Used for devise. Use `rake secret` to generate a new value."
 # Most personal server users can delete this.
 FORCE_SSL: "Remove this if not using HTTPS://"
-# Firmware update server. Use default if you don't have a special use case.
+# FarmBot OS update server. Use default if you don't have a special use case.
 # Off grid servers may have issues connecting to our update URL.
-FW_UPDATE_SERVER: "https://api.github.com/repos/FarmBot/farmbot-arduino-firmware/releases/latest"
 OS_UPDATE_SERVER: "https://api.github.com/repos/farmbot/farmbot_os/releases/latest"
 # Google Cloud Storage API Bucket for image data.
 # Deleting this will save to disk.

--- a/config/application.example.yml
+++ b/config/application.example.yml
@@ -75,3 +75,7 @@ NO_EMAILS: "TRUE"
 # If you are not using the standard MQTT broker (eg: you use a 3rd party
 # MQTT vendor), you will need to change this line.
 MQTT_WS: "ws://DELETE_OR_CHANGE_THIS_LINE/ws"
+# ENV var used by FarmBot employees when building different versions of the JWT
+# auth backend plugin.
+# Can be deleted safely.
+API_PUBLIC_KEY_PATH: "http://changeme.io/api/public_key"

--- a/config/application.example.yml
+++ b/config/application.example.yml
@@ -79,3 +79,6 @@ MQTT_WS: "ws://DELETE_OR_CHANGE_THIS_LINE/ws"
 # auth backend plugin.
 # Can be deleted safely.
 API_PUBLIC_KEY_PATH: "http://changeme.io/api/public_key"
+# If you are using a shared RabbitMQ server and need to use a VHost other than
+# "/", change this ENV var.
+MQTT_VHOST: "/"

--- a/lib/tasks/api.rake
+++ b/lib/tasks/api.rake
@@ -1,5 +1,5 @@
 namespace :api do
-  desc "TODO"
+  desc "Run Webpack and Rails"
   task start: :environment do
     sh "PORT=3000 bundle exec foreman start --procfile=Procfile.dev"
   end

--- a/lib/tasks/mqtt.rake
+++ b/lib/tasks/mqtt.rake
@@ -1,5 +1,6 @@
 namespace :mqtt do
-  desc "Bootstraps the MQTT config file"
+  desc "Bootstraps the MQTT config file. To force a rebuild of *everything*, " +
+       "set FORCE_REBUILD='true'"
   task start: :environment do
     require_relative '../../mqtt/server.rb'
   end

--- a/mqtt/rabbitmq.config.erb
+++ b/mqtt/rabbitmq.config.erb
@@ -14,14 +14,10 @@
           rabbit_auth_backend_jwt
         ]}
     ] },
-
-  { rabbitmq_web_mqtt, [{ port, 3002 }]},
+  { rabbitmq_mqtt, [{vhost, <<"<%= farmbot_vhost %>">>}] },
+  { rabbitmq_web_mqtt, [{ port, 3002 }, {vhost, <<"<%= farmbot_vhost %>">>}]},
   {
-    rabbitmq_management, [{
-      listener, [
-        { port, 15672 },
-        { ssl, false }
-      ] } ] },
+    rabbitmq_management, [{listener, [ { port, 15672 }, { ssl, false }] } ] },
 
   { rabbit_auth_backend_jwt, [
       { farmbot_api_key_url, "<%= farmbot_api_key_url %>" },

--- a/mqtt/server.rb
+++ b/mqtt/server.rb
@@ -1,22 +1,22 @@
 require 'erb'
 puts "=== Retrieving container info"
-PLUGIN_PATH         = "mqtt/jwt_plugin/plugins/rabbit_auth_backend*"
-PLUGIN_IS_BUILT     = Dir[PLUGIN_PATH].any?
-FORCE_REBUILD       = ENV["FORCE_REBUILD"].present?
-DOCKER_IMG_NAME     = "farmbot-mqtt"
-IMG_IS_BUILT        = `cd mqtt; sudo docker images`.include?(DOCKER_IMG_NAME)
+PLUGIN_PATH     = "mqtt/jwt_plugin/plugins/rabbit_auth_backend*"
+PLUGIN_IS_BUILT = Dir[PLUGIN_PATH].any?
+FORCE_REBUILD   = ENV["FORCE_REBUILD"].present?
+DOCKER_IMG_NAME = "farmbot-mqtt"
+IMG_IS_BUILT    = `cd mqtt; sudo docker images`.include?(DOCKER_IMG_NAME)
 
 puts "=== Setting config data"
-CONFIG_PATH         = "./mqtt/conf"
-CONFIG_FILENAME     = "rabbitmq.config"
-CONFIG_OUTPUT       = "#{CONFIG_PATH}/#{CONFIG_FILENAME}"
-NO_API_HOST         = "You need to set API_HOST to a real IP address or " +
-                      "domain name (not localhost)."
-TEMPLATE_FILE       = "./mqtt/rabbitmq.config.erb"
-TEMPLATE            = File.read(TEMPLATE_FILE)
-RENDERER            = ERB.new(TEMPLATE)
-PROTO               = ENV["FORCE_SSL"] ? "https:" : "http:"
-VHOST               = ENV.fetch("MQTT_VHOST") { "/" }
+CONFIG_PATH     = "./mqtt/conf"
+CONFIG_FILENAME = "rabbitmq.config"
+CONFIG_OUTPUT   = "#{CONFIG_PATH}/#{CONFIG_FILENAME}"
+NO_API_HOST     = "You need to set API_HOST to a real IP address or " +
+                  "domain name (not localhost)."
+TEMPLATE_FILE   = "./mqtt/rabbitmq.config.erb"
+TEMPLATE        = File.read(TEMPLATE_FILE)
+RENDERER        = ERB.new(TEMPLATE)
+PROTO           = ENV["FORCE_SSL"] ? "https:" : "http:"
+VHOST           = ENV.fetch("MQTT_VHOST") { "/" }
 
 puts "=== Building JWT plugin config"
 farmbot_api_key_url = ENV.fetch("API_PUBLIC_KEY_PATH") do

--- a/spec/controllers/api/users/users_controller_spec.rb
+++ b/spec/controllers/api/users/users_controller_spec.rb
@@ -138,17 +138,20 @@ describe Api::UsersController do
       expect(json[:user])
         .to include(Users::ResendVerification::ALREADY_VERIFIED)
     end
+    unless ENV["NO_EMAILS"]
+      it 're-sends verification email' do
+        unverified = User.create!(email:                 Faker::Internet.email,
+                                  password:              "password123",
+                                  password_confirmation: "password123")
 
-    it 're-sends verification email' do
-      unverified = User.create!(email:                 Faker::Internet.email,
-                                password:              "password123",
-                                password_confirmation: "password123")
+        post :resend_verification,
+            params: { email: unverified.email },
+            format: :json
 
-      post :resend_verification,
-           params: { email: unverified.email },
-           format: :json
-
-      expect(response.status).to eq(200)
-      expect(json[:user]).to include(Users::ResendVerification::SENT)
+        expect(response.status).to eq(200)
+        expect(json[:user]).to include(Users::ResendVerification::SENT)
+      end
+    else
+      puts "Skipping test because NO_EMAILS was enabled."
     end
 end

--- a/spec/lib/session_token_spec.rb
+++ b/spec/lib/session_token_spec.rb
@@ -40,11 +40,14 @@ describe SessionToken do
     expect(result.success?).to be(false)
     expect(result.errors.values.first.message).to include("is not valid")
   end
-
-  it "doesn't mint tokens for unverified users" do
-    user.update_attributes!(verified_at: nil)
-    expect {
-      SessionToken.issue_to(user, iat: 000, exp: 1, iss: "//lycos.com:9867")
-    }.to raise_error(Errors::Forbidden)
+  unless ENV["NO_EMAILS"]
+    it "doesn't mint tokens for unverified users" do
+      user.update_attributes!(verified_at: nil)
+      expect {
+        SessionToken.issue_to(user, iat: 000, exp: 1, iss: "//lycos.com:9867")
+      }.to raise_error(Errors::Forbidden)
+    end
+  else
+    puts "Skipping a test because NO_EMAILS was enabled."
   end
 end


### PR DESCRIPTION
# What's New?

 * Skip email related tests when `NO_EMAILS` is active.
 * Add a `--depth=10` flag to install instructions, since most users don't want a full (length download) commit log when cloning.
 * Run `make dist`, but only as needed.
 * `gitignore` updates.
