### PR TITLE
Bug Fixes and Additions

### DIFF
--- a/webpack/css/farm_designer/farm_designer_panels.scss
+++ b/webpack/css/farm_designer/farm_designer_panels.scss
@@ -172,6 +172,9 @@
     margin-top: -0.2rem;
     vertical-align: bottom;
   }
+  input {
+    background: white;
+  }
 }
 
 .add-farm-event-panel button.red,

--- a/webpack/css/widgets.scss
+++ b/webpack/css/widgets.scss
@@ -50,7 +50,17 @@
     max-height: 0px;
     transition: all 0.5s ease;
     transition-delay: 0.2s;
-    pointer-events: none;
+    a:link {
+      font-style: normal;
+      color: $off_white;
+    }
+    a:hover {
+      font-weight: 600;
+      color: white;
+    }
+    a:active {
+      color: white;
+    }
   }
   h5 {
     color: $gray;

--- a/webpack/devices/devices.tsx
+++ b/webpack/devices/devices.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { connect } from "react-redux";
 import { HardwareSettings } from "./components/hardware_settings";
 import { FarmbotOsSettings } from "./components/farmbot_os_settings";
-import { Page, Col } from "../ui";
+import { Page, Col, Row } from "../ui";
 import { mapStateToProps } from "./state_to_props";
 import { Props } from "./interfaces";
 import { ConnectivityPanel } from "./connectivity/index";
@@ -51,30 +51,32 @@ export class Devices extends React.Component<Props, {}> {
   render() {
     if (this.props.auth) {
       return <Page className="devices">
-        <Col xs={12} sm={6}>
-          <FarmbotOsSettings
-            account={this.props.deviceAccount}
-            dispatch={this.props.dispatch}
-            bot={this.props.bot}
-            auth={this.props.auth} />
-          <ConnectivityPanel
-            status={this.props.deviceAccount.specialStatus}
-            onRefresh={this.refresh}
-            rowData={this.rowData}>
-            <Diagnosis
-              userAPI={!!this.flags.userAPI}
-              userMQTT={!!this.flags.userMQTT.connectionStatus}
-              botMQTT={!!this.flags.botMQTT.connectionStatus}
-              botAPI={!!this.flags.botAPI.connectionStatus}
-              botFirmware={!!this.flags.botFirmware.connectionStatus} />
-          </ConnectivityPanel>
-        </Col>
-        <Col xs={12} sm={6}>
-          <HardwareSettings
-            controlPanelState={this.props.bot.controlPanelState}
-            dispatch={this.props.dispatch}
-            bot={this.props.bot} />
-        </Col>
+        <Row>
+          <Col xs={12} sm={6}>
+            <FarmbotOsSettings
+              account={this.props.deviceAccount}
+              dispatch={this.props.dispatch}
+              bot={this.props.bot}
+              auth={this.props.auth} />
+            <ConnectivityPanel
+              status={this.props.deviceAccount.specialStatus}
+              onRefresh={this.refresh}
+              rowData={this.rowData}>
+              <Diagnosis
+                userAPI={!!this.flags.userAPI}
+                userMQTT={!!this.flags.userMQTT.connectionStatus}
+                botMQTT={!!this.flags.botMQTT.connectionStatus}
+                botAPI={!!this.flags.botAPI.connectionStatus}
+                botFirmware={!!this.flags.botFirmware.connectionStatus} />
+            </ConnectivityPanel>
+          </Col>
+          <Col xs={12} sm={6}>
+            <HardwareSettings
+              controlPanelState={this.props.bot.controlPanelState}
+              dispatch={this.props.dispatch}
+              bot={this.props.bot} />
+          </Col>
+        </Row>
       </Page>;
     } else {
       throw new Error("Log in first");

--- a/webpack/farm_designer/index.tsx
+++ b/webpack/farm_designer/index.tsx
@@ -81,7 +81,7 @@ export class FarmDesigner extends React.Component<Props, Partial<State>> {
   }
 
   updateZoomLevel = (zoomIncrement: number) => () => {
-    const payload = this.getZoomLevel() + zoomIncrement;
+    const payload = Math.round((this.getZoomLevel() + zoomIncrement) * 10) / 10;
     this.setState({ zoomLevel: payload });
     Session.setNum(NumericSetting.zoomLevel, payload);
   }
@@ -173,7 +173,7 @@ export class FarmDesigner extends React.Component<Props, Partial<State>> {
           botSize={botSize}
           stopAtHome={stopAtHome}
           hoveredPlant={this.props.hoveredPlant}
-          zoomLvl={Math.round(zoomLevel * 10) / 10}
+          zoomLvl={zoomLevel}
           botOriginQuadrant={botOriginQuadrant}
           gridSize={getGridSize(botSize)}
           gridOffset={gridOffset} />

--- a/webpack/farm_designer/map/__tests__/garden_map_legend_test.tsx
+++ b/webpack/farm_designer/map/__tests__/garden_map_legend_test.tsx
@@ -1,0 +1,48 @@
+import * as React from "react";
+import { shallow } from "enzyme";
+import { GardenMapLegend } from "../garden_map_legend";
+import { GardenMapLegendProps } from "../interfaces";
+
+describe("<GardenMapLegend />", () => {
+  function fakeProps(): GardenMapLegendProps {
+    return {
+      zoom: () => () => undefined,
+      toggle: () => () => undefined,
+      updateBotOriginQuadrant: () => () => undefined,
+      botOriginQuadrant: 2,
+      zoomLvl: 1,
+      legendMenuOpen: true,
+      showPlants: false,
+      showPoints: false,
+      showSpread: false,
+      showFarmbot: false
+    };
+  }
+
+  function checkZoomButtons(level: number, disabled: number) {
+    const p = fakeProps();
+    p.zoomLvl = level;
+    const wrapper = shallow(<GardenMapLegend {...p} />);
+    expect(wrapper.find(".disabled").length).toEqual(disabled);
+  }
+
+  const MAX = 1.8;
+  const MIN = 0.1;
+
+  it("zoom buttons active", () => {
+    checkZoomButtons(1.0, 0);
+    checkZoomButtons(MIN + 0.1, 0);
+  });
+
+  it("zoom out button disabled", () => {
+    checkZoomButtons(MIN + 0.01, 1);
+    checkZoomButtons(MIN, 1);
+    checkZoomButtons(MIN - 0.05, 1);
+  });
+
+  it("zoom in button disabled", () => {
+    checkZoomButtons(MAX - 0.01, 1);
+    checkZoomButtons(MAX, 1);
+    checkZoomButtons(MAX + 0.05, 1);
+  });
+});

--- a/webpack/farm_designer/map/garden_map_legend.tsx
+++ b/webpack/farm_designer/map/garden_map_legend.tsx
@@ -18,8 +18,9 @@ export function GardenMapLegend(props: GardenMapLegendProps) {
     showFarmbot
   } = props;
 
-  const plusBtnClass = (zoomLvl && zoomLvl >= 1.8) ? "disabled" : "";
-  const minusBtnClass = (zoomLvl && zoomLvl <= 0.4) ? "disabled" : "";
+  const rZoomLvl = Math.round(zoomLvl * 10) / 10;
+  const plusBtnClass = (rZoomLvl && rZoomLvl >= 1.8) ? "disabled" : "";
+  const minusBtnClass = (rZoomLvl && rZoomLvl <= 0.1) ? "disabled" : "";
   const menuClass = legendMenuOpen ? "active" : "";
 
   return (
@@ -37,12 +38,12 @@ export function GardenMapLegend(props: GardenMapLegendProps) {
       <div className="content">
         <div className="zoom-buttons">
           <button
-            className={"fb-button gray zoom top " + plusBtnClass}
+            className={"fb-button gray zoom " + plusBtnClass}
             onClick={zoom(0.1)}>
             <i className="fa fa-2x fa-plus" />
           </button>
           <button
-            className={"fb-button gray zoom zoom-out bottom " + minusBtnClass}
+            className={"fb-button gray zoom zoom-out " + minusBtnClass}
             onClick={zoom(-0.1)}>
             <i className="fa fa-2x fa-minus" />
           </button>

--- a/webpack/farm_designer/map/tool_slot_point.tsx
+++ b/webpack/farm_designer/map/tool_slot_point.tsx
@@ -33,8 +33,8 @@ export class ToolSlotPoint extends
     return <g id={"toolslot-" + id}>
       <defs>
         <radialGradient id="SeedBinGradient">
-          <stop offset="5%" stopColor="rgba(0, 0, 0, 0.3)" />
-          <stop offset="95%" stopColor="rgba(0, 0, 0, 0.1)" />
+          <stop offset="5%" stopColor="rgb(0, 0, 0)" stopOpacity={0.3} />
+          <stop offset="95%" stopColor="rgb(0, 0, 0)" stopOpacity={0.1} />
         </radialGradient>
         <pattern id="SeedTrayPattern"
           x={0} y={0} width={0.25} height={0.25}>

--- a/webpack/farmware/__tests__/farmware_panel_test.tsx
+++ b/webpack/farmware/__tests__/farmware_panel_test.tsx
@@ -2,7 +2,8 @@ const mockDevice = {
   installFarmware: jest.fn(() => { return Promise.resolve(); }),
   updateFarmware: jest.fn(() => { return Promise.resolve(); }),
   removeFarmware: jest.fn(() => { return Promise.resolve(); }),
-  execScript: jest.fn(() => { return Promise.resolve(); })
+  execScript: jest.fn(() => { return Promise.resolve(); }),
+  installFirstPartyFarmware: jest.fn(),
 };
 
 jest.mock("../../device", () => ({
@@ -12,7 +13,7 @@ jest.mock("../../device", () => ({
 import * as React from "react";
 import { mount } from "enzyme";
 import { getDevice } from "../../device";
-import { FarmwarePanel } from "../farmware_panel";
+import { FarmwarePanel, FarmwareConfigMenu } from "../farmware_panel";
 
 describe("<FarmwarePanel/>", () => {
   beforeEach(() => {
@@ -70,5 +71,16 @@ describe("<FarmwarePanel/>", () => {
     buttons.at(4).simulate("click");
     expect(mock.calls.length).toEqual(1);
     expect(mock.calls[0][0]).toEqual("run this");
+  });
+});
+
+describe("<FarmwareConfigMenu />", () => {
+  it("calls install 1st party farmwares", () => {
+    const firstParty = getDevice().installFirstPartyFarmware;
+    const wrapper = mount(<FarmwareConfigMenu />);
+    const button = wrapper.find("button");
+    expect(button.hasClass("fa-download")).toBeTruthy();
+    button.simulate("click");
+    expect(firstParty).toHaveBeenCalled();
   });
 });

--- a/webpack/farmware/camera_calibration/camera_calibration.tsx
+++ b/webpack/farmware/camera_calibration/camera_calibration.tsx
@@ -20,6 +20,7 @@ export class CameraCalibration extends
         <TitleBar
           title={"Camera Calibration"}
           help={t(ToolTips.CAMERA_CALIBRATION)}
+          docs={"farmware#section-weed-detector"}
           onCalibrate={this.props.dispatch(calibrate)}
           env={this.props.env} />
         <WidgetBody>

--- a/webpack/farmware/farmware_panel.tsx
+++ b/webpack/farmware/farmware_panel.tsx
@@ -15,6 +15,20 @@ import {
 } from "../ui";
 import { betterCompact } from "../util";
 import { FBSelect } from "../ui/new_fb_select";
+import { Popover, Position } from "@blueprintjs/core";
+
+export function FarmwareConfigMenu() {
+  return <div>
+    <fieldset>
+      <label>
+        {t("Install first-party farmwares")}
+      </label>
+      <button
+        className="fb-button gray fa fa-download"
+        onClick={getDevice().installFirstPartyFarmware} />
+    </fieldset>
+  </div>;
+}
 
 export class FarmwarePanel extends React.Component<FWProps, Partial<FWState>> {
   constructor() {
@@ -97,7 +111,14 @@ export class FarmwarePanel extends React.Component<FWProps, Partial<FWState>> {
   render() {
     return (
       <Widget className="farmware-widget">
-        <WidgetHeader title="Farmware" helpText={ToolTips.FARMWARE} />
+        <WidgetHeader
+          title="Farmware"
+          helpText={ToolTips.FARMWARE}>
+          <Popover position={Position.BOTTOM_RIGHT}>
+            <i className="fa fa-gear" />
+            <FarmwareConfigMenu />
+          </Popover>
+        </WidgetHeader>
         <WidgetBody>
           <MustBeOnline
             status={this.props.syncStatus}

--- a/webpack/farmware/weed_detector/index.tsx
+++ b/webpack/farmware/weed_detector/index.tsx
@@ -65,7 +65,8 @@ export class WeedDetector
         deletionProgress={this.state.deletionProgress}
         onTest={this.props.dispatch(test)}
         title={"Weed Detector"}
-        help={t(ToolTips.WEED_DETECTOR)} />
+        help={t(ToolTips.WEED_DETECTOR)}
+        docs={"farmware#section-camera-calibration"} />
       <WidgetBody>
         <Row>
           <Col sm={12}>

--- a/webpack/farmware/weed_detector/title.tsx
+++ b/webpack/farmware/weed_detector/title.tsx
@@ -17,6 +17,7 @@ interface Props {
   title: string;
   help: string;
   env?: Partial<WD_ENV>;
+  docs?: string;
 }
 
 export function TitleBar({
@@ -27,10 +28,11 @@ export function TitleBar({
   onCalibrate,
   env,
   title,
-  help
+  help,
+  docs
 }: Props) {
   return (
-    <WidgetHeader helpText={help} title={title}>
+    <WidgetHeader helpText={help} title={title} docPage={docs}>
       <button
         hidden={!onSave}
         onClick={onSave}

--- a/webpack/sequences/__tests__/sequence_editor_middle_active_test.tsx
+++ b/webpack/sequences/__tests__/sequence_editor_middle_active_test.tsx
@@ -65,7 +65,7 @@ describe("onDrop()", () => {
 
   it("step_splice", () => {
     const dispatch = jest.fn();
-    onDrop(dispatch, fakeSequence())(0, "");
+    onDrop(dispatch, fakeSequence())(0, "fakeUuid");
     dispatch.mock.calls[0][0](() => {
       return { value: 1, intent: "step_splice", draggerId: 2 };
     });
@@ -76,7 +76,7 @@ describe("onDrop()", () => {
 
   it("step_move", () => {
     const dispatch = jest.fn();
-    onDrop(dispatch, fakeSequence())(3, "");
+    onDrop(dispatch, fakeSequence())(3, "fakeUuid");
     dispatch.mock.calls[0][0](() => {
       return { value: 4, intent: "step_move", draggerId: 5 };
     });
@@ -84,5 +84,11 @@ describe("onDrop()", () => {
     expect(argsList.step).toEqual(4);
     expect(argsList.to).toEqual(3);
     expect(argsList.from).toEqual(5);
+  });
+
+  it("not a valid step object", () => {
+    const dispatch = jest.fn();
+    onDrop(dispatch, fakeSequence())(0, "");
+    expect(dispatch).not.toHaveBeenCalled();
   });
 });

--- a/webpack/ui/__tests__/widget_header_test.ts
+++ b/webpack/ui/__tests__/widget_header_test.ts
@@ -1,0 +1,40 @@
+import { WidgetHeader } from "../widget_header";
+import { mount } from "enzyme";
+
+describe("<WidgetHeader />", () => {
+  it("renders title", () => {
+    const wrapper = mount(WidgetHeader({
+      title: "fakeWidget"
+    }));
+    expect(wrapper.html()).toContain("fakeWidget");
+  });
+
+  it("renders children", () => {
+    const wrapper = mount(WidgetHeader({
+      title: "fakeWidget",
+      children: "children"
+    }));
+    expect(wrapper.html()).toContain("children");
+  });
+
+  it("renders helpText", () => {
+    const wrapper = mount(WidgetHeader({
+      title: "fakeWidget",
+      helpText: "fakeHelp"
+    }));
+    expect(wrapper.html()).toContain("fakeHelp");
+    expect(wrapper.html()).not.toContain("a href");
+  });
+
+  it("renders docs link", () => {
+    const wrapper = mount(WidgetHeader({
+      title: "fakeWidget",
+      helpText: "fakeHelp",
+      docPage: "farmware"
+    }));
+    expect(wrapper.html())
+      .toContain("https://software.farmbot.io/docs/farmware");
+    expect(wrapper.text()).toContain("Documentation");
+    expect(wrapper.html()).toContain("fa-external-link");
+  });
+});

--- a/webpack/ui/widget_header.tsx
+++ b/webpack/ui/widget_header.tsx
@@ -5,6 +5,7 @@ import { JSXChildren } from "../util";
 interface WidgetHeaderProps {
   children?: JSXChildren;
   helpText?: string;
+  docPage?: string;
   title: string;
 }
 
@@ -16,6 +17,13 @@ export function WidgetHeader(props: WidgetHeaderProps) {
       <i className="fa fa-question-circle help-icon">
         <div className="help-text">
           {props.helpText}
+          {props.docPage &&
+            <a
+              href={"https://software.farmbot.io/docs/" + props.docPage}
+              target="_blank">
+              {" " + t("Documentation")}
+              <i className="fa fa-external-link" />
+            </a>}
         </div>
       </i>
     }


### PR DESCRIPTION
**Sequences:**
 * Fix move step to end duplicate bug. (https://github.com/FarmBot/Farmbot-Web-App/issues/342)

**Farm Designer:**
 * Increase range of map zoom out (two additional levels).
 * Fix special tool graphic rendering on some devices.

**Device:**
 * Fix widget widths on mobile.

**Farm Events:**
 * Fix time input backgrounds on mobile.

**Farmware:**
 * Add gear menu with button to (re)install first-party farmwares.
 * Add links to software documentation in Weed Detector and Camera Calibration widget help text.