### PR TITLE
Enforce Node Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You will need the following:
  0. [Docker 17.06.0-ce or greater](https://docs.docker.com/engine/installation/)
  0. [Ruby 2.4.2](http://rvm.io/rvm/install)
  0. [ImageMagick](https://www.imagemagick.org/script/index.php) (`brew install imagemagick` (Mac) or `sudo apt-get install imagemagick` (Ubuntu))
- 0. [Node JS > v6](https://nodejs.org/en/download/)
+ 0. [Node JS >= v8.9.0](https://nodejs.org/en/download/)
  0. [`libpq-dev` and `postgresql`](http://stackoverflow.com/questions/6040583/cant-find-the-libpq-fe-h-header-when-trying-to-install-pg-gem/6040822#6040822) and `postgresql-contrib`
  0. `gem install bundler`
 

--- a/package.json
+++ b/package.json
@@ -132,6 +132,10 @@
       "html",
       "json",
       "lcov"
-    ]
+    ],
+    "engines": {
+      "node": ">=8.9.0"
+    },
+    "engineStrict": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -132,10 +132,9 @@
       "html",
       "json",
       "lcov"
-    ],
-    "engines": {
-      "node": ">=8.9.0"
-    },
-    "engineStrict": true
+    ]
+  },
+  "engines": {
+    "node": ">=8.9.0"
   }
 }


### PR DESCRIPTION
# What's New?

 * Some users were unable to run the applicatiion due to a lower than required node.js version.
 * Added `engines` to `package.json.
 * Updated `README`