### PR TITLE
RPi GPIO pin bindings widget

### DIFF
--- a/webpack/__tests__/controls_popup_test.tsx
+++ b/webpack/__tests__/controls_popup_test.tsx
@@ -9,7 +9,6 @@ jest.mock("../device", () => ({
 import * as React from "react";
 import { ControlsPopup } from "../controls_popup";
 import { mount } from "enzyme";
-import { getDevice } from "../device";
 
 describe("<ControlsPopup />", () => {
   beforeEach(function () {
@@ -31,31 +30,24 @@ describe("<ControlsPopup />", () => {
   });
 
   it("x axis is inverted", () => {
-    const { mock } = getDevice().moveRelative as jest.Mock<{}>;
     const button = wrapper.find("button").first();
     expect(button.props().title).toBe("move x axis");
     button.simulate("click");
-    const args = mock.calls[0][0];
-    expect(args.x).toBe(100);
-    expect(args.y).toBe(0);
-    expect(args.z).toBe(0);
+    expect(mockDevice.moveRelative)
+      .toHaveBeenCalledWith({ speed: 100, x: 100, y: 0, z: 0 });
   });
 
   it("y axis is not inverted", () => {
-    const { mock } = getDevice().moveRelative as jest.Mock<{}>;
     const button = wrapper.find("button").at(2);
     expect(button.props().title).toBe("move y axis");
     button.simulate("click");
-    const args = mock.calls[0][0];
-    expect(args.x).toBe(0);
-    expect(args.y).toBe(100);
-    expect(args.z).toBe(0);
+    expect(mockDevice.moveRelative)
+      .toHaveBeenCalledWith({ speed: 100, x: 0, y: 100, z: 0 });
   });
 
   it("disabled when closed", () => {
-    const { mock } = getDevice().moveRelative as jest.Mock<{}>;
     wrapper.setState({ isOpen: false });
     [0, 1, 2, 3].map((i) => wrapper.find("button").at(i).simulate("click"));
-    expect(mock.calls.length).toBe(0);
+    expect(mockDevice.moveRelative).not.toHaveBeenCalled();
   });
 });

--- a/webpack/__tests__/test_util.ts
+++ b/webpack/__tests__/test_util.ts
@@ -11,7 +11,10 @@ import {
   bitArray,
   withTimeout,
   minFwVersionCheck,
-  move
+  move,
+  shortRevision,
+  clampUnsignedInteger,
+  isUndefined
 } from "../util";
 describe("util", () => {
   describe("safeStringFetch", () => {
@@ -123,6 +126,9 @@ describe("util", () => {
 
       expect(semverCompare("1.1.9", "2.0.2"))
         .toBe(SemverResult.RIGHT_IS_GREATER);
+
+      expect(semverCompare("", "1.0.0"))
+        .toBe(SemverResult.RIGHT_IS_GREATER);
     });
 
     it("knows when LEFT_IS_GREATER", () => {
@@ -136,6 +142,9 @@ describe("util", () => {
         .toBe(SemverResult.LEFT_IS_GREATER);
 
       expect(semverCompare("2.0.2", "1.1.9"))
+        .toBe(SemverResult.LEFT_IS_GREATER);
+
+      expect(semverCompare("1.0.0", ""))
         .toBe(SemverResult.LEFT_IS_GREATER);
     });
   });
@@ -205,5 +214,46 @@ describe("move()", () => {
 
     const case3 = move(fixture, 0, 0);
     expect(case3).toEqual(fixture);
+  });
+});
+
+describe("shortRevision()", () => {
+  it("none", () => {
+    globalConfig.SHORT_REVISION = "";
+    const short = shortRevision();
+    expect(short).toEqual("NONE");
+  });
+
+  it("slices", () => {
+    globalConfig.SHORT_REVISION = "0123456789";
+    const short = shortRevision();
+    expect(short).toEqual("01234567");
+  });
+});
+
+describe("clampUnsignedInteger()", () => {
+  function clampTest(
+    input: string, output: number | undefined, message: string) {
+    it(message, () => {
+      const result = clampUnsignedInteger(input);
+      expect(result.outcome).toEqual(message);
+      expect(result.result).toEqual(output);
+    });
+  }
+  clampTest("nope", undefined, "malformed");
+  clampTest("100000", 32000, "high");
+  clampTest("-100000", 0, "low");
+  clampTest("1000", 1000, "ok");
+});
+
+describe("isUndefined()", () => {
+  it("undefined", () => {
+    const result = isUndefined(undefined);
+    expect(result).toBeTruthy();
+  });
+
+  it("defined", () => {
+    const result = isUndefined({});
+    expect(result).toBeFalsy();
   });
 });

--- a/webpack/account/__tests__/delete_account_test.tsx
+++ b/webpack/account/__tests__/delete_account_test.tsx
@@ -8,7 +8,7 @@ describe("<DeleteAccount/>", () => {
     const el = mount(<DeleteAccount onClick={fn} />);
     el.setState({ password: "123" });
     el.find("button.red").last().simulate("click");
-    expect(fn.mock.calls.length).toBe(1);
-    expect(fn.mock.calls[0][0]).toBe("123");
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith("123");
   });
 });

--- a/webpack/constants.ts
+++ b/webpack/constants.ts
@@ -35,6 +35,9 @@ export namespace ToolTips {
     unsupervised. Tip: Recalibrate FarmBot after changing settings and test a
     few sequences to verify that everything works as expected.`;
 
+  export const PIN_BINDINGS =
+    `Assign a sequence to execute when a Raspberry Pi GPIO pin is activated.`;
+
   // Hardware Settings: Homing and Calibration
   export const HOMING =
     `(Alpha) If encoders or end-stops are enabled, home axis (find zero).`;

--- a/webpack/controls/__tests__/direction_button_test.tsx
+++ b/webpack/controls/__tests__/direction_button_test.tsx
@@ -12,7 +12,6 @@ import * as React from "react";
 import { mount } from "enzyme";
 import { DirectionButton } from "../direction_button";
 import { DirectionButtonProps } from "../interfaces";
-import { getDevice } from "../../device";
 
 describe("<DirectionButton/>", function () {
   beforeEach(function () {
@@ -28,27 +27,22 @@ describe("<DirectionButton/>", function () {
   };
 
   it("calls move command", () => {
-    const { mock } = getDevice().moveRelative as jest.Mock<{}>;
     const btn = mount(<DirectionButton {...buttonProps} />);
     btn.simulate("click");
-    expect(mock.calls.length).toEqual(1);
+    expect(mockDevice.moveRelative).toHaveBeenCalledTimes(1);
   });
 
   it("is disabled", () => {
-    const { mock } = getDevice().moveRelative as jest.Mock<{}>;
     buttonProps.disabled = true;
     const btn = mount(<DirectionButton {...buttonProps} />);
     btn.simulate("click");
-    expect(mock.calls.length).toEqual(0);
+    expect(mockDevice.moveRelative).not.toHaveBeenCalled();
   });
 
   it("call has correct args", () => {
-    const { mock } = getDevice().moveRelative as jest.Mock<{}>;
     const btn = mount(<DirectionButton {...buttonProps} />);
     btn.simulate("click");
-    const argList = mock.calls[0][0];
-    expect(argList.x).toEqual(0);
-    expect(argList.y).toEqual(-1000);
-    expect(argList.z).toEqual(0);
+    expect(mockDevice.moveRelative)
+      .toHaveBeenCalledWith({ speed: 100, x: 0, y: -1000, z: 0 });
   });
 });

--- a/webpack/controls/__tests__/jog_buttons_test.tsx
+++ b/webpack/controls/__tests__/jog_buttons_test.tsx
@@ -13,7 +13,6 @@ import * as React from "react";
 import { mount } from "enzyme";
 import { JogButtons } from "../jog_buttons";
 import { JogMovementControlsProps } from "../interfaces";
-import { getDevice } from "../../device";
 import { bot } from "../../__test_support__/fake_state/bot";
 
 describe("<JogButtons/>", function () {
@@ -30,33 +29,28 @@ describe("<JogButtons/>", function () {
   };
 
   it("calls home command", () => {
-    const { mock } = getDevice().home as jest.Mock<{}>;
     const jogButtons = mount(<JogButtons {...jogButtonProps} />);
     jogButtons.find("button").at(3).simulate("click");
-    expect(mock.calls.length).toEqual(1);
+    expect(mockDevice.home).toHaveBeenCalledTimes(1);
   });
 
   it("is disabled", () => {
-    const { mock } = getDevice().home as jest.Mock<{}>;
     jogButtonProps.disabled = true;
     const jogButtons = mount(<JogButtons {...jogButtonProps} />);
     jogButtons.find("button").at(3).simulate("click");
-    expect(mock.calls.length).toEqual(0);
+    expect(mockDevice.home).not.toHaveBeenCalled();
   });
 
   it("call has correct args", () => {
-    const { mock } = getDevice().home as jest.Mock<{}>;
     const jogButtons = mount(<JogButtons {...jogButtonProps} />);
     jogButtons.find("button").at(3).simulate("click");
-    const argList = mock.calls[0][0];
-    expect(argList.axis).toEqual("all");
-    expect(argList.speed).toEqual(100);
+    expect(mockDevice.home)
+      .toHaveBeenCalledWith({ axis: "all", speed: 100 });
   });
 
   it("takes photo", () => {
-    const takePhoto = getDevice().takePhoto as jest.Mock<{}>;
     const jogButtons = mount(<JogButtons {...jogButtonProps} />);
     jogButtons.find("button").at(0).simulate("click");
-    expect(takePhoto).toHaveBeenCalled();
+    expect(mockDevice.takePhoto).toHaveBeenCalled();
   });
 });

--- a/webpack/controls/peripherals/__tests__/peripheral_list_test.tsx
+++ b/webpack/controls/peripherals/__tests__/peripheral_list_test.tsx
@@ -10,7 +10,6 @@ import { mount } from "enzyme";
 import { PeripheralList } from "../peripheral_list";
 import { TaggedPeripheral, SpecialStatus } from "../../../resources/tagged_resources";
 import { Pins } from "farmbot/dist";
-import { getDevice } from "../../../device";
 
 describe("<PeripheralList/>", function () {
   beforeEach(function () {
@@ -72,22 +71,19 @@ describe("<PeripheralList/>", function () {
   });
 
   it("toggles pins", () => {
-    const { mock } = getDevice().togglePin as jest.Mock<{}>;
     const wrapper = mount(<PeripheralList dispatch={() => { }}
       peripherals={peripherals}
       pins={pins}
       disabled={false} />);
     const toggle = wrapper.find("ToggleButton");
     toggle.first().simulate("click");
-    expect(mock.calls.length).toEqual(1);
-    expect(mock.calls[0][0].pin_number).toEqual(2);
+    expect(mockDevice.togglePin).toHaveBeenCalledWith({ pin_number: 2 });
     toggle.last().simulate("click");
-    expect(mock.calls.length).toEqual(2);
-    expect(mock.calls[1][0].pin_number).toEqual(13);
+    expect(mockDevice.togglePin).toHaveBeenLastCalledWith({ pin_number: 13 });
+    expect(mockDevice.togglePin).toHaveBeenCalledTimes(2);
   });
 
   it("pins toggles are disabled", () => {
-    const { mock } = getDevice().togglePin as jest.Mock<{}>;
     const wrapper = mount(<PeripheralList dispatch={() => { }}
       peripherals={peripherals}
       pins={pins}
@@ -95,6 +91,6 @@ describe("<PeripheralList/>", function () {
     const toggle = wrapper.find("ToggleButton");
     toggle.first().simulate("click");
     toggle.last().simulate("click");
-    expect(mock.calls.length).toEqual(0);
+    expect(mockDevice.togglePin).not.toHaveBeenCalled();
   });
 });

--- a/webpack/devices/__tests__/devices_test.tsx
+++ b/webpack/devices/__tests__/devices_test.tsx
@@ -8,7 +8,9 @@ import { Devices } from "../devices";
 import { Props } from "../interfaces";
 import { auth } from "../../__test_support__/fake_state/token";
 import { bot } from "../../__test_support__/fake_state/bot";
-import { fakeDevice } from "../../__test_support__/resource_index_builder";
+import {
+  fakeDevice, buildResourceIndex, FAKE_RESOURCES
+} from "../../__test_support__/resource_index_builder";
 import { FarmbotOsSettings } from "../components/farmbot_os_settings";
 
 describe("<Devices/>", () => {
@@ -20,7 +22,8 @@ describe("<Devices/>", () => {
     bot: bot,
     deviceAccount: fakeDevice(),
     images: [],
-    dispatch: jest.fn()
+    dispatch: jest.fn(),
+    resources: buildResourceIndex(FAKE_RESOURCES).index
   });
 
   it("renders relevant panels", () => {

--- a/webpack/devices/actions.ts
+++ b/webpack/devices/actions.ts
@@ -277,6 +277,27 @@ export function updateConfig(config: Configuration) {
   };
 }
 
+export function registerGpioPin(
+  pinBinding: { pin_number: number, sequence_id: number }) {
+  const noun = "Register GPIO Pin";
+  return function (dispatch: Function) {
+    getDevice()
+      .registerGpio(pinBinding)
+      .then(() => updateOK(dispatch, noun))
+      .catch(() => updateNO(dispatch, noun));
+  };
+}
+
+export function unregisterGpioPin(pin_number: number) {
+  const noun = "Unregister GPIO Pin";
+  return function (dispatch: Function) {
+    getDevice()
+      .unregisterGpio({ pin_number })
+      .then(() => updateOK(dispatch, noun))
+      .catch(() => updateNO(dispatch, noun));
+  };
+}
+
 export function changeStepSize(integer: number) {
   return {
     type: Actions.CHANGE_STEP_SIZE,

--- a/webpack/devices/components/__tests__/calibration_row_test.tsx
+++ b/webpack/devices/components/__tests__/calibration_row_test.tsx
@@ -8,20 +8,16 @@ import * as React from "react";
 import { mount } from "enzyme";
 import { CalibrationRow } from "../calibration_row";
 import { bot } from "../../../__test_support__/fake_state/bot";
-import { getDevice } from "../../../device";
 
 describe("<HomingRow />", () => {
   beforeEach(function () {
     jest.clearAllMocks();
   });
   it("calls device", () => {
-    const { mock } = getDevice().calibrate as jest.Mock<{}>;
     const result = mount(<CalibrationRow hardware={bot.hardware.mcu_params} />);
-    result.find("LockableButton").at(0).simulate("click");
-    result.find("LockableButton").at(1).simulate("click");
-    result.find("LockableButton").at(2).simulate("click");
-    expect(mock.calls.length).toEqual(2);
-    expect(mock.calls[0][0].axis).toEqual("x");
-    expect(mock.calls[1][0].axis).toEqual("y");
+    [0, 1, 2].map(i => result.find("LockableButton").at(i).simulate("click"));
+    expect(mockDevice.calibrate).toHaveBeenCalledTimes(2);
+    [{ axis: "y" }, { axis: "x" }].map(x =>
+      expect(mockDevice.calibrate).toHaveBeenCalledWith(x));
   });
 });

--- a/webpack/devices/components/__tests__/camera_selection_test.tsx
+++ b/webpack/devices/components/__tests__/camera_selection_test.tsx
@@ -10,7 +10,6 @@ jest.mock("farmbot-toastr", () => ({ info: mockInfo, error: mockError }));
 
 import * as React from "react";
 import { mount, shallow } from "enzyme";
-import { getDevice } from "../../../device";
 import { CameraSelection } from "../camera_selection";
 
 describe("<CameraSelection/>", () => {
@@ -31,12 +30,12 @@ describe("<CameraSelection/>", () => {
   });
 
   it("changes camera", () => {
-    const { mock } = getDevice().setUserEnv as jest.Mock<{}>;
-    const cameraSelection = shallow(<CameraSelection
-      env={{}} />);
+    const cameraSelection = shallow(<CameraSelection env={{}} />);
     cameraSelection.find("FBSelect")
       .simulate("change", { label: "My Camera", value: "mycamera" });
-    expect(mockInfo.mock.calls[0][0]).toEqual("Sending camera configuration...");
-    expect(mock.calls[0][0]).toEqual({ "camera": "\"mycamera\"" });
+    expect(mockInfo)
+      .toHaveBeenCalledWith("Sending camera configuration...", "Sending");
+    expect(mockDevice.setUserEnv)
+      .toHaveBeenCalledWith({ camera: "\"mycamera\"" });
   });
 });

--- a/webpack/devices/components/__tests__/homing_row_test.tsx
+++ b/webpack/devices/components/__tests__/homing_row_test.tsx
@@ -9,7 +9,6 @@ import * as React from "react";
 import { mount } from "enzyme";
 import { HomingRow } from "../homing_row";
 import { bot } from "../../../__test_support__/fake_state/bot";
-import { getDevice } from "../../../device";
 
 describe("<HomingRow />", () => {
   beforeEach(function () {
@@ -26,13 +25,10 @@ describe("<HomingRow />", () => {
     });
   });
   it("calls device", () => {
-    const { mock } = getDevice().findHome as jest.Mock<{}>;
     const result = mount(<HomingRow hardware={bot.hardware.mcu_params} />);
-    result.find("LockableButton").at(0).simulate("click");
-    result.find("LockableButton").at(1).simulate("click");
-    result.find("LockableButton").at(2).simulate("click");
-    expect(mock.calls.length).toEqual(2);
-    expect(mock.calls[0][0].axis).toEqual("x");
-    expect(mock.calls[1][0].axis).toEqual("y");
+    [0, 1, 2].map(i =>
+      result.find("LockableButton").at(i).simulate("click"));
+    [{ axis: "x", speed: 100 }, { axis: "y", speed: 100 }].map(x =>
+      expect(mockDevice.findHome).toHaveBeenCalledWith(x));
   });
 });

--- a/webpack/devices/components/__tests__/os_update_button_test.tsx
+++ b/webpack/devices/components/__tests__/os_update_button_test.tsx
@@ -10,7 +10,6 @@ jest.mock("farmbot-toastr", () => ({ success: mockOk }));
 import * as React from "react";
 import { mount } from "enzyme";
 import { bot } from "../../../__test_support__/fake_state/bot";
-import { getDevice } from "../../../device";
 import { OsUpdateButton } from "../fbos_settings/os_update_button";
 
 describe("<OsUpdateButton/>", () => {
@@ -39,30 +38,24 @@ describe("<OsUpdateButton/>", () => {
     expect(osUpdateButton.text()).toBe("UPDATE");
   });
   it("calls checkUpdates", () => {
-    const { mock } = getDevice().checkUpdates as jest.Mock<{}>;
     const buttons = mount(<OsUpdateButton bot={bot} />);
     const osUpdateButton = buttons.find("button").last();
     osUpdateButton.simulate("click");
-    expect(mock.calls.length).toEqual(1);
+    expect(mockDevice.checkUpdates).toHaveBeenCalledTimes(1);
   });
-  it("shows update progress: bytes", () => {
-    bot.hardware.jobs = { "FBOS_OTA": { status: "working", bytes: 300, unit: "bytes" } };
-    const buttons = mount(<OsUpdateButton bot={bot} />);
-    const osUpdateButton = buttons.find("button").last();
-    expect(osUpdateButton.text()).toBe("300B");
-  });
-  it("shows update progress: kilobytes", () => {
-    bot.hardware.jobs = { "FBOS_OTA": { status: "working", bytes: 30000, unit: "bytes" } };
-    const buttons = mount(<OsUpdateButton bot={bot} />);
-    const osUpdateButton = buttons.find("button").last();
-    expect(osUpdateButton.text()).toBe("29kB");
-  });
-  it("shows update progress: megabytes", () => {
-    bot.hardware.jobs = { "FBOS_OTA": { status: "working", bytes: 3e6, unit: "bytes" } };
-    const buttons = mount(<OsUpdateButton bot={bot} />);
-    const osUpdateButton = buttons.find("button").last();
-    expect(osUpdateButton.text()).toBe("3MB");
-  });
+
+  function bytesProgressTest(unit: string, progress: number, text: string) {
+    it(`shows update progress: ${unit}`, () => {
+      bot.hardware.jobs = { "FBOS_OTA": { status: "working", bytes: progress, unit: "bytes" } };
+      const buttons = mount(<OsUpdateButton bot={bot} />);
+      const osUpdateButton = buttons.find("button").last();
+      expect(osUpdateButton.text()).toBe(text);
+    });
+  }
+  bytesProgressTest("bytes", 300, "300B");
+  bytesProgressTest("kilobytes", 30000, "29kB");
+  bytesProgressTest("megabytes", 3e6, "3MB");
+
   it("shows update progress: percent", () => {
     bot.hardware.jobs = { "FBOS_OTA": { status: "working", percent: 10, unit: "percent" } };
     const buttons = mount(<OsUpdateButton bot={bot} />);
@@ -84,11 +77,10 @@ describe("<OsUpdateButton/>", () => {
     expect(osUpdateButton.text()).toBe("UPDATE");
   });
   it("is disabled", () => {
-    const { mock } = getDevice().checkUpdates as jest.Mock<{}>;
     bot.hardware.jobs = { "FBOS_OTA": { status: "working", percent: 10, unit: "percent" } };
     const buttons = mount(<OsUpdateButton bot={bot} />);
     const osUpdateButton = buttons.find("button").last();
     osUpdateButton.simulate("click");
-    expect(mock.calls.length).toEqual(0);
+    expect(mockDevice.checkUpdates).not.toHaveBeenCalled();
   });
 });

--- a/webpack/devices/components/__tests__/pin_bindings_test.tsx
+++ b/webpack/devices/components/__tests__/pin_bindings_test.tsx
@@ -1,0 +1,81 @@
+const mockDevice = {
+  registerGpio: jest.fn(() => { return Promise.resolve(); }),
+  unregisterGpio: jest.fn(() => { return Promise.resolve(); }),
+};
+jest.mock("../../../device", () => ({
+  getDevice: () => (mockDevice)
+}));
+
+import * as React from "react";
+import { PinBindings, PinBindingsProps } from "../pin_bindings";
+import { mount } from "enzyme";
+import { bot } from "../../../__test_support__/fake_state/bot";
+import {
+  buildResourceIndex
+} from "../../../__test_support__/resource_index_builder";
+import { TaggedSequence } from "../../../resources/tagged_resources";
+import { fakeSequence } from "../../../__test_support__/fake_state/resources";
+
+describe("<PinBindings/>", () => {
+  beforeEach(function () {
+    jest.clearAllMocks();
+  });
+
+  function fakeProps(): PinBindingsProps {
+    const fakeResources: TaggedSequence[] = [fakeSequence(), fakeSequence()];
+    fakeResources[0].body.id = 1;
+    fakeResources[0].body.name = "Sequence 1";
+    fakeResources[1].body.id = 2;
+    fakeResources[1].body.name = "Sequence 2";
+    const resources = buildResourceIndex(fakeResources).index;
+
+    bot.hardware.gpio_registry = {
+      10: "1",
+      11: "2"
+    };
+    return {
+      dispatch: jest.fn(),
+      bot: bot,
+      resources: resources
+    };
+  }
+
+  it("renders", () => {
+    const wrapper = mount(<PinBindings {...fakeProps() } />);
+    ["pin bindings", "pin number", "none", "bind"].map(string =>
+      expect(wrapper.text().toLowerCase()).toContain(string));
+    ["pi gpio 10", "sequence 1", "pi gpio 11", "sequence 2"].map(string =>
+      expect(wrapper.text().toLowerCase()).toContain(string));
+    expect(wrapper.find("input").length).toBe(1);
+    const buttons = wrapper.find("button");
+    expect(buttons.length).toBe(4);
+  });
+
+  it("unregisters pin", () => {
+    const dispatch = jest.fn();
+    const p = fakeProps();
+    p.dispatch = dispatch;
+    const wrapper = mount(<PinBindings {...p} />);
+    const buttons = wrapper.find("button");
+    buttons.first().simulate("click");
+    dispatch.mock.calls[0][0](jest.fn());
+    expect(mockDevice.unregisterGpio).toHaveBeenCalledWith({
+      pin_number: 10
+    });
+  });
+
+  it("registers pin", () => {
+    const dispatch = jest.fn();
+    const p = fakeProps();
+    p.dispatch = dispatch;
+    const wrapper = mount(<PinBindings {...p} />);
+    const buttons = wrapper.find("button");
+    expect(buttons.last().text()).toEqual("BIND");
+    wrapper.setState({ pinNumberInput: 1, sequenceIdInput: 2 });
+    buttons.last().simulate("click");
+    dispatch.mock.calls[0][0](dispatch);
+    expect(mockDevice.registerGpio).toHaveBeenCalledWith({
+      pin_number: 1, sequence_id: 2
+    });
+  });
+});

--- a/webpack/devices/components/__tests__/pin_bindings_test.tsx
+++ b/webpack/devices/components/__tests__/pin_bindings_test.tsx
@@ -73,7 +73,7 @@ describe("<PinBindings/>", () => {
     expect(buttons.last().text()).toEqual("BIND");
     wrapper.setState({ pinNumberInput: 1, sequenceIdInput: 2 });
     buttons.last().simulate("click");
-    dispatch.mock.calls[0][0](dispatch);
+    dispatch.mock.calls[0][0](jest.fn());
     expect(mockDevice.registerGpio).toHaveBeenCalledWith({
       pin_number: 1, sequence_id: 2
     });

--- a/webpack/devices/components/__tests__/zero_row_test.tsx
+++ b/webpack/devices/components/__tests__/zero_row_test.tsx
@@ -7,21 +7,16 @@ jest.mock("../../../device", () => ({
 import * as React from "react";
 import { mount } from "enzyme";
 import { ZeroRow } from "../zero_row";
-import { getDevice } from "../../../device";
 
 describe("<HomingRow />", () => {
   beforeEach(function () {
     jest.clearAllMocks();
   });
   it("calls device", () => {
-    const { mock } = getDevice().setZero as jest.Mock<{}>;
     const result = mount(<ZeroRow />);
-    result.find("ZeroButton").at(0).simulate("click");
-    result.find("ZeroButton").at(1).simulate("click");
-    result.find("ZeroButton").at(2).simulate("click");
-    expect(mock.calls.length).toEqual(3);
-    expect(mock.calls[0][0]).toEqual("x");
-    expect(mock.calls[1][0]).toEqual("y");
-    expect(mock.calls[2][0]).toEqual("z");
+    [0, 1, 2].map(i => result.find("ZeroButton").at(i).simulate("click"));
+    ["x", "y", "z"].map(x =>
+      expect(mockDevice.setZero).toHaveBeenCalledWith(x));
+    expect(mockDevice.setZero).toHaveBeenCalledTimes(3);
   });
 });

--- a/webpack/devices/components/pin_bindings.tsx
+++ b/webpack/devices/components/pin_bindings.tsx
@@ -1,0 +1,177 @@
+import * as React from "react";
+import { t } from "i18next";
+import * as _ from "lodash";
+import {
+  Widget, WidgetBody, WidgetHeader, Row, Col, BlurableInput, DropDownItem
+} from "../../ui/index";
+import { FBSelect } from "../../ui/new_fb_select";
+import { ToolTips } from "../../constants";
+import { BotState } from "../interfaces";
+import { registerGpioPin, unregisterGpioPin } from "../actions";
+import {
+  selectAllSequences, findSequenceById
+} from "../../resources/selectors";
+import { ResourceIndex } from "../../resources/interfaces";
+import { MustBeOnline } from "../must_be_online";
+
+export interface PinBindingsProps {
+  bot: BotState;
+  dispatch: Function;
+  resources: ResourceIndex;
+}
+
+export interface PinBindingsState {
+  isEditing: boolean;
+  pinNumberInput: number | undefined;
+  sequenceIdInput: number | undefined;
+}
+
+enum ColumnWidth {
+  pin = 4,
+  sequence = 7,
+  button = 1
+}
+
+export class PinBindings
+  extends React.Component<PinBindingsProps, PinBindingsState> {
+  constructor() {
+    super();
+    this.state = {
+      isEditing: false,
+      pinNumberInput: undefined,
+      sequenceIdInput: undefined
+    };
+  }
+
+  changeSelection = (input: DropDownItem) => {
+    this.setState({ sequenceIdInput: parseInt(input.value as string) });
+  }
+
+  sequenceDropDownList = () => {
+    const { resources } = this.props;
+    const dropDownList: DropDownItem[] = [];
+    selectAllSequences(resources)
+      .map(sequence => {
+        const { id, name } = sequence.body;
+        if (_.isNumber(id)) {
+          dropDownList.push({ label: name, value: id });
+        }
+      });
+    return dropDownList;
+  }
+
+  selectedSequence = () => {
+    const { resources } = this.props;
+    const { sequenceIdInput } = this.state;
+    if (sequenceIdInput) {
+      const { id, name } = findSequenceById(resources, sequenceIdInput).body;
+      return { label: name, value: (id as number) };
+    } else {
+      return undefined;
+    }
+  }
+
+  bindPin = () => {
+    const { pinNumberInput, sequenceIdInput } = this.state;
+    if (pinNumberInput && sequenceIdInput) {
+      this.props.dispatch(registerGpioPin({
+        pin_number: pinNumberInput,
+        sequence_id: sequenceIdInput
+      }));
+      this.setState({
+        pinNumberInput: undefined,
+        sequenceIdInput: undefined
+      });
+    }
+  }
+
+  currentBindingsList = () => {
+    const { bot, dispatch, resources } = this.props;
+    const { gpio_registry } = bot.hardware;
+    return <div style={{ marginBottom: "1rem" }}>
+      {gpio_registry &&
+        Object.entries(gpio_registry)
+          .map(([pin_number, sequence_id]) => {
+            return <Row key={`pin_${pin_number}_binding`}>
+              <Col xs={ColumnWidth.pin}>
+                {`Pi GPIO ${pin_number}`}
+              </Col>
+              <Col xs={ColumnWidth.sequence}>
+                {findSequenceById(
+                  resources, parseInt(sequence_id)).body.name}
+              </Col>
+              <Col xs={ColumnWidth.button}>
+                <button
+                  className="fb-button red"
+                  onClick={() => {
+                    dispatch(unregisterGpioPin(parseInt(pin_number)));
+                  }}>
+                  <i className="fa fa-minus" />
+                </button>
+              </Col>
+            </Row>;
+          })}
+    </div>;
+  }
+
+  pinBindingInputGroup = () => {
+    const { pinNumberInput, sequenceIdInput } = this.state;
+    return <Row>
+      <Col xs={ColumnWidth.pin}>
+        <BlurableInput
+          onCommit={(e) => this.setState({
+            pinNumberInput: parseInt(e.currentTarget.value)
+          })}
+          name="pin_number"
+          value={pinNumberInput || ""}
+          type="number" />
+      </Col>
+      <Col xs={ColumnWidth.sequence}>
+        <FBSelect
+          key={sequenceIdInput}
+          onChange={this.changeSelection}
+          selectedItem={this.selectedSequence()}
+          list={this.sequenceDropDownList()} />
+      </Col>
+      <Col xs={ColumnWidth.button}>
+        <button
+          className="fb-button green"
+          type="button"
+          onClick={() => { this.bindPin(); }}
+          style={{ marginTop: "0.5rem" }}>
+          {t("BIND")}
+        </button>
+      </Col>
+    </Row>;
+  }
+
+  render() {
+    const syncStatus = this.props.bot.hardware
+      .informational_settings.sync_status || "unknown";
+    return <Widget className="pin-bindings-widget">
+      <WidgetHeader
+        title={"Pin Bindings"}
+        helpText={ToolTips.PIN_BINDINGS} />
+      <WidgetBody>
+        <MustBeOnline
+          status={syncStatus}
+          lockOpen={process.env.NODE_ENV !== "production"}>
+          <Row>
+            <Col xs={ColumnWidth.pin}>
+              <label>
+                {t("Pin Number")}
+              </label>
+            </Col>
+            <Col xs={ColumnWidth.sequence}>
+              <label>
+                {t("Sequence")}
+              </label>
+            </Col>
+          </Row>
+          <this.currentBindingsList />
+          <this.pinBindingInputGroup />
+        </MustBeOnline>
+      </WidgetBody>
+    </Widget>;
+  }
+}

--- a/webpack/devices/devices.tsx
+++ b/webpack/devices/devices.tsx
@@ -12,6 +12,7 @@ import {
 import { Diagnosis, DiagnosisName } from "./connectivity/diagnosis";
 import { StatusRowProps } from "./connectivity/connectivity_row";
 import { resetConnectionInfo } from "./actions";
+import { PinBindings } from "./components/pin_bindings";
 
 @connect(mapStateToProps)
 export class Devices extends React.Component<Props, {}> {
@@ -73,6 +74,11 @@ export class Devices extends React.Component<Props, {}> {
               controlPanelState={this.props.bot.controlPanelState}
               dispatch={this.props.dispatch}
               bot={this.props.bot} />
+            {this.props.bot.hardware.gpio_registry &&
+              <PinBindings
+                dispatch={this.props.dispatch}
+                bot={this.props.bot}
+                resources={this.props.resources} />}
           </Col>
         </Row>
       </Page>;

--- a/webpack/devices/interfaces.ts
+++ b/webpack/devices/interfaces.ts
@@ -13,7 +13,7 @@ import {
   TaggedPeripheral,
   TaggedDevice
 } from "../resources/tagged_resources";
-import { RestResources } from "../resources/interfaces";
+import { RestResources, ResourceIndex } from "../resources/interfaces";
 import { TaggedUser } from "../resources/tagged_resources";
 import { WD_ENV } from "../farmware/weed_detector/remote_env/interfaces";
 import { EncoderDisplay } from "../controls/interfaces";
@@ -28,6 +28,7 @@ export interface Props {
   deviceAccount: TaggedDevice;
   images: TaggedImage[];
   dispatch: Function;
+  resources: ResourceIndex;
 }
 
 /** How the device is stored in the API side.

--- a/webpack/devices/state_to_props.ts
+++ b/webpack/devices/state_to_props.ts
@@ -14,6 +14,7 @@ export function mapStateToProps(props: Everything): Props {
     auth: props.auth,
     bot: props.bot,
     dispatch: props.dispatch,
-    images: selectAllImages(props.resources.index)
+    images: selectAllImages(props.resources.index),
+    resources: props.resources.index,
   };
 }

--- a/webpack/farm_designer/__tests__/actions_test.ts
+++ b/webpack/farm_designer/__tests__/actions_test.ts
@@ -12,54 +12,28 @@ describe("movePlant", () => {
     jest.clearAllMocks();
   });
 
-  it("updates plant", () => {
-    const payload: MovePlantProps = {
-      deltaX: 1,
-      deltaY: 2,
-      plant: fakePlant(),
-      gridSize: { x: 3000, y: 1500 }
-    };
-    const { mock } = edit as jest.Mock<{}>;
-    movePlant(payload);
-    const oldPlant = mock.calls[0][0];
-    expect(oldPlant.body.x).toBe(100);
-    expect(oldPlant.body.y).toBe(200);
-    const update = mock.calls[0][1];
-    expect(update.x).toBe(101);
-    expect(update.y).toBe(202);
-  });
-
-  it("restricts plant to grid area: high", () => {
-    const payload: MovePlantProps = {
-      deltaX: 10000,
-      deltaY: 10000,
-      plant: fakePlant(),
-      gridSize: { x: 3000, y: 1500 }
-    };
-    const { mock } = edit as jest.Mock<{}>;
-    movePlant(payload);
-    const oldPlant = mock.calls[0][0];
-    expect(oldPlant.body.x).toBe(100);
-    expect(oldPlant.body.y).toBe(200);
-    const update = mock.calls[0][1];
-    expect(update.x).toBe(3000);
-    expect(update.y).toBe(1500);
-  });
-
-  it("restricts plant to grid area: low", () => {
-    const payload: MovePlantProps = {
-      deltaX: -10000,
-      deltaY: -10000,
-      plant: fakePlant(),
-      gridSize: { x: 3000, y: 1500 }
-    };
-    const { mock } = edit as jest.Mock<{}>;
-    movePlant(payload);
-    const oldPlant = mock.calls[0][0];
-    expect(oldPlant.body.x).toBe(100);
-    expect(oldPlant.body.y).toBe(200);
-    const update = mock.calls[0][1];
-    expect(update.x).toBe(0);
-    expect(update.y).toBe(0);
-  });
+  function movePlantTest(
+    caseDescription: string,
+    attempted: { x: number, y: number },
+    expected: { x: number, y: number }) {
+    it(`restricts plant to grid area: ${caseDescription}`, () => {
+      const payload: MovePlantProps = {
+        deltaX: attempted.x,
+        deltaY: attempted.y,
+        plant: fakePlant(),
+        gridSize: { x: 3000, y: 1500 }
+      };
+      movePlant(payload);
+      const [argList] = (edit as jest.Mock<{}>).mock.calls;
+      const oldPlant = argList[0];
+      expect(oldPlant.body.x).toBe(100);
+      expect(oldPlant.body.y).toBe(200);
+      const update = argList[1];
+      expect(update.x).toBe(expected.x);
+      expect(update.y).toBe(expected.y);
+    });
+  }
+  movePlantTest("within bounds", { x: 1, y: 2 }, { x: 101, y: 202 });
+  movePlantTest("too high", { x: 10000, y: 10000 }, { x: 3000, y: 1500 });
+  movePlantTest("too low", { x: -10000, y: -10000 }, { x: 0, y: 0 });
 });

--- a/webpack/farmware/__tests__/farmware_panel_test.tsx
+++ b/webpack/farmware/__tests__/farmware_panel_test.tsx
@@ -18,7 +18,6 @@ jest.mock("../actions", () => ({
 
 import * as React from "react";
 import { mount, shallow } from "enzyme";
-import { getDevice } from "../../device";
 import { FarmwarePanel, FarmwareConfigMenu } from "../farmware_panel";
 import { FWProps, FarmwareConfigMenuProps } from "../interfaces";
 import { fakeFarmwares } from "../../__test_support__/fake_farmwares";
@@ -36,69 +35,61 @@ describe("<FarmwarePanel/>: actions", () => {
   }
 
   it("calls install", () => {
-    const { mock } = getDevice().installFarmware as jest.Mock<{}>;
     const panel = mount(<FarmwarePanel {...fakeProps() } />);
     const buttons = panel.find("button");
     expect(buttons.at(0).text()).toEqual("Install");
     panel.setState({ packageUrl: "install this" });
     buttons.at(0).simulate("click");
-    expect(mock.calls.length).toEqual(1);
-    expect(mock.calls[0][0]).toEqual("install this");
+    expect(mockDevice.installFarmware).toHaveBeenCalledWith("install this");
   });
 
   it("farmware not selected", () => {
-    const updateFarmware = getDevice().updateFarmware;
     const panel = mount(<FarmwarePanel {...fakeProps() } />);
     panel.setState({ selectedFarmware: undefined });
     const updateBtn = panel.find("button").at(3);
     expect(updateBtn.text()).toEqual("Update");
     updateBtn.simulate("click");
-    expect(updateFarmware).not.toHaveBeenCalled();
+    expect(mockDevice.updateFarmware).not.toHaveBeenCalled();
     const installBtn = panel.find("button").at(0);
     expect(installBtn.text()).toEqual("Install");
     installBtn.simulate("click");
-    expect(updateFarmware).not.toHaveBeenCalled();
+    expect(mockDevice.installFarmware).not.toHaveBeenCalled();
   });
 
   it("calls update", () => {
-    const { mock } = getDevice().updateFarmware as jest.Mock<{}>;
     const panel = mount(<FarmwarePanel {...fakeProps() } />);
     const buttons = panel.find("button");
     expect(buttons.at(3).text()).toEqual("Update");
     panel.setState({ selectedFarmware: "update this" });
     buttons.at(3).simulate("click");
-    expect(mock.calls.length).toEqual(1);
-    expect(mock.calls[0][0]).toEqual("update this");
+    expect(mockDevice.updateFarmware).toHaveBeenCalledWith("update this");
   });
 
   it("calls remove", () => {
-    const removeFarmware = getDevice().removeFarmware;
     const panel = mount(<FarmwarePanel {...fakeProps() } />);
     const removeBtn = panel.find("button").at(2);
     expect(removeBtn.text()).toEqual("Remove");
     panel.setState({ selectedFarmware: "remove this" });
     removeBtn.simulate("click");
-    expect(removeFarmware).toHaveBeenCalledTimes(1);
-    expect(removeFarmware).toHaveBeenCalledWith("remove this");
+    expect(mockDevice.removeFarmware).toHaveBeenCalledTimes(1);
+    expect(mockDevice.removeFarmware).toHaveBeenCalledWith("remove this");
     panel.setState({ selectedFarmware: "first-party farmware" });
     removeBtn.simulate("click");
-    expect(removeFarmware).toHaveBeenCalledTimes(1);
+    expect(mockDevice.removeFarmware).toHaveBeenCalledTimes(1);
     // tslint:disable-next-line:no-any
     (global as any).confirm = () => true;
     removeBtn.simulate("click");
-    expect(removeFarmware).toHaveBeenCalledTimes(2);
-    expect(removeFarmware).toHaveBeenLastCalledWith("first-party farmware");
+    expect(mockDevice.removeFarmware).toHaveBeenCalledTimes(2);
+    expect(mockDevice.removeFarmware).toHaveBeenLastCalledWith("first-party farmware");
   });
 
   it("calls run", () => {
-    const { mock } = getDevice().execScript as jest.Mock<{}>;
     const panel = mount(<FarmwarePanel {...fakeProps() } />);
     const buttons = panel.find("button");
     expect(buttons.at(4).text()).toEqual("Run");
     panel.setState({ selectedFarmware: "run this" });
     buttons.at(4).simulate("click");
-    expect(mock.calls.length).toEqual(1);
-    expect(mock.calls[0][0]).toEqual("run this");
+    expect(mockDevice.execScript).toHaveBeenCalledWith("run this");
   });
 
   it("sets url to install", () => {
@@ -195,17 +186,15 @@ describe("<FarmwareConfigMenu />", () => {
   }
 
   it("calls install 1st party farmwares", () => {
-    const firstParty = getDevice().installFirstPartyFarmware;
     const wrapper = mount(
       <FarmwareConfigMenu {...fakeProps() } />);
     const button = wrapper.find("button").first();
     expect(button.hasClass("fa-download")).toBeTruthy();
     button.simulate("click");
-    expect(firstParty).toHaveBeenCalled();
+    expect(mockDevice.installFirstPartyFarmware).toHaveBeenCalled();
   });
 
   it("1st party farmwares all installed", () => {
-    const firstParty = getDevice().installFirstPartyFarmware;
     const p = fakeProps();
     p.firstPartyFwsInstalled = true;
     const wrapper = mount(
@@ -213,7 +202,7 @@ describe("<FarmwareConfigMenu />", () => {
     const button = wrapper.find("button").first();
     expect(button.hasClass("fa-download")).toBeTruthy();
     button.simulate("click");
-    expect(firstParty).not.toHaveBeenCalled();
+    expect(mockDevice.installFirstPartyFarmware).not.toHaveBeenCalled();
   });
 
   it("toggles 1st party farmware display", () => {

--- a/webpack/farmware/camera_calibration/__tests__/actions_test.ts
+++ b/webpack/farmware/camera_calibration/__tests__/actions_test.ts
@@ -6,26 +6,21 @@ jest.mock("../../../device", () => ({
 }));
 
 import { calibrate, scanImage } from "../actions";
-import { getDevice } from "../../../device";
 
 describe("scanImage()", () => {
   beforeEach(function () {
     jest.clearAllMocks();
   });
   it("calls out to the device", () => {
-    const { mock } = getDevice().execScript as jest.Mock<{}>;
     // Run function to invoke side effects
     const thunk = scanImage(4);
     thunk();
     // Ensure the side effects were the ones we expected.
-    expect(mock.calls.length).toEqual(1);
-    const argList = mock.calls[0];
-    expect(argList[0]).toEqual("historical-camera-calibration");
-    expect(argList[1]).toBeInstanceOf(Array);
-    expect(argList[1][0].kind).toBe("pair");
-    expect(argList[1][0].args).toBeInstanceOf(Object);
-    expect(argList[1][0].args.value).toBe("4");
-    expect(argList[1][0].args.label).toBe("CAMERA_CALIBRATION_selected_image");
+    expect(mockDevice.execScript)
+      .toHaveBeenCalledWith("historical-camera-calibration", [{
+        args: { label: "CAMERA_CALIBRATION_selected_image", value: "4" },
+        kind: "pair"
+      }]);
   });
 });
 
@@ -34,14 +29,10 @@ describe("calibrate()", () => {
     jest.clearAllMocks();
   });
   it("calls out to the device", () => {
-    const { mock } = getDevice().execScript as jest.Mock<{}>;
     // Run function to invoke side effects
     const thunk = calibrate();
     thunk();
     // Ensure the side effects were the ones we expected.
-    expect(mock.calls.length).toEqual(1);
-    const argList = mock.calls[0];
-    expect(argList[0]).toEqual("camera-calibration");
-    expect(argList[1]).toBeUndefined();
+    expect(mockDevice.execScript).toHaveBeenCalledWith("camera-calibration");
   });
 });

--- a/webpack/farmware/images/__tests__/photos_test.tsx
+++ b/webpack/farmware/images/__tests__/photos_test.tsx
@@ -51,7 +51,6 @@ describe("<Photos/>", () => {
   });
 
   it("deletes photo", () => {
-    const { mock } = destroy as jest.Mock<{}>;
     const dispatch = jest.fn(() => { return Promise.resolve(); });
     const images = prepareImages(fakeImages);
     const currentImage = images[1];
@@ -60,6 +59,6 @@ describe("<Photos/>", () => {
     const deleteButton = wrapper.find("button").at(1);
     expect(deleteButton.text().toLowerCase()).toBe("delete photo");
     deleteButton.simulate("click");
-    expect(mock.calls[0][0]).toBe("Position 1");
+    expect(destroy).toHaveBeenCalledWith("Position 1");
   });
 });

--- a/webpack/farmware/weed_detector/__tests__/actions_tests.ts
+++ b/webpack/farmware/weed_detector/__tests__/actions_tests.ts
@@ -7,7 +7,6 @@ jest.mock("../../../device", () => {
     getDevice: () => (mockDevice)
   };
 });
-import { getDevice } from "../../../device";
 import { translateImageWorkspaceAndSave } from "../actions";
 import { scanImage, test } from "../actions";
 
@@ -30,8 +29,7 @@ describe("actions", () => {
       "V_LO": "WEED_DETECTOR_V_LO"
     });
     translator("H_HI", 45);
-    expect(getDevice().setUserEnv).toHaveBeenCalledTimes(1);
-    expect(getDevice().setUserEnv)
+    expect(mockDevice.setUserEnv)
       .toHaveBeenLastCalledWith({ "WEED_DETECTOR_H_HI": "45" });
   });
 });
@@ -41,19 +39,15 @@ describe("scanImage()", () => {
     jest.clearAllMocks();
   });
   it("calls out to the device", () => {
-    const { mock } = getDevice().execScript as jest.Mock<{}>;
     // Run function to invoke side effects
     const thunk = scanImage(5);
     thunk();
     // Ensure the side effects were the ones we expected.
-    expect(mock.calls.length).toEqual(1);
-    const argList = mock.calls[0];
-    expect(argList[0]).toEqual("historical-plant-detection");
-    expect(argList[1]).toBeInstanceOf(Array);
-    expect(argList[1][0].kind).toBe("pair");
-    expect(argList[1][0].args).toBeInstanceOf(Object);
-    expect(argList[1][0].args.value).toBe("5");
-    expect(argList[1][0].args.label).toBe("PLANT_DETECTION_selected_image");
+    expect(mockDevice.execScript)
+      .toHaveBeenCalledWith("historical-plant-detection", [{
+        args: { label: "PLANT_DETECTION_selected_image", value: "5" },
+        kind: "pair"
+      }]);
   });
 });
 
@@ -62,14 +56,11 @@ describe("test()", () => {
     jest.clearAllMocks();
   });
   it("calls out to the device", () => {
-    const { mock } = getDevice().execScript as jest.Mock<{}>;
     // Run function to invoke side effects
     const thunk = test();
     thunk();
     // Ensure the side effects were the ones we expected.
-    expect(mock.calls.length).toEqual(1);
-    const argList = mock.calls[0];
-    expect(argList[0]).toEqual("plant-detection");
-    expect(argList[1]).toBeUndefined();
+    expect(mockDevice.execScript)
+      .toHaveBeenCalledWith("plant-detection");
   });
 });

--- a/webpack/regimens/editor/__tests__/index_test.tsx
+++ b/webpack/regimens/editor/__tests__/index_test.tsx
@@ -1,11 +1,9 @@
 import { fakeState } from "../../../__test_support__/fake_state";
 const mockState = fakeState;
-const mockDestroy = jest.fn();
-const mockSave = jest.fn();
 jest.mock("../../../api/crud", () => ({
   getState: mockState,
-  destroy: mockDestroy,
-  save: mockSave
+  destroy: jest.fn(),
+  save: jest.fn()
 }));
 
 import * as React from "react";
@@ -15,6 +13,7 @@ import { fakeRegimen } from "../../../__test_support__/fake_state/resources";
 import { RegimenEditorWidgetProps } from "../interfaces";
 import { auth } from "../../../__test_support__/fake_state/token";
 import { bot } from "../../../__test_support__/fake_state/bot";
+import { destroy, save } from "../../../api/crud";
 
 describe("<RegimenEditorWidget />", () => {
   beforeEach(function () {
@@ -71,7 +70,7 @@ describe("<RegimenEditorWidget />", () => {
     const deleteButton = wrapper.find("button").at(2);
     expect(deleteButton.text()).toContain("Delete");
     deleteButton.simulate("click");
-    expect(mockDestroy).toHaveBeenCalledWith("Regimen.6.23");
+    expect(destroy).toHaveBeenCalledWith("Regimen.6.23");
   });
 
   it("saves regimen", () => {
@@ -79,6 +78,6 @@ describe("<RegimenEditorWidget />", () => {
     const saveeButton = wrapper.find("button").at(0);
     expect(saveeButton.text()).toContain("Save");
     saveeButton.simulate("click");
-    expect(mockSave).toHaveBeenCalledWith("Regimen.8.25");
+    expect(save).toHaveBeenCalledWith("Regimen.8.25");
   });
 });

--- a/webpack/sequences/__tests__/sequence_editor_middle_active_test.tsx
+++ b/webpack/sequences/__tests__/sequence_editor_middle_active_test.tsx
@@ -1,6 +1,5 @@
-const mockDestroy = jest.fn();
 jest.mock("../../api/crud", () => ({
-  destroy: mockDestroy
+  destroy: jest.fn()
 }));
 
 const mockCopy = jest.fn();
@@ -16,11 +15,16 @@ jest.mock("../step_tiles/index", () => ({
 }));
 
 import * as React from "react";
-import { SequenceEditorMiddleActive, onDrop } from "../sequence_editor_middle_active";
+import {
+  SequenceEditorMiddleActive, onDrop
+} from "../sequence_editor_middle_active";
 import { mount } from "enzyme";
 import { ActiveMiddleProps } from "../interfaces";
-import { FAKE_RESOURCES, buildResourceIndex } from "../../__test_support__/resource_index_builder";
+import {
+  FAKE_RESOURCES, buildResourceIndex
+} from "../../__test_support__/resource_index_builder";
 import { fakeSequence } from "../../__test_support__/fake_state/resources";
+import { destroy } from "../../api/crud";
 
 describe("<SequenceEditorMiddleActive/>", () => {
   function fakeProps(): ActiveMiddleProps {
@@ -43,7 +47,7 @@ describe("<SequenceEditorMiddleActive/>", () => {
 
   it("deletes", () => {
     clickButton(2, "Delete");
-    expect(mockDestroy).toHaveBeenCalledWith("Sequence.0.17");
+    expect(destroy).toHaveBeenCalledWith("Sequence.0.17");
   });
 
   it("copies", () => {

--- a/webpack/sequences/step_tiles/tile_if/__tests__/else_test.tsx
+++ b/webpack/sequences/step_tiles/tile_if/__tests__/else_test.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+import { Else } from "../else";
+import { mount } from "enzyme";
+import { fakeSequence } from "../../../../__test_support__/fake_state/resources";
+import { If } from "farmbot/dist";
+import { emptyState } from "../../../../resources/reducer";
+import { IfParams } from "../index";
+
+describe("<Else/>", () => {
+  function fakeProps(): IfParams {
+    const currentStep: If = {
+      kind: "_if",
+      args: {
+        lhs: "pin0",
+        op: "is",
+        rhs: 0,
+        _then: { kind: "nothing", args: {} },
+        _else: { kind: "nothing", args: {} }
+      }
+    };
+    return {
+      currentSequence: fakeSequence(),
+      currentStep,
+      dispatch: jest.fn(),
+      index: 0,
+      resources: emptyState().index
+    };
+  }
+
+  it("renders", () => {
+    const wrapper = mount(<Else {...fakeProps() } />);
+    ["ELSE", "Execute Sequence"].map(string =>
+      expect(wrapper.text()).toContain(string));
+    expect(wrapper.find("button").length).toEqual(1);
+  });
+});

--- a/webpack/sequences/step_tiles/tile_if/__tests__/if_test.tsx
+++ b/webpack/sequences/step_tiles/tile_if/__tests__/if_test.tsx
@@ -1,0 +1,37 @@
+import * as React from "react";
+import { If_ } from "../if";
+import { mount } from "enzyme";
+import { fakeSequence } from "../../../../__test_support__/fake_state/resources";
+import { If } from "farmbot/dist";
+import { emptyState } from "../../../../resources/reducer";
+import { IfParams } from "../index";
+
+describe("<If_/>", () => {
+  function fakeProps(): IfParams {
+    const currentStep: If = {
+      kind: "_if",
+      args: {
+        lhs: "pin0",
+        op: "is",
+        rhs: 0,
+        _then: { kind: "nothing", args: {} },
+        _else: { kind: "nothing", args: {} }
+      }
+    };
+    return {
+      currentSequence: fakeSequence(),
+      currentStep,
+      dispatch: jest.fn(),
+      index: 0,
+      resources: emptyState().index
+    };
+  }
+
+  it("renders", () => {
+    const wrapper = mount(<If_ {...fakeProps() } />);
+    ["Variable", "Operator", "Value"].map(string =>
+      expect(wrapper.text()).toContain(string));
+    expect(wrapper.find("button").length).toEqual(2);
+    expect(wrapper.find("input").length).toEqual(1);
+  });
+});

--- a/webpack/sequences/step_tiles/tile_if/__tests__/index_test.tsx
+++ b/webpack/sequences/step_tiles/tile_if/__tests__/index_test.tsx
@@ -1,0 +1,101 @@
+jest.mock("../../../../api/crud", () => ({
+  overwrite: jest.fn(),
+}));
+
+import * as React from "react";
+import { mount } from "enzyme";
+import {
+  seqDropDown, initialValue, InnerIf, IfParams, IfBlockDropDownHandler
+} from "../index";
+import {
+  buildResourceIndex, FAKE_RESOURCES
+} from "../../../../__test_support__/resource_index_builder";
+import { Execute, If } from "farmbot";
+import { TaggedSequence } from "../../../../resources/tagged_resources";
+import { overwrite } from "../../../../api/crud";
+
+const fakeResourceIndex = buildResourceIndex(FAKE_RESOURCES).index;
+const fakeTaggedSequence = fakeResourceIndex
+  .references[fakeResourceIndex.byKind.Sequence[0]] as TaggedSequence;
+const fakeId = fakeTaggedSequence && fakeTaggedSequence.body.id || 0;
+const fakeName = fakeTaggedSequence && fakeTaggedSequence.body.name || "";
+const expectedItem = { label: fakeName, value: fakeId };
+
+function fakeProps(): IfParams {
+  const currentStep: If = {
+    kind: "_if",
+    args: {
+      lhs: "pin0",
+      op: "is",
+      rhs: 0,
+      _then: { kind: "nothing", args: {} },
+      _else: { kind: "nothing", args: {} }
+    }
+  };
+  return {
+    currentSequence: fakeTaggedSequence,
+    currentStep,
+    dispatch: jest.fn(),
+    index: 0,
+    resources: fakeResourceIndex
+  };
+}
+
+const execute: Execute = { kind: "execute", args: { sequence_id: fakeId } };
+
+describe("seqDropDown()", () => {
+  it("returns list", () => {
+    const list = seqDropDown(fakeResourceIndex);
+    expect(list).toEqual([expectedItem]);
+  });
+});
+
+describe("initialValue()", () => {
+  it("returns dropdown initial value", () => {
+    const item = initialValue(execute, fakeResourceIndex);
+    expect(item).toEqual({ label: fakeName, value: fakeId });
+  });
+});
+
+describe("<InnerIf />", () => {
+  it("renders", () => {
+    const wrapper = mount(<InnerIf {...fakeProps() } />);
+    ["IF", "THEN", "ELSE"].map(string =>
+      expect(wrapper.text()).toContain(string));
+  });
+
+  it("is recursive", () => {
+    const p = fakeProps();
+    p.currentStep.args._then = execute;
+    const wrapper = mount(<InnerIf {...p } />);
+    expect(wrapper.text()).toContain("Recursive condition");
+  });
+});
+
+describe("IfBlockDropDownHandler()", () => {
+  it("onChange()", () => {
+    const { onChange } = IfBlockDropDownHandler(fakeProps(), "_else");
+    onChange(expectedItem);
+    const [argsList1] = (overwrite as jest.Mock).mock.calls;
+    expect(argsList1[1].body[0].args._else).toEqual(execute);
+    jest.clearAllMocks();
+    onChange({ label: "None", value: "" });
+    const [argsList2] = (overwrite as jest.Mock).mock.calls;
+    expect(argsList2[1].body[0].args._else)
+      .toEqual({ kind: "nothing", args: {} });
+  });
+
+  it("selectedItem()", () => {
+    const p = fakeProps();
+    p.currentStep.args._then = execute;
+    const { selectedItem } = IfBlockDropDownHandler(p, "_then");
+    const item = selectedItem();
+    expect(item).toEqual(expectedItem);
+  });
+
+  it("selectedItem(): null", () => {
+    const { selectedItem } = IfBlockDropDownHandler(fakeProps(), "_then");
+    const item = selectedItem();
+    expect(item).toEqual({ label: "None", value: "" });
+  });
+});

--- a/webpack/sequences/step_tiles/tile_if/__tests__/then_test.tsx
+++ b/webpack/sequences/step_tiles/tile_if/__tests__/then_test.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+import { Then } from "../then";
+import { mount } from "enzyme";
+import { fakeSequence } from "../../../../__test_support__/fake_state/resources";
+import { If } from "farmbot/dist";
+import { emptyState } from "../../../../resources/reducer";
+import { IfParams } from "../index";
+
+describe("<Then/>", () => {
+  function fakeProps(): IfParams {
+    const currentStep: If = {
+      kind: "_if",
+      args: {
+        lhs: "pin0",
+        op: "is",
+        rhs: 0,
+        _then: { kind: "nothing", args: {} },
+        _else: { kind: "nothing", args: {} }
+      }
+    };
+    return {
+      currentSequence: fakeSequence(),
+      currentStep,
+      dispatch: jest.fn(),
+      index: 0,
+      resources: emptyState().index
+    };
+  }
+
+  it("renders", () => {
+    const wrapper = mount(<Then {...fakeProps() } />);
+    ["THEN", "Execute Sequence"].map(string =>
+      expect(wrapper.text()).toContain(string));
+    expect(wrapper.find("button").length).toEqual(1);
+  });
+});

--- a/webpack/sequences/step_tiles/tile_if/else.tsx
+++ b/webpack/sequences/step_tiles/tile_if/else.tsx
@@ -1,9 +1,5 @@
 import * as React from "react";
-import {
-  IfParams,
-  seqDropDown,
-  IfBlockDropDownHandler
-} from "./index";
+import { IfParams, seqDropDown, IfBlockDropDownHandler } from "./index";
 import { t } from "i18next";
 import { FBSelect } from "../../../ui/new_fb_select";
 
@@ -11,7 +7,7 @@ export function Else(props: IfParams) {
   const { onChange, selectedItem } = IfBlockDropDownHandler(props, "_else");
   return <div>
     <div className="col-xs-12 col-md-12">
-      <h4>ELSE...</h4>
+      <h4>{t("ELSE...")}</h4>
     </div>
     <div className="col-xs-12 col-md-12">
       <label>{t("Execute Sequence")}</label>

--- a/webpack/sequences/step_tiles/tile_if/index.tsx
+++ b/webpack/sequences/step_tiles/tile_if/index.tsx
@@ -100,7 +100,7 @@ export function InnerIf(props: IfParams) {
             {recursive && (
               <span>
                 <i className="fa fa-exclamation-triangle"></i>
-                &nbsp;Recursive condition.
+                &nbsp;{t("Recursive condition.")}
               </span>
             )}
           </div>

--- a/webpack/sequences/step_tiles/tile_if/then.tsx
+++ b/webpack/sequences/step_tiles/tile_if/then.tsx
@@ -7,7 +7,7 @@ export function Then(props: IfParams) {
   const { onChange, selectedItem } = IfBlockDropDownHandler(props, "_then");
   return <div>
     <div className="col-xs-12 col-md-12">
-      <h4>THEN...</h4>
+      <h4>{t("THEN...")}</h4>
     </div>
     <div className="col-xs-12 col-md-12">
       <label>{t("Execute Sequence")}</label>

--- a/webpack/tools/components/__tests__/toolbay_form_test.tsx
+++ b/webpack/tools/components/__tests__/toolbay_form_test.tsx
@@ -32,9 +32,7 @@ describe("<ToolBayForm/>", () => {
     const inputs = test.component.find("input");
     expect(inputs.length).toEqual(3);
     expect(test.component.text()).toContain("Trench Digging Tool");
-    expect(inputs.at(0).props().value).toEqual("10");
-    expect(inputs.at(1).props().value).toEqual("10");
-    expect(inputs.at(2).props().value).toEqual("10");
+    [0, 1, 2].map(i => expect(inputs.at(i).props().value).toEqual("10"));
   });
 
   it("fills inputs with bot position", () => {


### PR DESCRIPTION
**Device:**
 * Add widget to set and remove Raspberry Pi GPIO pin bindings to allow start of a sequence by pressing a physical button (or by motion sensor output).