### PR TITLE
Bug Fix: API Port on self hosted setups. Closes #567

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,5 +1,5 @@
 # Run Rails & Webpack concurrently
-rails:   rails s -e development -p 3000 -b 0.0.0.0
+rails:   rails s -e development -p ${API_PORT:-3000} -b 0.0.0.0
 webpack: ./node_modules/.bin/webpack-dev-server --config config/webpack.config.js
 worker:  rake jobs:work
 logger:  rails r lib/log_service.rb

--- a/config/application.example.yml
+++ b/config/application.example.yml
@@ -24,7 +24,7 @@ ACME_SECRET: "-----"
 API_HOST: "12.34.56.78"
 # 3000 for local development. 443 is using SSL. You will need `sudo` to use PORT
 # 80 on most systems.
-PORT: "3000"
+API_PORT: "3000"
 # This can be set to anything.
 # Most users can just delete it.
 # This is used for people writing modifications to the software, mostly.


### PR DESCRIPTION
# What's New?

 * Some self hosted users that ran servers on ports other than the default `3000` had noticed problems starting the MQTT broker.
 * The `PORT` ENV variable has been renamed to `API_PORT`. This is a legacy artifact from when we tried to use `PORT` instead of `API_PORT` but hit issues on Dokku / Heroku.

# Important

 * If you were affected by this bug, you **must updated application.yml to use API_PORT insead of PORT**.