### PR TITLE
Webcamfeed offline bug

### DIFF
--- a/webpack/devices/reducer.ts
+++ b/webpack/devices/reducer.ts
@@ -183,14 +183,6 @@ export let botReducer = generateReducer<BotState>(initialState())
     s.encoder_visibility[payload] = !s.encoder_visibility[payload];
     return s;
   })
-  .add<void>(Actions._RESOURCE_NO, (s, a) => {
-    console.log("No longer needed?");
-    /** Panic and restore syncStatus to what it was before operation failed. */
-    if (s.consistent && (s.statusStash !== "syncing")) {
-      s.hardware.informational_settings.sync_status = s.statusStash;
-    }
-    return s;
-  })
   .add<void>(Actions.STASH_STATUS, (s, a) => {
     stashStatus(s);
     return s;

--- a/webpack/redux/middlewares.ts
+++ b/webpack/redux/middlewares.ts
@@ -1,6 +1,7 @@
 import thunk from "redux-thunk";
 import { applyMiddleware, compose, Middleware } from "redux";
 import { EnvName } from "./interfaces";
+import { Actions } from "../constants";
 
 interface MiddlewareConfig {
   fn: Middleware;
@@ -24,7 +25,13 @@ export function getMiddleware(env: EnvName) {
   const middlewareFns = mwConfig
     .filter(function (mwc) { return (mwc.env === env) || (mwc.env === "*"); })
     .map((mwc) => mwc.fn);
-  const dtCompose = (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__;
+  const wow = (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__;
+  const dtCompose = wow && wow({
+    actionsBlacklist: [
+      Actions.NETWORK_EDGE_CHANGE,
+      Actions.RESOURCE_READY
+    ]
+  });
   const composeEnhancers = dtCompose || compose;
   const middlewares = applyMiddleware(...middlewareFns);
 


### PR DESCRIPTION
# What's New?

 * Ignore `NETWORK_EDGE_CHANGE` and `RESOURCE_READY` in Redux devtools (was getting noisy)
 * Fix bug where device appears offline after 422 response from API.