### PR TITLE
temporary reconnect toast implementation.

### DIFF
--- a/webpack/connectivity/__tests__/temporary_reconnect_idea.ts
+++ b/webpack/connectivity/__tests__/temporary_reconnect_idea.ts
@@ -1,3 +1,38 @@
+import { temporaryReconnectIdea } from "../reducer";
+import { ConnectionState, EdgeStatus } from "../interfaces";
+import { success } from "farmbot-toastr";
 describe("temporaryReconnectIdea", () => {
-  it("calls success()");
+  it("calls success() when going from down to up", () => {
+    jest.resetAllMocks();
+    const state: ConnectionState = {
+      ["user.mqtt"]: { state: "down", at: "---" },
+      ["user.api"]: undefined,
+      ["bot.mqtt"]: undefined
+    };
+
+    const action: EdgeStatus = {
+      name: "user.mqtt",
+      status: { state: "up", at: "---" }
+    };
+
+    temporaryReconnectIdea(state, action);
+    expect(success).toHaveBeenCalled();
+  });
+
+  it("skips success() when going from up to down", () => {
+    jest.resetAllMocks();
+    const state: ConnectionState = {
+      ["user.mqtt"]: { state: "up", at: "---" },
+      ["user.api"]: undefined,
+      ["bot.mqtt"]: undefined
+    };
+
+    const action: EdgeStatus = {
+      name: "user.mqtt",
+      status: { state: "down", at: "---" }
+    };
+
+    temporaryReconnectIdea(state, action);
+    expect(success).not.toHaveBeenCalled();
+  });
 });

--- a/webpack/connectivity/__tests__/temporary_reconnect_idea.ts
+++ b/webpack/connectivity/__tests__/temporary_reconnect_idea.ts
@@ -1,0 +1,3 @@
+describe("temporaryReconnectIdea", () => {
+  it("calls success()");
+});

--- a/webpack/connectivity/reducer.ts
+++ b/webpack/connectivity/reducer.ts
@@ -2,6 +2,7 @@ import { generateReducer } from "../redux/generate_reducer";
 import { Actions } from "../constants";
 import { ConnectionState, EdgeStatus, ResourceReady } from "./interfaces";
 import { computeBestTime } from "./reducer_support";
+import { success } from "farmbot-toastr";
 
 export const DEFAULT_STATE: ConnectionState = {
   "bot.mqtt": undefined,
@@ -12,6 +13,7 @@ export const DEFAULT_STATE: ConnectionState = {
 export let connectivityReducer =
   generateReducer<ConnectionState>(DEFAULT_STATE)
     .add<EdgeStatus>(Actions.NETWORK_EDGE_CHANGE, (s, { payload }) => {
+      temporaryReconnectIdea(s, payload);
       s[payload.name] = payload.status;
       return s;
     })
@@ -30,3 +32,15 @@ export let connectivityReducer =
 
       return s;
     });
+
+export function temporaryReconnectIdea(s: ConnectionState, a: EdgeStatus) {
+  /** Emitting side effects in a Reducer is considered bad practice.
+   * I was really hoping that this could be handled via the `connect` event
+   * in MQTT.js, but for some reason it's not triggering.
+   * https://github.com/mqttjs/MQTT.js/issues/743 */
+  const x = s["user.mqtt"];
+  const wasDown = ((x && x.state) || "down") === "down";
+  const isUp = (a.status.state === "up");
+  (x && wasDown && isUp)
+    && success("Browser is re-connected to the message broker");
+}


### PR DESCRIPTION
# What's New?

 * Add a temporary toast for reconnection notices.
 * Long term solution: Figure out [why the connect event isn't firing on `bot.client`](https://github.com/mqttjs/MQTT.js/issues/743#issuecomment-354171924). 