### PR TITLE
Beta Release Opt-In, Part I

### DIFF
--- a/app/lib/session_token.rb
+++ b/app/lib/session_token.rb
@@ -20,7 +20,7 @@ class SessionToken < AbstractJwtToken
   # If you have a really, really old FBOS
   OLD_OS_URL   = "https://api.github.com/repos/" +
                  "farmbot/farmbot_os/releases/8772352"
-  BETA_OS_URL  = BETA_OTA_URL || "NOT_SET"
+  BETA_OS_URL  = ENV["BETA_OTA_URL"] || "NOT_SET"
   def self.issue_to(user,
                     iat: Time.now.to_i,
                     exp: EXPIRY.from_now.to_i,

--- a/app/lib/session_token.rb
+++ b/app/lib/session_token.rb
@@ -20,6 +20,7 @@ class SessionToken < AbstractJwtToken
   # If you have a really, really old FBOS
   OLD_OS_URL   = "https://api.github.com/repos/" +
                  "farmbot/farmbot_os/releases/8772352"
+  BETA_OS_URL  = BETA_OTA_URL || "NOT_SET"
   def self.issue_to(user,
                     iat: Time.now.to_i,
                     exp: EXPIRY.from_now.to_i,
@@ -32,19 +33,20 @@ class SessionToken < AbstractJwtToken
       raise Errors::Forbidden, MUST_VERIFY
     end
     url = (fbos_version <= FBOS_CUTOFF) ? OLD_OS_URL : OS_RELEASE
-    self.new([{ aud:              aud,
-                sub:              user.id,
-                iat:              iat,
-                jti:              SecureRandom.uuid,
-                iss:              iss,
-                exp:              exp,
-                mqtt:             MQTT,
-                mqtt_ws:          MQTT_WS,
-                os_update_server: url,
-                fw_update_server: "DEPRECATED",
-                interim_email:    user.email, # Dont use this for anything ever -RC
-                bot:              "device_#{user.device.id}",
-                vhost:            VHOST }])
+    self.new([{ aud:                   aud,
+                sub:                   user.id,
+                iat:                   iat,
+                jti:                   SecureRandom.uuid,
+                iss:                   iss,
+                exp:                   exp,
+                mqtt:                  MQTT,
+                bot:                   "device_#{user.device.id}",
+                vhost:                 VHOST,
+                mqtt_ws:               MQTT_WS,
+                interim_email:         user.email, # Dont use this for anything ever -RC
+                os_update_server:      url,
+                fw_update_server:      "DEPRECATED",
+                beta_os_update_server: BETA_OS_URL }])
   end
 
   def self.as_json(user, aud, fbos_version)

--- a/app/lib/session_token.rb
+++ b/app/lib/session_token.rb
@@ -43,7 +43,6 @@ class SessionToken < AbstractJwtToken
                 bot:                   "device_#{user.device.id}",
                 vhost:                 VHOST,
                 mqtt_ws:               MQTT_WS,
-                interim_email:         user.email, # Dont use this for anything ever -RC
                 os_update_server:      url,
                 fw_update_server:      "DEPRECATED",
                 beta_os_update_server: BETA_OS_URL }])

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "enzyme": "^3.1.0",
     "enzyme-adapter-react-16": "^1.1.0",
     "extract-text-webpack-plugin": "^3.0.1",
-    "farmbot": "5.2.2",
+    "farmbot": "5.3.0",
     "farmbot-toastr": "^1.0.3",
     "fastclick": "^1.0.6",
     "file-loader": "^1.1.5",

--- a/spec/lib/session_token_spec.rb
+++ b/spec/lib/session_token_spec.rb
@@ -30,10 +30,11 @@ describe SessionToken do
   end
 
   it 'issues a token to a user' do
-    SessionToken.issue_to(user, iat: 000,
+    token = SessionToken.issue_to(user, iat: 000,
                                 exp: 456,
                                 iss: "//lycos.com:9867",
                                 fbos_version: Gem::Version.new("9.9.9"))
+    expect(token.unencoded[:beta_os_update_server]).to be_kind_of(String)
   end
 
   it 'conditionally sets `os_update_server`' do

--- a/yarn.lock
+++ b/yarn.lock
@@ -2101,9 +2101,9 @@ farmbot-toastr@^1.0.0, farmbot-toastr@^1.0.3:
     farmbot-toastr "^1.0.0"
     typescript "^2.3.4"
 
-farmbot@5.2.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/farmbot/-/farmbot-5.2.2.tgz#062776af941c3aed6319ba12fad59ab0f07f1875"
+farmbot@5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/farmbot/-/farmbot-5.3.0.tgz#eac1d3225f35f7b7a0d00d160c0582dfc02855ce"
   dependencies:
     mqtt "2.15.0"
     typescript "^2.4.2"


### PR DESCRIPTION
# What's New?

 * Add `beta_opt_in` to device state tree
 * Add `beta_os_update_server` to session token. (CC @ConnorRigby )

# What's Next?

 * UI additions