### PR TITLE
Re-add interim_email

### DIFF
--- a/app/lib/session_token.rb
+++ b/app/lib/session_token.rb
@@ -44,6 +44,7 @@ class SessionToken < AbstractJwtToken
                 vhost:                 VHOST,
                 mqtt_ws:               MQTT_WS,
                 os_update_server:      url,
+                interim_email:         user.email, # Dont use this for anything ever -RC
                 fw_update_server:      "DEPRECATED",
                 beta_os_update_server: BETA_OS_URL }])
   end


### PR DESCRIPTION
# What's New?

 * I removed `interim_email`, but legacy users still require it as part of the upgrade path.
