### PR TITLE
Translate legacyKeyNames to new_naming_convention

### DIFF
--- a/.codebeatignore
+++ b/.codebeatignore
@@ -4,3 +4,5 @@ webpack/**/*test*.tsx
 **__test**
 **__tests__**
 **test**
+webpack/entry.tsx
+webpack/password_reset/index.tsx

--- a/webpack/__test_support__/localstorage.js
+++ b/webpack/__test_support__/localstorage.js
@@ -6,6 +6,7 @@ function whatever() {
   var store = {};
 
   return {
+    store,
     clear() {
       store = {};
     },
@@ -13,6 +14,7 @@ function whatever() {
       return store[key];
     },
     setItem(key, value) {
+      console.log(`Set ${key} to ${value} = = = =`);
       store[key] = value.toString();
     },
     removeItem(key) {

--- a/webpack/__test_support__/localstorage.js
+++ b/webpack/__test_support__/localstorage.js
@@ -14,7 +14,6 @@ function whatever() {
       return store[key];
     },
     setItem(key, value) {
-      console.log(`Set ${key} to ${value} = = = =`);
       store[key] = value.toString();
     },
     removeItem(key) {

--- a/webpack/__tests__/storage_key_translator_test.ts
+++ b/webpack/__tests__/storage_key_translator_test.ts
@@ -1,0 +1,6 @@
+describe("maybeRunLocalstorageMigration", () => {
+  it("translate legacyKeyNames to new_key_names", () => {
+    localStorage.clear();
+    expect(localStorage.getItem(DONE_FLAG));
+  });
+});

--- a/webpack/__tests__/storage_key_translator_test.ts
+++ b/webpack/__tests__/storage_key_translator_test.ts
@@ -1,6 +1,25 @@
+import { DONE_FLAG, maybeRunLocalstorageMigration } from "../storage_key_translator";
+import { NumericSetting } from "../session_keys";
+import { camelCase } from "lodash";
+
 describe("maybeRunLocalstorageMigration", () => {
   it("translate legacyKeyNames to new_key_names", () => {
+
+    /** This is a temporary stub.
+     * Don't want to spend a bunch of time writing in depth tests for a function
+     * that will have a one month shelf life. */
     localStorage.clear();
-    expect(localStorage.getItem(DONE_FLAG));
+    const legacyKey = camelCase(NumericSetting.bot_origin_quadrant);
+    const storedValue = "1";
+    localStorage.setItem(legacyKey, storedValue);
+    expect(localStorage.getItem(DONE_FLAG)).toBeUndefined();
+    expect(localStorage.getItem(NumericSetting.bot_origin_quadrant))
+      .toBeUndefined();
+
+    maybeRunLocalstorageMigration();
+
+    expect(localStorage.getItem(NumericSetting.bot_origin_quadrant))
+      .toBe(storedValue);
+    expect(localStorage.getItem(DONE_FLAG)).toBe(DONE_FLAG);
   });
 });

--- a/webpack/entry.tsx
+++ b/webpack/entry.tsx
@@ -7,9 +7,12 @@ import { detectLanguage } from "./i18n";
 import { stopIE, shortRevision } from "./util";
 import { init } from "i18next";
 import { attachAppToDom } from "./routes";
+import { maybeRunLocalstorageMigration } from "./storage_key_translator";
 
 stopIE();
 
 console.log(shortRevision());
+
+maybeRunLocalstorageMigration();
 
 detectLanguage().then(config => init(config, attachAppToDom));

--- a/webpack/storage_key_translator.ts
+++ b/webpack/storage_key_translator.ts
@@ -27,6 +27,6 @@ const translateKeys = () => eachEntry().map(transferKey);
 
 const doRunMigration = () => translateKeys() && markAsDone();
 
-const hasFlag = () => !!localStorage.getItem(DONE_FLAG);
+const mustRun = () => !localStorage.getItem(DONE_FLAG);
 
-export const maybeRunLocalstorageMigration = () => hasFlag() && doRunMigration();
+export const maybeRunLocalstorageMigration = () => mustRun() && doRunMigration();

--- a/webpack/storage_key_translator.ts
+++ b/webpack/storage_key_translator.ts
@@ -1,0 +1,32 @@
+import { BooleanSetting, NumericSetting } from "./session_keys";
+import { camelCase } from "lodash";
+
+/** HISTORICAL CONTEXT: Session store is gradually being replaced with API-based
+ *  storage. In the process we needed to go from jsCase to ruby_elixir_case.
+ * Performing a onetime translation prevents loss of settings in localstorage. */
+
+/** All the information needed to migrate the localStorage keys from one place
+ * to the other. */
+type KeyTranslationPair = { jsCaseKey: string, ruby_case_key: string; };
+
+const eachEntry = (): KeyTranslationPair[] => {
+  return Object
+    .keys(BooleanSetting)
+    .concat(Object.keys(NumericSetting))
+    .map(key => ({ jsCaseKey: camelCase(key), ruby_case_key: key, value: key }));
+};
+
+const transferKey = (x: KeyTranslationPair) =>
+  localStorage.setItem(x.ruby_case_key, localStorage.getItem(x.jsCaseKey) || "");
+
+export const DONE_FLAG = "done";
+
+const markAsDone = () => localStorage.setItem(DONE_FLAG, DONE_FLAG);
+
+const translateKeys = () => eachEntry().map(transferKey);
+
+const doRunMigration = () => translateKeys() && markAsDone();
+
+const hasFlag = () => !!localStorage.getItem(DONE_FLAG);
+
+export const maybeRunLocalstorageMigration = () => hasFlag() && doRunMigration();


### PR DESCRIPTION
# What's New?

 * We are slowly making our way towards API stored settings.
 * We changed key names from `thisCase` to `this_case` in the process.
 * We need to move old values over to avoid setting loss.
