### PR TITLE
FarmBot OS settings improvements

### DIFF
--- a/webpack/auth/actions.ts
+++ b/webpack/auth/actions.ts
@@ -21,7 +21,10 @@ import { toastErrors } from "../toast_errors";
 
 export function didLogin(authState: AuthState, dispatch: Function) {
   API.setBaseUrl(authState.token.unencoded.iss);
-  dispatch(fetchReleases(authState.token.unencoded.os_update_server));
+  const { os_update_server, beta_os_update_server } = authState.token.unencoded;
+  dispatch(fetchReleases(os_update_server));
+  beta_os_update_server && dispatch(fetchReleases(beta_os_update_server,
+    { beta: true }));
   dispatch(setToken(authState));
   Sync.fetchSyncData(dispatch);
   dispatch(connectDevice(authState));

--- a/webpack/auth/interfaces.ts
+++ b/webpack/auth/interfaces.ts
@@ -12,6 +12,8 @@ export interface UnencodedToken {
   iss: string;
   /** Where to download RPi software */
   os_update_server: string;
+  /** Where to download beta RPi software */
+  beta_os_update_server?: string;
   /** JSON Token Identifier- auto sync needs this to hear its echo on MQTT */
   jti: string;
 }

--- a/webpack/constants.ts
+++ b/webpack/constants.ts
@@ -365,6 +365,10 @@ export namespace Content {
     trim(`This will shutdown FarmBot's Raspberry Pi. To turn it
     back on, unplug FarmBot and plug it back in.`);
 
+  export const OS_BETA_RELEASES =
+    trim(`Warning! Opting in to FarmBot OS beta releases may reduce
+    FarmBot system stability. Are you sure?`);
+
   // Hardware Settings
   export const RESTORE_DEFAULT_HARDWARE_SETTINGS =
     trim(`Restoring hardware parameter defaults will destroy the
@@ -467,7 +471,7 @@ export enum Actions {
   SETTING_UPDATE_END = "SETTING_UPDATE_END",
   BOT_CHANGE = "BOT_CHANGE",
   FETCH_OS_UPDATE_INFO_OK = "FETCH_OS_UPDATE_INFO_OK",
-  FETCH_FW_UPDATE_INFO_OK = "FETCH_FW_UPDATE_INFO_OK",
+  FETCH_BETA_OS_UPDATE_INFO_OK = "FETCH_BETA_OS_UPDATE_INFO_OK",
   INVERT_JOG_BUTTON = "INVERT_JOG_BUTTON",
   DISPLAY_ENCODER_DATA = "DISPLAY_ENCODER_DATA",
   STASH_STATUS = "STASH_STATUS",

--- a/webpack/devices/actions.ts
+++ b/webpack/devices/actions.ts
@@ -137,25 +137,30 @@ export let saveAccountChanges: Thunk = function (dispatch, getState) {
 };
 
 export let fetchReleases =
-  (url: string) => (dispatch: Function, getState: Function) => {
-    axios
-      .get(url)
-      .then((resp: HttpData<GithubRelease>) => {
-        const version = resp.data.tag_name;
-        const versionWithoutV = version.toLowerCase().replace("v", "");
-        dispatch({
-          type: Actions.FETCH_OS_UPDATE_INFO_OK,
-          payload: versionWithoutV
+  (url: string, options = { beta: false }) =>
+    (dispatch: Function, getState: Function) => {
+      axios
+        .get(url)
+        .then((resp: HttpData<GithubRelease>) => {
+          const version = resp.data.tag_name;
+          const versionWithoutV = version.toLowerCase().replace("v", "");
+          dispatch({
+            type: options.beta
+              ? Actions.FETCH_BETA_OS_UPDATE_INFO_OK
+              : Actions.FETCH_OS_UPDATE_INFO_OK,
+            payload: versionWithoutV
+          });
+        })
+        .catch((ferror) => {
+          error(t("Could not download FarmBot OS update information."));
+          dispatch({
+            type: options.beta
+              ? "FETCH_BETA_OS_UPDATE_INFO_ERROR"
+              : "FETCH_OS_UPDATE_INFO_ERROR",
+            payload: ferror
+          });
         });
-      })
-      .catch((ferror) => {
-        error(t("Could not download FarmBot OS update information."));
-        dispatch({
-          type: "FETCH_OS_UPDATE_INFO_ERROR",
-          payload: ferror
-        });
-      });
-  };
+    };
 
 export function save(input: TaggedDevice) {
   return function (dispatch: Function, getState: GetState) {

--- a/webpack/devices/components/farmbot_os_settings.tsx
+++ b/webpack/devices/components/farmbot_os_settings.tsx
@@ -122,7 +122,9 @@ export class FarmbotOsSettings
           <MustBeOnline
             status={hardware.informational_settings.sync_status}
             lockOpen={process.env.NODE_ENV !== "production"}>
-            <AutoUpdateRow bot={this.props.bot} controller_version={controller_version} />
+            <AutoUpdateRow
+              bot={this.props.bot}
+              controller_version={controller_version} />
             {this.maybeShowAutoSync()}
             <CameraSelection env={hardware.user_env} />
             <BoardType firmwareVersion={firmware_version} />

--- a/webpack/devices/components/fbos_settings/__tests__/auto_update_row_test.tsx
+++ b/webpack/devices/components/fbos_settings/__tests__/auto_update_row_test.tsx
@@ -1,9 +1,20 @@
+const mockDevice = {
+  updateConfig: jest.fn(() => { return Promise.resolve(); }),
+};
+jest.mock("../../../../device", () => ({
+  getDevice: () => (mockDevice)
+}));
+
 import * as React from "react";
 import { FbosDetails } from "../auto_update_row";
-import { shallow } from "enzyme";
+import { shallow, mount } from "enzyme";
 import { bot } from "../../../../__test_support__/fake_state/bot";
 
 describe("<FbosDetails/>", () => {
+  beforeEach(function () {
+    jest.clearAllMocks();
+  });
+
   it("renders", () => {
     bot.hardware.informational_settings.env = "fakeEnv";
     bot.hardware.informational_settings.commit = "fakeCommit";
@@ -11,5 +22,25 @@ describe("<FbosDetails/>", () => {
     const wrapper = shallow(<FbosDetails {...bot} />);
     ["Environment", "fakeEnv", "Commit", "fakeCommit", "Target", "fakeTarget"]
       .map(string => expect(wrapper.text()).toContain(string));
+  });
+
+  it("toggles os beta opt in setting on", () => {
+    bot.hardware.configuration.beta_opt_in = false;
+    const wrapper = mount(<FbosDetails {...bot} />);
+    wrapper.find("button").simulate("click");
+    expect(mockDevice.updateConfig).not.toHaveBeenCalled();
+    window.confirm = () => true;
+    wrapper.find("button").simulate("click");
+    expect(mockDevice.updateConfig)
+      .toHaveBeenCalledWith({ beta_opt_in: true });
+  });
+
+  it("toggles os beta opt in setting off", () => {
+    bot.hardware.configuration.beta_opt_in = true;
+    const wrapper = mount(<FbosDetails {...bot} />);
+    window.confirm = () => false;
+    wrapper.find("button").simulate("click");
+    expect(mockDevice.updateConfig)
+      .toHaveBeenCalledWith({ beta_opt_in: false });
   });
 });

--- a/webpack/devices/components/fbos_settings/auto_update_row.tsx
+++ b/webpack/devices/components/fbos_settings/auto_update_row.tsx
@@ -5,6 +5,10 @@ import { OsUpdateButton } from "./os_update_button";
 import { BotState } from "../../interfaces";
 import { Popover, Position } from "@blueprintjs/core";
 import { ColWidth } from "../farmbot_os_settings";
+import { ToggleButton } from "../../../controls/toggle_button";
+import { updateConfig } from "../../actions";
+import { noop } from "lodash";
+import { Content } from "../../../constants";
 
 interface AutoUpdateRowProps {
   controller_version: string | undefined;
@@ -13,14 +17,26 @@ interface AutoUpdateRowProps {
 
 export function FbosDetails(bot: BotState) {
   const {
-     env, commit, target, node_name, firmware_version
+     env, commit, target, node_name, firmware_version, firmware_commit
   } = bot.hardware.informational_settings;
+  const { beta_opt_in } = bot.hardware.configuration;
   return <div>
     <p><b>Environment: </b>{env}</p>
     <p><b>Commit: </b>{commit}</p>
     <p><b>Target: </b>{target}</p>
     <p><b>Node name: </b>{node_name}</p>
     <p><b>Firmware: </b>{firmware_version}</p>
+    <p><b>Firmware commit: </b>{firmware_commit}</p>
+    <fieldset>
+      <label>
+        {t("Opt-In to FarmBot OS Beta releases")}
+      </label>
+      <ToggleButton
+        toggleValue={beta_opt_in}
+        toggleAction={() =>
+          (beta_opt_in || confirm(Content.OS_BETA_RELEASES)) &&
+          updateConfig({ beta_opt_in: !beta_opt_in })(noop)} />
+    </fieldset>
   </div>;
 }
 

--- a/webpack/devices/components/fbos_settings/board_type.tsx
+++ b/webpack/devices/components/fbos_settings/board_type.tsx
@@ -87,6 +87,7 @@ export class BoardType
       <Col xs={ColWidth.description}>
         <div>
           <FBSelect
+            key={this.getBoardType()}
             allowEmpty={true}
             list={FIRMWARE_CHOICES}
             selectedItem={this.selectedBoard()}

--- a/webpack/devices/components/fbos_settings/os_update_button.tsx
+++ b/webpack/devices/components/fbos_settings/os_update_button.tsx
@@ -1,8 +1,7 @@
 import * as React from "react";
 import { t } from "i18next";
-import { isUndefined, noop } from "lodash";
 import * as _ from "lodash";
-import { JobProgress, Configuration } from "farmbot/dist";
+import { JobProgress } from "farmbot/dist";
 import { SemverResult, semverCompare } from "../../../util";
 import { BotProp } from "../../interfaces";
 import { Row, Col } from "../../../ui/index";
@@ -10,13 +9,17 @@ import { ToggleButton } from "../../../controls/toggle_button";
 import { updateConfig, checkControllerUpdates } from "../../actions";
 
 export let OsUpdateButton = ({ bot }: BotProp) => {
-  const osUpdateBool = bot.hardware.configuration.os_auto_update;
   let buttonStr = "Can't Connect to bot";
   let buttonColor = "yellow";
-  const { currentOSVersion } = bot;
+
+  const { os_auto_update, beta_opt_in } = bot.hardware.configuration;
+  const { currentOSVersion, currentBetaOSVersion } = bot;
+  const latestReleaseV = beta_opt_in
+    ? currentBetaOSVersion
+    : currentOSVersion;
   const { controller_version } = bot.hardware.informational_settings;
-  if (_.isString(currentOSVersion) && _.isString(controller_version)) {
-    switch (semverCompare(currentOSVersion, controller_version)) {
+  if (_.isString(latestReleaseV) && _.isString(controller_version)) {
+    switch (semverCompare(latestReleaseV, controller_version)) {
       case SemverResult.RIGHT_IS_GREATER:
       case SemverResult.EQUAL:
         buttonStr = t("UP TO DATE");
@@ -29,13 +32,11 @@ export let OsUpdateButton = ({ bot }: BotProp) => {
   } else {
     buttonStr = "Can't Connect to release server";
   }
-  const toggleVal = isUndefined(osUpdateBool) ? "undefined" : ("" + osUpdateBool);
 
-  // DONT TOUCH THIS!!! SERIOUSLY -- RC 8 August
-  // DO NOT REMOVE `|| {}` UNTIL SEPTEMBER.
   const osUpdateJob = (bot.hardware.jobs || {})["FBOS_OTA"];
 
-  const isWorking = (job: JobProgress | undefined) => job && (job.status == "working");
+  const isWorking = (job: JobProgress | undefined) =>
+    job && (job.status == "working");
 
   function downloadProgress(job: JobProgress | undefined) {
     if (job && isWorking(job)) {
@@ -62,17 +63,16 @@ export let OsUpdateButton = ({ bot }: BotProp) => {
         <p>{t("Auto Updates?")}</p>
       </Col>
       <Col xs={3}>
-        <ToggleButton toggleValue={toggleVal}
+        <ToggleButton toggleValue={os_auto_update}
           toggleAction={() => {
-            const os_auto_update: Configuration = {
-              os_auto_update: !osUpdateBool ? 1 : 0
-            };
-            updateConfig(os_auto_update)(noop);
+            const newOsAutoUpdateNum = !os_auto_update ? 1 : 0;
+            updateConfig({ os_auto_update: newOsAutoUpdateNum })(_.noop);
           }} />
       </Col>
       <Col xs={5}>
         <button
           className={"fb-button " + buttonColor}
+          title={latestReleaseV}
           disabled={isWorking(osUpdateJob)}
           onClick={() => checkControllerUpdates()}>
           {downloadProgress(osUpdateJob) || buttonStr}

--- a/webpack/devices/interfaces.ts
+++ b/webpack/devices/interfaces.ts
@@ -54,8 +54,8 @@ export interface BotState {
   stepSize: number;
   /** The current os version on the github release api */
   currentOSVersion?: string;
-  /** The current fw version on the github release api */
-  currentFWVersion?: string;
+  /** The current beta os version on the github release api */
+  currentBetaOSVersion?: string;
   /** Is the bot in sync with the api */
   dirty: boolean;
   /** The state of the bot, as reported by the bot over MQTT. */

--- a/webpack/devices/reducer.ts
+++ b/webpack/devices/reducer.ts
@@ -85,7 +85,7 @@ export let initialState = (): BotState => ({
   },
   dirty: false,
   currentOSVersion: undefined,
-  currentFWVersion: undefined,
+  currentBetaOSVersion: undefined,
   axis_inversion: {
     x: !!Session.getBool(BooleanSetting.x_axis_inverted),
     y: !!Session.getBool(BooleanSetting.y_axis_inverted),
@@ -156,6 +156,10 @@ export let botReducer = generateReducer<BotState>(initialState(), afterEach)
     s.currentOSVersion = payload;
     return s;
   })
+  .add<string>(Actions.FETCH_BETA_OS_UPDATE_INFO_OK, (s, { payload }) => {
+    s.currentBetaOSVersion = payload;
+    return s;
+  })
   .add<HardwareState>(Actions.BOT_CHANGE, (state, { payload }) => {
     state.hardware = payload;
     const { informational_settings } = state.hardware;
@@ -184,10 +188,6 @@ export let botReducer = generateReducer<BotState>(initialState(), afterEach)
     versionOK(informational_settings.controller_version);
     state.hardware.informational_settings.sync_status = nextSyncStatus;
     return state;
-  })
-  .add<string>(Actions.FETCH_FW_UPDATE_INFO_OK, (s, { payload }) => {
-    s.currentFWVersion = payload;
-    return s;
   })
   .add<Xyz>(Actions.INVERT_JOG_BUTTON, (s, { payload }) => {
     s.axis_inversion[payload] = !s.axis_inversion[payload];

--- a/webpack/farmware/farmware_panel.tsx
+++ b/webpack/farmware/farmware_panel.tsx
@@ -195,7 +195,9 @@ export class FarmwarePanel extends React.Component<FWProps, Partial<FWState>> {
             <Row>
               <fieldset>
                 <Col xs={12}>
-                  <FBSelect list={this.fwList()}
+                  <FBSelect
+                    key={"farmware_" + this.selectedItem()}
+                    list={this.fwList()}
                     selectedItem={this.selectedItem()}
                     onChange={(x) => {
                       const selectedFarmware = x.value;


### PR DESCRIPTION
**Device:**
 * Add firmware commit info to FarmBot OS info pop-up.
 * Add beta release opt-in toggle.
 * Improve update performance of board type display.
 * Show latest available FarmBot OS version upon update button hover.

**Farmware:**
 * Fix Farmware selection stale data bug.