### PR TITLE
FarmBot OS Release Notes pop-up

### DIFF
--- a/webpack/auth/actions.ts
+++ b/webpack/auth/actions.ts
@@ -23,8 +23,8 @@ export function didLogin(authState: AuthState, dispatch: Function) {
   API.setBaseUrl(authState.token.unencoded.iss);
   const { os_update_server, beta_os_update_server } = authState.token.unencoded;
   dispatch(fetchReleases(os_update_server));
-  beta_os_update_server && dispatch(fetchReleases(beta_os_update_server,
-    { beta: true }));
+  beta_os_update_server && beta_os_update_server != "NOT_SET" &&
+    dispatch(fetchReleases(beta_os_update_server, { beta: true }));
   dispatch(setToken(authState));
   Sync.fetchSyncData(dispatch);
   dispatch(connectDevice(authState));

--- a/webpack/constants.ts
+++ b/webpack/constants.ts
@@ -354,6 +354,10 @@ export namespace Content {
     trim(`This will restart FarmBot's Raspberry Pi and controller
     software.`);
 
+  export const OS_AUTO_UPDATE =
+    trim(`When enabled, FarmBot OS will periodically check for, download,
+    and install updates automatically.`);
+
   export const AUTO_SYNC =
     trim(`When enabled, device resources such as sequences and regimens
     will be sent to the device automatically. This removes the need to push

--- a/webpack/css/global.scss
+++ b/webpack/css/global.scss
@@ -574,3 +574,25 @@ ul {
     min-width: 120px;
   }
 }
+
+.release-notes-button {
+  font-weight: bold;
+  cursor: pointer;
+}
+
+.release-notes {
+  max-width: 250px;
+  h1 {
+    font-weight: 300;
+    font-size: 1.5rem;
+  }
+  li:before {
+    content: "• ";
+  }
+  li {
+    font-weight: 300;
+    font-size: 1.1rem;
+    line-height: 1.75rem;
+    margin-bottom: 1rem;
+  }
+}

--- a/webpack/css/global.scss
+++ b/webpack/css/global.scss
@@ -263,12 +263,22 @@ fieldset {
   opacity: 0.40;
 }
 
-.webcam-stream-valid img {
-  display: flex;
-  max-width: 100%;
-  margin: auto;
-  max-height: 650px;
-  min-height: 300px;
+.webcam-stream-valid {
+  img {
+    display: flex;
+    max-width: 100%;
+    margin: auto;
+    max-height: 650px;
+    min-height: 300px;
+  }
+  iframe {
+    display: flex;
+    width: 100%;
+    margin: auto;
+    max-height: 650px;
+    min-height: 300px;
+    border: none;
+  }
 }
 
 .webcam-stream-unavailable text {

--- a/webpack/devices/components/__tests__/farmbot_os_settings_test.tsx
+++ b/webpack/devices/components/__tests__/farmbot_os_settings_test.tsx
@@ -1,3 +1,13 @@
+jest.mock("axios", () => ({
+  default: {
+    get: jest.fn(() => { return Promise.resolve({ data: "notes" }); })
+      .mockImplementationOnce(() => { return Promise.resolve(); })
+      .mockImplementationOnce(() => {
+        return Promise.resolve({ data: "intro\n\n# v6\n\n* note" });
+      })
+  }
+}));
+
 import * as React from "react";
 import { FarmbotOsSettings } from "../farmbot_os_settings";
 import { mount } from "enzyme";
@@ -5,19 +15,42 @@ import { bot } from "../../../__test_support__/fake_state/bot";
 import { fakeState } from "../../../__test_support__/fake_state";
 import { fakeResource } from "../../../__test_support__/fake_resource";
 import { AuthState } from "../../../auth/interfaces";
-import { FbosDetails } from "../fbos_settings/auto_update_row";
+import { FbosDetails } from "../fbos_settings/farmbot_os_row";
+import { FarmbotOsProps } from "../../interfaces";
+import axios from "axios";
 
 describe("<FarmbotOsSettings/>", () => {
+  function fakeProps(): FarmbotOsProps {
+    return {
+      account: fakeResource("Device", { id: 0, name: "", tz_offset_hrs: 0 }),
+      dispatch: jest.fn(),
+      bot: bot,
+      auth: fakeState().auth as AuthState
+    };
+  }
+
   it("renders settings", () => {
-    const osSettings = mount(<FarmbotOsSettings
-      account={fakeResource("Device", { id: 0, name: "", tz_offset_hrs: 0 })}
-      dispatch={jest.fn()}
-      bot={bot}
-      auth={fakeState().auth as AuthState} />);
+    const osSettings = mount(<FarmbotOsSettings {...fakeProps() } />);
     expect(osSettings.find("input").length).toBe(1);
     expect(osSettings.find("button").length).toBe(6);
     ["NAME", "TIME ZONE", "LAST SEEN", "FARMBOT OS", "CAMERA", "FIRMWARE"]
       .map(string => expect(osSettings.text()).toContain(string));
+  });
+
+  it("fetches OS release notes", async () => {
+    const osSettings = await mount(<FarmbotOsSettings {...fakeProps() } />);
+    await expect(axios.get).toHaveBeenCalledWith(
+      expect.stringContaining("RELEASE_NOTES.md"));
+    await expect(osSettings.state().osReleaseNotes)
+      .toEqual("# FarmBot OS v6\n* note");
+  });
+
+  it("doesn't fetch OS release notes", async () => {
+    const osSettings = await mount(<FarmbotOsSettings {...fakeProps() } />);
+    await expect(axios.get).toHaveBeenCalledWith(
+      expect.stringContaining("RELEASE_NOTES.md"));
+    await expect(osSettings.state().osReleaseNotes)
+      .toEqual("Could not get release notes.");
   });
 });
 

--- a/webpack/devices/components/farmbot_os_settings.tsx
+++ b/webpack/devices/components/farmbot_os_settings.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { t } from "i18next";
-import { FarmbotOsProps } from "../interfaces";
+import { FarmbotOsProps, FarmbotOsState } from "../interfaces";
 import {
   Widget,
   WidgetHeader,
@@ -17,10 +17,13 @@ import { timezoneMismatch } from "../timezones/guess_timezone";
 import { LastSeen } from "./fbos_settings/last_seen_row";
 import { CameraSelection } from "./fbos_settings/camera_selection";
 import { BoardType } from "./fbos_settings/board_type";
+import { FarmbotOsRow } from "./fbos_settings/farmbot_os_row";
 import { AutoUpdateRow } from "./fbos_settings/auto_update_row";
 import { AutoSyncRow } from "./fbos_settings/auto_sync_row";
 import { isUndefined } from "lodash";
 import { PowerAndReset } from "./fbos_settings/power_and_reset";
+import axios from "axios";
+import { HttpData } from "../../util";
 
 export enum ColWidth {
   label = 3,
@@ -28,8 +31,33 @@ export enum ColWidth {
   button = 2
 }
 
+const OS_RELEASE_NOTES_URL =
+  "https://raw.githubusercontent.com/FarmBot/farmbot_os/staging/RELEASE_NOTES.md";
+
 export class FarmbotOsSettings
-  extends React.Component<FarmbotOsProps> {
+  extends React.Component<FarmbotOsProps, FarmbotOsState> {
+  state = { osReleaseNotes: "" };
+
+  componentDidMount() {
+    this.fetchReleaseNotes(OS_RELEASE_NOTES_URL,
+      (this.props.bot.hardware.informational_settings
+        .controller_version || "6").split(".")[0]);
+  }
+
+  fetchReleaseNotes = (url: string, osMajorVersion: string) => {
+    axios
+      .get(url)
+      .then((resp: HttpData<string>) => {
+        const notes = resp.data
+          .split("# v")
+          .filter(x => x.startsWith(osMajorVersion))[0]
+          .split("\n\n").join("\n");
+        const osReleaseNotes = "# FarmBot OS v" + notes;
+        this.setState({ osReleaseNotes });
+      })
+      .catch(() =>
+        this.setState({ osReleaseNotes: "Could not get release notes." }));
+  }
 
   changeBot = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { account, dispatch } = this.props;
@@ -122,9 +150,11 @@ export class FarmbotOsSettings
           <MustBeOnline
             status={hardware.informational_settings.sync_status}
             lockOpen={process.env.NODE_ENV !== "production"}>
-            <AutoUpdateRow
+            <FarmbotOsRow
               bot={this.props.bot}
-              controller_version={controller_version} />
+              controller_version={controller_version}
+              osReleaseNotes={this.state.osReleaseNotes} />
+            <AutoUpdateRow bot={this.props.bot} />
             {this.maybeShowAutoSync()}
             <CameraSelection env={hardware.user_env} />
             <BoardType firmwareVersion={firmware_version} />

--- a/webpack/devices/components/fbos_settings/__tests__/auto_update_row_test.tsx
+++ b/webpack/devices/components/fbos_settings/__tests__/auto_update_row_test.tsx
@@ -6,41 +6,33 @@ jest.mock("../../../../device", () => ({
 }));
 
 import * as React from "react";
-import { FbosDetails } from "../auto_update_row";
-import { shallow, mount } from "enzyme";
+import { AutoUpdateRow } from "../auto_update_row";
+import { mount } from "enzyme";
 import { bot } from "../../../../__test_support__/fake_state/bot";
 
-describe("<FbosDetails/>", () => {
+describe("<AutoUpdateRow/>", () => {
   beforeEach(function () {
     jest.clearAllMocks();
   });
 
   it("renders", () => {
-    bot.hardware.informational_settings.env = "fakeEnv";
-    bot.hardware.informational_settings.commit = "fakeCommit";
-    bot.hardware.informational_settings.target = "fakeTarget";
-    const wrapper = shallow(<FbosDetails {...bot} />);
-    ["Environment", "fakeEnv", "Commit", "fakeCommit", "Target", "fakeTarget"]
-      .map(string => expect(wrapper.text()).toContain(string));
+    const wrapper = mount(<AutoUpdateRow bot={bot} />);
+    expect(wrapper.text().toLowerCase()).toContain("auto update");
   });
 
-  it("toggles os beta opt in setting on", () => {
-    bot.hardware.configuration.beta_opt_in = false;
-    const wrapper = mount(<FbosDetails {...bot} />);
-    wrapper.find("button").simulate("click");
-    expect(mockDevice.updateConfig).not.toHaveBeenCalled();
-    window.confirm = () => true;
-    wrapper.find("button").simulate("click");
+  it("toggles auto-update on", () => {
+    bot.hardware.configuration.os_auto_update = 0;
+    const wrapper = mount(<AutoUpdateRow bot={bot} />);
+    wrapper.find("button").first().simulate("click");
     expect(mockDevice.updateConfig)
-      .toHaveBeenCalledWith({ beta_opt_in: true });
+      .toHaveBeenCalledWith({ os_auto_update: 1 });
   });
 
-  it("toggles os beta opt in setting off", () => {
-    bot.hardware.configuration.beta_opt_in = true;
-    const wrapper = mount(<FbosDetails {...bot} />);
-    window.confirm = () => false;
-    wrapper.find("button").simulate("click");
+  it("toggles auto-update off", () => {
+    bot.hardware.configuration.os_auto_update = 1;
+    const wrapper = mount(<AutoUpdateRow bot={bot} />);
+    wrapper.find("button").first().simulate("click");
     expect(mockDevice.updateConfig)
-      .toHaveBeenCalledWith({ beta_opt_in: false });
+      .toHaveBeenCalledWith({ os_auto_update: 0 });
   });
 });

--- a/webpack/devices/components/fbos_settings/__tests__/farmbot_os_row_test.tsx
+++ b/webpack/devices/components/fbos_settings/__tests__/farmbot_os_row_test.tsx
@@ -1,0 +1,46 @@
+const mockDevice = {
+  updateConfig: jest.fn(() => { return Promise.resolve(); }),
+};
+jest.mock("../../../../device", () => ({
+  getDevice: () => (mockDevice)
+}));
+
+import * as React from "react";
+import { FbosDetails } from "../farmbot_os_row";
+import { shallow, mount } from "enzyme";
+import { bot } from "../../../../__test_support__/fake_state/bot";
+
+describe("<FbosDetails/>", () => {
+  beforeEach(function () {
+    jest.clearAllMocks();
+  });
+
+  it("renders", () => {
+    bot.hardware.informational_settings.env = "fakeEnv";
+    bot.hardware.informational_settings.commit = "fakeCommit";
+    bot.hardware.informational_settings.target = "fakeTarget";
+    const wrapper = shallow(<FbosDetails {...bot} />);
+    ["Environment", "fakeEnv", "Commit", "fakeCommit", "Target", "fakeTarget"]
+      .map(string => expect(wrapper.text()).toContain(string));
+  });
+
+  it("toggles os beta opt in setting on", () => {
+    bot.hardware.configuration.beta_opt_in = false;
+    const wrapper = mount(<FbosDetails {...bot} />);
+    wrapper.find("button").simulate("click");
+    expect(mockDevice.updateConfig).not.toHaveBeenCalled();
+    window.confirm = () => true;
+    wrapper.find("button").simulate("click");
+    expect(mockDevice.updateConfig)
+      .toHaveBeenCalledWith({ beta_opt_in: true });
+  });
+
+  it("toggles os beta opt in setting off", () => {
+    bot.hardware.configuration.beta_opt_in = true;
+    const wrapper = mount(<FbosDetails {...bot} />);
+    window.confirm = () => false;
+    wrapper.find("button").simulate("click");
+    expect(mockDevice.updateConfig)
+      .toHaveBeenCalledWith({ beta_opt_in: false });
+  });
+});

--- a/webpack/devices/components/fbos_settings/__tests__/os_update_button_test.tsx
+++ b/webpack/devices/components/fbos_settings/__tests__/os_update_button_test.tsx
@@ -16,11 +16,12 @@ import { OsUpdateButton } from "../os_update_button";
 describe("<OsUpdateButton/>", () => {
   beforeEach(function () {
     bot.currentOSVersion = "3.1.6";
+    bot.hardware.configuration.beta_opt_in = false;
     jest.clearAllMocks();
   });
   it("renders buttons: not connected", () => {
     const buttons = mount(<OsUpdateButton bot={bot} />);
-    expect(buttons.find("button").length).toBe(2);
+    expect(buttons.find("button").length).toBe(1);
     const autoUpdate = buttons.find("button").first();
     expect(autoUpdate.hasClass("yellow")).toBeTruthy();
     const osUpdateButton = buttons.find("button").last();
@@ -31,12 +32,30 @@ describe("<OsUpdateButton/>", () => {
     const buttons = mount(<OsUpdateButton bot={bot} />);
     const osUpdateButton = buttons.find("button").last();
     expect(osUpdateButton.text()).toBe("UP TO DATE");
+    expect(osUpdateButton.props().title).toBe("3.1.6");
+  });
+  it("up to date: newer", () => {
+    bot.hardware.informational_settings.controller_version = "5.0.0";
+    const buttons = mount(<OsUpdateButton bot={bot} />);
+    const osUpdateButton = buttons.find("button").last();
+    expect(osUpdateButton.text()).toBe("UP TO DATE");
+    expect(osUpdateButton.props().title).toBe("3.1.6");
   });
   it("update available", () => {
     bot.hardware.informational_settings.controller_version = "3.1.5";
     const buttons = mount(<OsUpdateButton bot={bot} />);
     const osUpdateButton = buttons.find("button").last();
     expect(osUpdateButton.text()).toBe("UPDATE");
+    expect(osUpdateButton.props().title).toBe("3.1.6");
+  });
+  it("beta update available", () => {
+    bot.hardware.informational_settings.controller_version = "3.1.5";
+    bot.hardware.configuration.beta_opt_in = true;
+    bot.currentBetaOSVersion = "5.0.0-beta";
+    const buttons = mount(<OsUpdateButton bot={bot} />);
+    const osUpdateButton = buttons.find("button").last();
+    expect(osUpdateButton.text()).toBe("UPDATE");
+    expect(osUpdateButton.props().title).toBe("5.0.0-beta");
   });
   it("calls checkUpdates", () => {
     const buttons = mount(<OsUpdateButton bot={bot} />);
@@ -93,13 +112,5 @@ describe("<OsUpdateButton/>", () => {
     const osUpdateButton = buttons.find("button").last();
     osUpdateButton.simulate("click");
     expect(mockDevice.checkUpdates).not.toHaveBeenCalled();
-  });
-
-  it("toggles auto-update", () => {
-    bot.hardware.configuration.os_auto_update = 0;
-    const wrapper = mount(<OsUpdateButton bot={bot} />);
-    wrapper.find("button").first().simulate("click");
-    expect(mockDevice.updateConfig)
-      .toHaveBeenCalledWith({ os_auto_update: 1 });
   });
 });

--- a/webpack/devices/components/fbos_settings/auto_update_row.tsx
+++ b/webpack/devices/components/fbos_settings/auto_update_row.tsx
@@ -1,9 +1,7 @@
 import * as React from "react";
 import { Row, Col } from "../../../ui/index";
 import { t } from "i18next";
-import { OsUpdateButton } from "./os_update_button";
 import { BotState } from "../../interfaces";
-import { Popover, Position } from "@blueprintjs/core";
 import { ColWidth } from "../farmbot_os_settings";
 import { ToggleButton } from "../../../controls/toggle_button";
 import { updateConfig } from "../../actions";
@@ -11,53 +9,28 @@ import { noop } from "lodash";
 import { Content } from "../../../constants";
 
 interface AutoUpdateRowProps {
-  controller_version: string | undefined;
   bot: BotState;
 }
 
-export function FbosDetails(bot: BotState) {
-  const {
-     env, commit, target, node_name, firmware_version, firmware_commit
-  } = bot.hardware.informational_settings;
-  const { beta_opt_in } = bot.hardware.configuration;
-  return <div>
-    <p><b>Environment: </b>{env}</p>
-    <p><b>Commit: </b>{commit}</p>
-    <p><b>Target: </b>{target}</p>
-    <p><b>Node name: </b>{node_name}</p>
-    <p><b>Firmware: </b>{firmware_version}</p>
-    <p><b>Firmware commit: </b>{firmware_commit}</p>
-    <fieldset>
-      <label>
-        {t("Opt-In to FarmBot OS Beta releases")}
-      </label>
-      <ToggleButton
-        toggleValue={beta_opt_in}
-        toggleAction={() =>
-          (beta_opt_in || confirm(Content.OS_BETA_RELEASES)) &&
-          updateConfig({ beta_opt_in: !beta_opt_in })(noop)} />
-    </fieldset>
-  </div>;
-}
-
 export function AutoUpdateRow(props: AutoUpdateRowProps) {
-  const version = props.controller_version || t(" unknown (offline)");
+  const { os_auto_update } = props.bot.hardware.configuration;
   return <Row>
     <Col xs={ColWidth.label}>
       <label>
-        {t("FARMBOT OS")}
+        {t("FARMBOT OS AUTO UPDATE")}
       </label>
     </Col>
-    <Col xs={2}>
-      <Popover position={Position.TOP_LEFT}>
-        <p>
-          {t("Version {{ version }}", { version })}
-        </p>
-        <FbosDetails {...props.bot} />
-      </Popover>
+    <Col xs={ColWidth.description}>
+      <p>
+        {t(Content.OS_AUTO_UPDATE)}
+      </p>
     </Col>
-    <Col xs={7}>
-      <OsUpdateButton bot={props.bot} />
+    <Col xs={ColWidth.button}>
+      <ToggleButton toggleValue={os_auto_update}
+        toggleAction={() => {
+          const newOsAutoUpdateNum = !os_auto_update ? 1 : 0;
+          updateConfig({ os_auto_update: newOsAutoUpdateNum })(noop);
+        }} />
     </Col>
   </Row>;
 }

--- a/webpack/devices/components/fbos_settings/farmbot_os_row.tsx
+++ b/webpack/devices/components/fbos_settings/farmbot_os_row.tsx
@@ -1,0 +1,77 @@
+import * as React from "react";
+import { Row, Col, Markdown } from "../../../ui/index";
+import { t } from "i18next";
+import { OsUpdateButton } from "./os_update_button";
+import { BotState } from "../../interfaces";
+import { Popover, Position } from "@blueprintjs/core";
+import { ColWidth } from "../farmbot_os_settings";
+import { ToggleButton } from "../../../controls/toggle_button";
+import { updateConfig } from "../../actions";
+import { noop } from "lodash";
+import { Content } from "../../../constants";
+
+interface FarmbotOsRowProps {
+  controller_version: string | undefined;
+  bot: BotState;
+  osReleaseNotes: string;
+}
+
+export function FbosDetails(bot: BotState) {
+  const {
+     env, commit, target, node_name, firmware_version, firmware_commit
+  } = bot.hardware.informational_settings;
+  const { beta_opt_in } = bot.hardware.configuration;
+  return <div>
+    <p><b>Environment: </b>{env}</p>
+    <p><b>Commit: </b>{commit}</p>
+    <p><b>Target: </b>{target}</p>
+    <p><b>Node name: </b>{node_name}</p>
+    <p><b>Firmware: </b>{firmware_version}</p>
+    <p><b>Firmware commit: </b>{firmware_commit}</p>
+    <fieldset>
+      <label>
+        {t("Opt-In to FarmBot OS Beta releases")}
+      </label>
+      <ToggleButton
+        toggleValue={beta_opt_in}
+        toggleAction={() =>
+          (beta_opt_in || confirm(Content.OS_BETA_RELEASES)) &&
+          updateConfig({ beta_opt_in: !beta_opt_in })(noop)} />
+    </fieldset>
+  </div>;
+}
+
+export function FarmbotOsRow(props: FarmbotOsRowProps) {
+  const version = props.controller_version || t(" unknown (offline)");
+  return <Row>
+    <Col xs={ColWidth.label}>
+      <label>
+        {t("FARMBOT OS")}
+      </label>
+    </Col>
+    <Col xs={3}>
+      <Popover position={Position.TOP_LEFT}>
+        <p>
+          {t("Version {{ version }}", { version })}
+        </p>
+        <FbosDetails {...props.bot} />
+      </Popover>
+    </Col>
+    <Col xs={3}>
+      <Popover position={Position.BOTTOM}>
+        <p className="release-notes-button">
+          {t("Release Notes")}&nbsp;
+          <i className="fa fa-caret-down" />
+        </p>
+        <div className="release-notes">
+          <Markdown>
+            {props.osReleaseNotes}
+          </Markdown>
+        </div>
+      </Popover>
+    </Col>
+    <Col xs={3}>
+      <OsUpdateButton bot={props.bot} />
+    </Col>
+  </Row >;
+}

--- a/webpack/devices/components/fbos_settings/os_update_button.tsx
+++ b/webpack/devices/components/fbos_settings/os_update_button.tsx
@@ -4,15 +4,13 @@ import * as _ from "lodash";
 import { JobProgress } from "farmbot/dist";
 import { SemverResult, semverCompare } from "../../../util";
 import { BotProp } from "../../interfaces";
-import { Row, Col } from "../../../ui/index";
-import { ToggleButton } from "../../../controls/toggle_button";
-import { updateConfig, checkControllerUpdates } from "../../actions";
+import { checkControllerUpdates } from "../../actions";
 
 export let OsUpdateButton = ({ bot }: BotProp) => {
   let buttonStr = "Can't Connect to bot";
   let buttonColor = "yellow";
 
-  const { os_auto_update, beta_opt_in } = bot.hardware.configuration;
+  const { beta_opt_in } = bot.hardware.configuration;
   const { currentOSVersion, currentBetaOSVersion } = bot;
   const latestReleaseV = beta_opt_in
     ? currentBetaOSVersion
@@ -57,27 +55,11 @@ export let OsUpdateButton = ({ bot }: BotProp) => {
     }
   }
 
-  return <div className="updates">
-    <Row>
-      <Col xs={4}>
-        <p>{t("Auto Updates?")}</p>
-      </Col>
-      <Col xs={3}>
-        <ToggleButton toggleValue={os_auto_update}
-          toggleAction={() => {
-            const newOsAutoUpdateNum = !os_auto_update ? 1 : 0;
-            updateConfig({ os_auto_update: newOsAutoUpdateNum })(_.noop);
-          }} />
-      </Col>
-      <Col xs={5}>
-        <button
-          className={"fb-button " + buttonColor}
-          title={latestReleaseV}
-          disabled={isWorking(osUpdateJob)}
-          onClick={() => checkControllerUpdates()}>
-          {downloadProgress(osUpdateJob) || buttonStr}
-        </button>
-      </Col>
-    </Row>
-  </div>;
+  return <button
+    className={"fb-button " + buttonColor}
+    title={latestReleaseV}
+    disabled={isWorking(osUpdateJob)}
+    onClick={() => checkControllerUpdates()}>
+    {downloadProgress(osUpdateJob) || buttonStr}
+  </button>;
 };

--- a/webpack/devices/interfaces.ts
+++ b/webpack/devices/interfaces.ts
@@ -112,6 +112,10 @@ export interface FarmbotOsProps {
   dispatch: Function;
 }
 
+export interface FarmbotOsState {
+  osReleaseNotes: string;
+}
+
 export interface CameraSelectionProps {
   env: Dictionary<string | undefined>
 }

--- a/webpack/ui/__tests__/fallback_img_test.tsx
+++ b/webpack/ui/__tests__/fallback_img_test.tsx
@@ -1,0 +1,35 @@
+import * as React from "react";
+import { FallbackImg } from "../fallback_img";
+import { mount } from "enzyme";
+
+describe("<FallbackImg />", () => {
+  function fakeProps() {
+    return {
+      src: "url",
+      fallback: "fallback"
+    };
+  }
+  it("renders img", () => {
+    const wrapper = mount(<FallbackImg {...fakeProps() } />);
+    const content = wrapper.find("img");
+    expect(content.length).toEqual(1);
+    expect(content.props().src).toEqual("url");
+  });
+
+  it("renders iframe", () => {
+    const p = fakeProps();
+    p.src = "iframe url";
+    const wrapper = mount(<FallbackImg {...p} />);
+    const content = wrapper.find("iframe");
+    expect(content.length).toEqual(1);
+    expect(content.props().src).toEqual("url");
+  });
+
+  it("falls back", () => {
+    const wrapper = mount(<FallbackImg {...fakeProps() } />);
+    wrapper.setState({ needsFallback: true });
+    const content = wrapper.find("img");
+    expect(content.length).toEqual(1);
+    expect(content.props().src).toEqual("fallback");
+  });
+});

--- a/webpack/ui/fallback_img.tsx
+++ b/webpack/ui/fallback_img.tsx
@@ -30,29 +30,33 @@ export class FallbackImg extends React.Component<Props, State> {
   }
 
   fallback = () => {
-    return (
-      <div className="webcam-stream-unavailable">
-        <img src={this.props.fallback} style={{ maxWidth: "100%" }} />
-        <text>
-          {t("Unable to load webcam feed.")}
-        </text>
-      </div>
-    );
+    return <div className="webcam-stream-unavailable">
+      <img src={this.props.fallback} style={{ maxWidth: "100%" }} />
+      <text>
+        {t("Unable to load webcam feed.")}
+      </text>
+    </div>;
   }
 
   dontFallback = () => {
     const imgProps: Props = defensiveClone(this.props);
     delete imgProps.fallback;
-    return (
-      <div className="webcam-stream-valid">
-        <img
-          onError={() => this.setState({ needsFallback: true })}
-          src={this.props.src} />
-      </div>
-    );
+    const onError = () => this.setState({ needsFallback: true });
+    const splitSrc = this.props.src.split(" ");
+    const displaySrc = () => {
+      switch (splitSrc[0]) {
+        case "iframe":
+          return <iframe src={splitSrc[1]} />;
+        default:
+          return <img src={this.props.src} onError={onError} />;
+      }
+    };
+    return <div className="webcam-stream-valid">
+      {displaySrc()}
+    </div>;
   }
 
   render() {
-    return ((this.state.needsFallback) ? this.fallback : this.dontFallback)();
+    return (this.state.needsFallback ? this.fallback : this.dontFallback)();
   }
 }


### PR DESCRIPTION
**Device:**
 * Display important changes to FarmBot OS by clicking `Release Notes`.
 * Move FarmBot OS auto update toggle to a new row.