### PR TITLE
Factor Documentation Link Generation

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,3 +1,3 @@
-## other configuration excluded from example...
 exclude_paths:
-- public/app-resources/languages/*.js
+- "public/app-resources/languages/*.js"
+- "**/*__test*"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,3 +1,4 @@
 exclude_paths:
-- "public/app-resources/languages/*.js"
 - "**/*__test*"
+- "**/*spec*.rb"
+- "public/app-resources/languages/*.js"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 
 [![codecov](https://codecov.io/gh/FarmBot/Farmbot-Web-App/branch/master/graph/badge.svg)](https://codecov.io/gh/FarmBot/Farmbot-Web-App)(API)
 
+[![Maintainability](https://api.codeclimate.com/v1/badges/74091163d8a02bb8988f/maintainability)](https://codeclimate.com/github/FarmBot/Farmbot-Web-App/maintainability)
+
+
 # Q: Do I need this?
 
 This repository is intended for *software developers* who wish to modify the [Farmbot Web App](http://my.farmbot.io/). **If you are not a developer**, you are highly encouraged to use [the publicly available web app](http://my.farmbot.io/). Running a server is *a non-trivial task with security implications*. It requires an intermediate background in Ruby, SQL and Linux system administration.

--- a/webpack/__tests__/storage_key_translator_test.ts
+++ b/webpack/__tests__/storage_key_translator_test.ts
@@ -18,6 +18,8 @@ describe("maybeRunLocalstorageMigration", () => {
 
     maybeRunLocalstorageMigration();
 
+    expect(localStorage.getItem(NumericSetting.busy_log))
+      .toBeUndefined();
     expect(localStorage.getItem(NumericSetting.bot_origin_quadrant))
       .toBe(storedValue);
     expect(localStorage.getItem(DONE_FLAG)).toBe(DONE_FLAG);

--- a/webpack/farmware/weed_detector/title.tsx
+++ b/webpack/farmware/weed_detector/title.tsx
@@ -5,6 +5,7 @@ import { WidgetHeader } from "../../ui/index";
 import { WD_ENV } from "./remote_env/interfaces";
 import { envSave } from "./remote_env/actions";
 import { Popover, PopoverInteractionKind } from "@blueprintjs/core";
+import { DocSlug } from "../../ui/doc_link";
 
 type ClickHandler = React.EventHandler<React.MouseEvent<HTMLButtonElement>>;
 
@@ -17,7 +18,7 @@ interface Props {
   title: string;
   help: string;
   env?: Partial<WD_ENV>;
-  docs?: string;
+  docs?: DocSlug;
 }
 
 export function TitleBar({

--- a/webpack/nav/additional_menu.tsx
+++ b/webpack/nav/additional_menu.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { Link } from "react-router";
 import { t } from "i18next";
 import { AccountMenuProps } from "./interfaces";
+import { docLink } from "../ui/doc_link";
 
 export const AdditionalMenu = (props: AccountMenuProps) => {
   return <div className="nav-additional-menu">
@@ -10,7 +11,7 @@ export const AdditionalMenu = (props: AccountMenuProps) => {
       {t("Account Settings")}
     </Link>
     <div>
-      <a href="https://software.farmbot.io/docs/the-farmbot-web-app"
+      <a href={docLink("the-farmbot-web-app")}
         target="_blank">
         <i className="fa fa-file-text-o"></i>{t("Documentation")}
       </a>

--- a/webpack/ui/__tests__/doc_link_test.ts
+++ b/webpack/ui/__tests__/doc_link_test.ts
@@ -1,0 +1,8 @@
+import { docLink, BASE_URL } from "../doc_link";
+
+describe("docLink", () => {
+  it("creates doc links", () => {
+    expect(docLink()).toEqual(BASE_URL);
+    expect(docLink("farmware")).toEqual(BASE_URL + "farmware");
+  })
+});

--- a/webpack/ui/__tests__/widget_header_test.ts
+++ b/webpack/ui/__tests__/widget_header_test.ts
@@ -1,5 +1,6 @@
 import { WidgetHeader } from "../widget_header";
 import { mount } from "enzyme";
+import { docLink } from "../doc_link";
 
 describe("<WidgetHeader />", () => {
   it("renders title", () => {
@@ -33,7 +34,7 @@ describe("<WidgetHeader />", () => {
       docPage: "farmware"
     }));
     expect(wrapper.html())
-      .toContain("https://software.farmbot.io/docs/farmware");
+      .toContain(docLink("farmware"));
     expect(wrapper.text()).toContain("Documentation");
     expect(wrapper.html()).toContain("fa-external-link");
   });

--- a/webpack/ui/doc_link.ts
+++ b/webpack/ui/doc_link.ts
@@ -1,0 +1,13 @@
+export const BASE_URL = "https://software.farm.bot/docs/";
+
+/** A centralized list of all documentation slugs in the app makes it easier to
+ * rename / move links in the future. */
+export type DocSlug =
+  | "farmware#section-weed-detector"
+  | "farmware#section-camera-calibration"
+  | "the-farmbot-web-app"
+  | "farmware";
+
+/** WHY?: The function keeps things DRY. It also makes life easier when the
+ * documentation URL / slug name changes. */
+export const docLink = (slug?: DocSlug) => BASE_URL + (slug || "");

--- a/webpack/ui/widget_header.tsx
+++ b/webpack/ui/widget_header.tsx
@@ -1,11 +1,12 @@
 import * as React from "react";
 import { t } from "i18next";
 import { JSXChildren } from "../util";
+import { docLink, DocSlug } from "./doc_link";
 
 interface WidgetHeaderProps {
   children?: JSXChildren;
   helpText?: string;
-  docPage?: string;
+  docPage?: DocSlug;
   title: string;
 }
 
@@ -19,7 +20,7 @@ export function WidgetHeader(props: WidgetHeaderProps) {
           {props.helpText}
           {props.docPage &&
             <a
-              href={"https://software.farmbot.io/docs/" + props.docPage}
+              href={docLink(props.docPage)}
               target="_blank">
               {" " + t("Documentation")}
               <i className="fa fa-external-link" />


### PR DESCRIPTION
# Whats New?

 * Add `docLink` helper that points to shiny new `farm.bot` domain.
 * Keep tabs on every documentation link in the app via the `DocSlug` type (let's Typescript compiler keep track of it for us).

# What's Next?

 * Get SSL set up on  `staging.farm.bot` and `my.farm.bot`