### PR TITLE
Allow * iframe on CSP for certain types of webcam feed

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -66,8 +66,8 @@ module FarmBot
           fonts.gstatic.com
         ),
         form_action: %w('self'),
-        frame_ancestors: %w('none'),
-        img_src: %w(* data:), # We need "*" to support webcam users.
+        frame_ancestors: %w(*), # We need "*" to support webcam users.
+        img_src: %w(* data:),   # We need "*" to support webcam users.
         manifest_src: %w('self'),
         media_src: %w(),
         object_src: %w(),


### PR DESCRIPTION
# What's New?

 * Allow `*` as a `frame-src` in the Content Security Policy.

# Why?

 * Some webcam feeds (eg: Nest) require use of an iframe. CSPs require explicit whitelisting of iframe URLs.