### PR TITLE
Update logic for v6 upgrade path

### DIFF
--- a/app/lib/calculate_upgrade.rb
+++ b/app/lib/calculate_upgrade.rb
@@ -1,0 +1,16 @@
+class CalculateUpgrade < Mutations::Command
+    # If version <= this, you can't just fast forward to the latest FBOS version.
+    FBOS_CUTOFF  = Gem::Version.new("5.0.6")
+    # If you have a really, really old FBOS
+    OLD_OS_URL   = "https://api.github.com/repos/farmbot/farmbot_os"+
+                   "/releases/8772352"
+    OS_RELEASE   = ENV.fetch("OS_UPDATE_SERVER") { DEFAULT_OS }
+
+  required do
+    model :version, class: Gem::Version
+  end
+
+  def execute
+    (version <= FBOS_CUTOFF) ? OLD_OS_URL : OS_RELEASE
+  end
+end

--- a/app/lib/calculate_upgrade.rb
+++ b/app/lib/calculate_upgrade.rb
@@ -1,16 +1,30 @@
 class CalculateUpgrade < Mutations::Command
-    # If version <= this, you can't just fast forward to the latest FBOS version.
-    FBOS_CUTOFF  = Gem::Version.new("5.0.6")
-    # If you have a really, really old FBOS
-    OLD_OS_URL   = "https://api.github.com/repos/farmbot/farmbot_os"+
-                   "/releases/8772352"
-    OS_RELEASE   = ENV.fetch("OS_UPDATE_SERVER") { DEFAULT_OS }
+    # If version <= this, you can't just fast forward to the latest FBOS version
+    MEDIUM_OLDISH = Gem::Version.new("5.0.9")
+    LEGACY_CUTOFF = Gem::Version.new("5.0.6")
+
+    # For extremely old versions:
+    OLD_OS_URL    = "https://api.github.com/repos/farmbot/farmbot_os"+
+                    "/releases/8772352"
+
+    # For versions that are slightly out of date:
+    MID_OS_URL    = "https://api.github.com/repos/FarmBot/farmbot_os/releases" +
+                    "/9200943"
+
+    # Latest version when you don't have a custom release URL.
+    DEFAULT_OS    = "https://api.github.com/repos/farmbot/farmbot_os/releases" +
+                    "/latest"
+
+    # Custom URL, or fallback to default if no custom URL is set.
+    OS_RELEASE    = ENV.fetch("OS_UPDATE_SERVER") { DEFAULT_OS }
 
   required do
     model :version, class: Gem::Version
   end
 
   def execute
-    (version <= FBOS_CUTOFF) ? OLD_OS_URL : OS_RELEASE
+    return OLD_OS_URL if version <= LEGACY_CUTOFF
+    return MID_OS_URL if version <= MEDIUM_OLDISH
+    return OS_RELEASE
   end
 end

--- a/app/lib/calculate_upgrade.rb
+++ b/app/lib/calculate_upgrade.rb
@@ -1,5 +1,4 @@
 class CalculateUpgrade < Mutations::Command
-    # If version <= this, you can't just fast forward to the latest FBOS version
     MEDIUM_OLDISH = Gem::Version.new("5.0.9")
     LEGACY_CUTOFF = Gem::Version.new("5.0.6")
 

--- a/app/lib/session_token.rb
+++ b/app/lib/session_token.rb
@@ -4,7 +4,6 @@ class SessionToken < AbstractJwtToken
   MUST_VERIFY  = "Verify account first"
   DEFAULT_OS   = "https://api.github.com/repos/" \
                  "farmbot/farmbot_os/releases/latest"
-  OS_RELEASE   = ENV.fetch("OS_UPDATE_SERVER") { DEFAULT_OS }
   MQTT         = ENV.fetch("MQTT_HOST")
   # If you are not using the standard MQTT broker (eg: you use a 3rd party
   # MQTT vendor), you will need to change this line.
@@ -15,11 +14,6 @@ class SessionToken < AbstractJwtToken
   end
   EXPIRY       = 40.days
   VHOST        = ENV.fetch("MQTT_VHOST") { "/" }
-  # If version <= this, you can't just fast forward to the latest FBOS version.
-  FBOS_CUTOFF  = Gem::Version.new("5.0.6")
-  # If you have a really, really old FBOS
-  OLD_OS_URL   = "https://api.github.com/repos/" +
-                 "farmbot/farmbot_os/releases/8772352"
   BETA_OS_URL  = ENV["BETA_OTA_URL"] || "NOT_SET"
   def self.issue_to(user,
                     iat: Time.now.to_i,
@@ -32,7 +26,7 @@ class SessionToken < AbstractJwtToken
       Rollbar.info("Verification Error", email: user.email)
       raise Errors::Forbidden, MUST_VERIFY
     end
-    url = (fbos_version <= FBOS_CUTOFF) ? OLD_OS_URL : OS_RELEASE
+    url = CalculateUpgrade.run!(version: fbos_version)
     self.new([{ aud:                   aud,
                 sub:                   user.id,
                 iat:                   iat,

--- a/app/lib/session_token.rb
+++ b/app/lib/session_token.rb
@@ -2,8 +2,6 @@
 # `Authorization` header, or used a password to gain access to the MQTT server.
 class SessionToken < AbstractJwtToken
   MUST_VERIFY  = "Verify account first"
-  DEFAULT_OS   = "https://api.github.com/repos/" \
-                 "farmbot/farmbot_os/releases/latest"
   MQTT         = ENV.fetch("MQTT_HOST")
   # If you are not using the standard MQTT broker (eg: you use a 3rd party
   # MQTT vendor), you will need to change this line.

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,7 +38,6 @@ module FarmBot
         [ENV["API_HOST"]] + (ENV["EXTRA_DOMAINS"] || "").split(",")
       )
       .map { |x| x.present? ? "#{x}:#{ENV["API_PORT"]}" : nil }.compact
-    puts ALL_LOCAL_URIS.inspect
     SecureHeaders::Configuration.default do |config|
       config.hsts                              = "max-age=#{1.week.to_i}"
       config.x_frame_options                   = "DENY"

--- a/lib/log_service.rb
+++ b/lib/log_service.rb
@@ -2,7 +2,6 @@ require_relative "./log_service_support"
 
 begin
   # Listen to all logs on the message broker and store them in the database.
-  puts "Starting device log service..."
 
   Transport
     .log_channel

--- a/spec/lib/session_token_spec.rb
+++ b/spec/lib/session_token_spec.rb
@@ -44,12 +44,12 @@ describe SessionToken do
         .unencoded[:os_update_server]
     end
 
-    expect(test_case["0.0.0"]).to eq(SessionToken::OLD_OS_URL)
-    expect(test_case["5.0.5"]).to eq(SessionToken::OLD_OS_URL)
-    expect(test_case["5.0.6"]).to eq(SessionToken::OLD_OS_URL)
-    expect(test_case["5.0.7"]).to eq(SessionToken::OS_RELEASE)
-    expect(test_case["5.0.8"]).to eq(SessionToken::OS_RELEASE)
-    expect(test_case["5.1.0"]).to eq(SessionToken::OS_RELEASE)
+    expect(test_case["0.0.0"]).to eq(CalculateUpgrade::OLD_OS_URL)
+    expect(test_case["5.0.5"]).to eq(CalculateUpgrade::OLD_OS_URL)
+    expect(test_case["5.0.6"]).to eq(CalculateUpgrade::OLD_OS_URL)
+    expect(test_case["5.0.7"]).to eq(CalculateUpgrade::OS_RELEASE)
+    expect(test_case["5.0.8"]).to eq(CalculateUpgrade::OS_RELEASE)
+    expect(test_case["5.1.0"]).to eq(CalculateUpgrade::OS_RELEASE)
   end
 
   it "doesn't honor expired tokens" do

--- a/spec/lib/session_token_spec.rb
+++ b/spec/lib/session_token_spec.rb
@@ -47,8 +47,8 @@ describe SessionToken do
     expect(test_case["0.0.0"]).to eq(CalculateUpgrade::OLD_OS_URL)
     expect(test_case["5.0.5"]).to eq(CalculateUpgrade::OLD_OS_URL)
     expect(test_case["5.0.6"]).to eq(CalculateUpgrade::OLD_OS_URL)
-    expect(test_case["5.0.7"]).to eq(CalculateUpgrade::OS_RELEASE)
-    expect(test_case["5.0.8"]).to eq(CalculateUpgrade::OS_RELEASE)
+    expect(test_case["5.0.7"]).to eq(CalculateUpgrade::MID_OS_URL)
+    expect(test_case["5.0.8"]).to eq(CalculateUpgrade::MID_OS_URL)
     expect(test_case["5.1.0"]).to eq(CalculateUpgrade::OS_RELEASE)
   end
 

--- a/spec/mutations/auth/create_token_from_credentials_spec.rb
+++ b/spec/mutations/auth/create_token_from_credentials_spec.rb
@@ -28,7 +28,7 @@ describe Auth::FromJWT do
       .run!(credentials: creds, fbos_version: Gem::Version.new("999.9.9"))
     expect(results[:token]).to be_kind_of(SessionToken)
     expect(results[:user]).to eq(user)
-    expect(results[:token].unencoded[:os_update_server]).to eq(SessionToken::OS_RELEASE)
+    expect(results[:token].unencoded[:os_update_server]).to eq(CalculateUpgrade::OS_RELEASE)
   end
 
   it 'sometimes renders the legacy URL' do
@@ -41,6 +41,6 @@ describe Auth::FromJWT do
     expect(results[:token]).to be_kind_of(SessionToken)
     expect(results[:user]).to eq(user)
     expect(results[:token].unencoded[:os_update_server])
-      .to eq(SessionToken::OLD_OS_URL)
+      .to eq(CalculateUpgrade::OLD_OS_URL)
   end
 end


### PR DESCRIPTION
# What's New?

 * Update the logic for fetching the appropriate FBOS upgrade path.
 * Move said logic into its own class for flexibility/testability next time around.