### PR TITLE
Jog button improvements

### DIFF
--- a/webpack/__tests__/controls_popup_test.tsx
+++ b/webpack/__tests__/controls_popup_test.tsx
@@ -9,6 +9,7 @@ jest.mock("../device", () => ({
 import * as React from "react";
 import { ControlsPopup } from "../controls_popup";
 import { mount } from "enzyme";
+import { bot } from "../__test_support__/fake_state/bot";
 
 describe("<ControlsPopup />", () => {
   beforeEach(function () {
@@ -17,7 +18,9 @@ describe("<ControlsPopup />", () => {
 
   const wrapper = mount(<ControlsPopup
     dispatch={jest.fn()}
-    axisInversion={{ x: true, y: false, z: false }} />);
+    axisInversion={{ x: true, y: false, z: false }}
+    botPosition={{ x: undefined, y: undefined, z: undefined }}
+    mcuParams={bot.hardware.mcu_params} />);
 
   it("Has a false initial state", () => {
     expect(wrapper.state("isOpen")).toBeFalsy();
@@ -30,16 +33,16 @@ describe("<ControlsPopup />", () => {
   });
 
   it("x axis is inverted", () => {
-    const button = wrapper.find("button").first();
-    expect(button.props().title).toBe("move x axis");
+    const button = wrapper.find("button").at(3);
+    expect(button.props().title).toBe("move x axis (100)");
     button.simulate("click");
     expect(mockDevice.moveRelative)
       .toHaveBeenCalledWith({ speed: 100, x: 100, y: 0, z: 0 });
   });
 
   it("y axis is not inverted", () => {
-    const button = wrapper.find("button").at(2);
-    expect(button.props().title).toBe("move y axis");
+    const button = wrapper.find("button").at(1);
+    expect(button.props().title).toBe("move y axis (100)");
     button.simulate("click");
     expect(mockDevice.moveRelative)
       .toHaveBeenCalledWith({ speed: 100, x: 0, y: 100, z: 0 });

--- a/webpack/app.tsx
+++ b/webpack/app.tsx
@@ -118,7 +118,9 @@ export class App extends React.Component<AppProps, {}> {
         !currentPath.startsWith("/app/regimens") &&
         <ControlsPopup
           dispatch={this.props.dispatch}
-          axisInversion={this.props.axisInversion} />}
+          axisInversion={this.props.axisInversion}
+          botPosition={this.props.bot.hardware.location_data.position}
+          mcuParams={this.props.bot.hardware.mcu_params} />}
     </div>;
   }
 }

--- a/webpack/controls/direction_button.tsx
+++ b/webpack/controls/direction_button.tsx
@@ -3,26 +3,58 @@ import { Farmbot } from "farmbot";
 import { moveRelative } from "../devices/actions";
 import { DirectionButtonProps, Payl } from "./interfaces";
 
+export function directionDisabled(props: DirectionButtonProps): boolean {
+  const {
+    stopAtHome, stopAtMax, axisLength, position, isInverted, negativeOnly
+   } = props.directionAxisProps;
+  const { direction } = props;
+  const loc = position || 0;
+  const jog = calculateDistance(props);
+  const directionDisableHome = stopAtHome && loc === 0 &&
+    (negativeOnly ? jog > 0 : jog < 0);
+  const directionDisableEnd = stopAtMax && axisLength > 0 &&
+    Math.abs(loc) === axisLength && Math.abs(loc + jog) > axisLength;
+  switch (direction) {
+    case "left":
+    case "down":
+      return (isInverted === negativeOnly)
+        ? directionDisableHome
+        : directionDisableEnd;
+    case "right":
+    case "up":
+      return (isInverted === !negativeOnly)
+        ? directionDisableHome
+        : directionDisableEnd;
+    default:
+      return false;
+  }
+}
+
+export function calculateDistance(props: DirectionButtonProps) {
+  const { direction } = props;
+  const { isInverted } = props.directionAxisProps;
+  const isNegative = (direction === "down") || (direction === "left");
+  const inverter = isInverted ? -1 : 1;
+  const multiplier = isNegative ? -1 : 1;
+  const distance = (props.steps || 250) * multiplier * inverter;
+  return distance;
+}
+
 export class DirectionButton extends React.Component<DirectionButtonProps, {}> {
   sendCommand = () => {
-    const { direction, isInverted } = this.props;
-    const isNegative = (direction === "up") || (direction === "right");
-    const inverter = isInverted ? -1 : 1;
-    const multiplier = isNegative ? -1 : 1;
-    const distance = (this.props.steps || 250) * multiplier * inverter;
     const payload: Payl = { speed: Farmbot.defaults.speed, x: 0, y: 0, z: 0 };
-    payload[this.props.axis] = distance;
+    payload[this.props.axis] = calculateDistance(this.props);
     moveRelative(payload);
   }
 
   render() {
     const { direction, axis, disabled } = this.props;
     const klass = `fb-button fa fa-2x arrow-button radius fa-arrow-${direction}`;
-    const title = `move ${axis} axis`;
+    const title = `move ${axis} axis (${calculateDistance(this.props)})`;
     return <button
       onClick={this.sendCommand}
       className={klass}
       title={title}
-      disabled={disabled || false} />;
+      disabled={disabled || directionDisabled(this.props)} />;
   }
 }

--- a/webpack/controls/interfaces.ts
+++ b/webpack/controls/interfaces.ts
@@ -34,7 +34,14 @@ export interface MoveProps {
 export interface DirectionButtonProps {
   axis: Xyz;
   direction: "up" | "down" | "left" | "right";
-  isInverted: boolean;
+  directionAxisProps: {
+    isInverted: boolean;
+    stopAtHome: boolean;
+    stopAtMax: boolean;
+    axisLength: number;
+    negativeOnly: boolean;
+    position: number | undefined;
+  }
   steps: number;
   disabled: boolean | undefined;
 }

--- a/webpack/controls/jog_buttons.tsx
+++ b/webpack/controls/jog_buttons.tsx
@@ -6,6 +6,36 @@ import { getDevice } from "../device";
 
 export class JogButtons extends React.Component<JogMovementControlsProps, {}> {
   render() {
+    const { mcu_params } = this.props.bot.hardware;
+    const directionAxesProps = {
+      x: {
+        isInverted: this.props.x_axis_inverted,
+        stopAtHome: !!mcu_params.movement_stop_at_home_x,
+        stopAtMax: !!mcu_params.movement_stop_at_max_x,
+        axisLength: (mcu_params.movement_axis_nr_steps_x || 0)
+          / (mcu_params.movement_step_per_mm_x || 1),
+        negativeOnly: !!mcu_params.movement_home_up_x,
+        position: this.props.bot.hardware.location_data.position.x
+      },
+      y: {
+        isInverted: this.props.y_axis_inverted,
+        stopAtHome: !!mcu_params.movement_stop_at_home_y,
+        stopAtMax: !!mcu_params.movement_stop_at_max_y,
+        axisLength: (mcu_params.movement_axis_nr_steps_y || 0)
+          / (mcu_params.movement_step_per_mm_y || 1),
+        negativeOnly: !!mcu_params.movement_home_up_y,
+        position: this.props.bot.hardware.location_data.position.y
+      },
+      z: {
+        isInverted: this.props.z_axis_inverted,
+        stopAtHome: !!mcu_params.movement_stop_at_home_z,
+        stopAtMax: !!mcu_params.movement_stop_at_max_z,
+        axisLength: (mcu_params.movement_axis_nr_steps_z || 0)
+          / (mcu_params.movement_step_per_mm_z || 1),
+        negativeOnly: !!mcu_params.movement_home_up_z,
+        position: this.props.bot.hardware.location_data.position.z
+      },
+    };
     return <table className="jog-table" style={{ border: 0 }}>
       <tbody>
         <tr>
@@ -20,7 +50,7 @@ export class JogButtons extends React.Component<JogMovementControlsProps, {}> {
             <DirectionButton
               axis="y"
               direction="up"
-              isInverted={this.props.y_axis_inverted}
+              directionAxisProps={directionAxesProps.y}
               steps={this.props.bot.stepSize || 1000}
               disabled={this.props.disabled} />
           </td>
@@ -30,7 +60,7 @@ export class JogButtons extends React.Component<JogMovementControlsProps, {}> {
             <DirectionButton
               axis="z"
               direction="up"
-              isInverted={this.props.z_axis_inverted}
+              directionAxisProps={directionAxesProps.z}
               steps={this.props.bot.stepSize || 1000}
               disabled={this.props.disabled} />
           </td>
@@ -47,7 +77,7 @@ export class JogButtons extends React.Component<JogMovementControlsProps, {}> {
             <DirectionButton
               axis="x"
               direction="left"
-              isInverted={this.props.x_axis_inverted}
+              directionAxisProps={directionAxesProps.x}
               steps={this.props.bot.stepSize || 1000}
               disabled={this.props.disabled} />
           </td>
@@ -55,7 +85,7 @@ export class JogButtons extends React.Component<JogMovementControlsProps, {}> {
             <DirectionButton
               axis="y"
               direction="down"
-              isInverted={this.props.y_axis_inverted}
+              directionAxisProps={directionAxesProps.y}
               steps={this.props.bot.stepSize || 1000}
               disabled={this.props.disabled} />
           </td>
@@ -63,7 +93,7 @@ export class JogButtons extends React.Component<JogMovementControlsProps, {}> {
             <DirectionButton
               axis="x"
               direction="right"
-              isInverted={this.props.x_axis_inverted}
+              directionAxisProps={directionAxesProps.x}
               steps={this.props.bot.stepSize || 1000}
               disabled={this.props.disabled} />
           </td>
@@ -72,7 +102,7 @@ export class JogButtons extends React.Component<JogMovementControlsProps, {}> {
             <DirectionButton
               axis="z"
               direction="down"
-              isInverted={this.props.z_axis_inverted}
+              directionAxisProps={directionAxesProps.z}
               steps={this.props.bot.stepSize || 1000}
               disabled={this.props.disabled} />
           </td>

--- a/webpack/controls_popup.tsx
+++ b/webpack/controls_popup.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
 
 import { DirectionButton } from "./controls/direction_button";
-import { Xyz } from "./devices/interfaces";
+import { Xyz, BotPosition } from "./devices/interfaces";
+import { McuParams } from "farmbot";
 
 export interface State {
   isOpen: boolean;
@@ -11,6 +12,8 @@ export interface State {
 export interface Props {
   dispatch: Function;
   axisInversion: Record<Xyz, boolean>;
+  botPosition: BotPosition;
+  mcuParams: McuParams;
 }
 
 export class ControlsPopup extends React.Component<Props, Partial<State>> {
@@ -25,6 +28,27 @@ export class ControlsPopup extends React.Component<Props, Partial<State>> {
 
   public render() {
     const isOpen = this.state.isOpen ? "open" : "";
+    const { mcuParams } = this.props;
+    const directionAxesProps = {
+      x: {
+        isInverted: this.props.axisInversion.x,
+        stopAtHome: !!mcuParams.movement_stop_at_home_x,
+        stopAtMax: !!mcuParams.movement_stop_at_max_x,
+        axisLength: (mcuParams.movement_axis_nr_steps_x || 0)
+          / (mcuParams.movement_step_per_mm_x || 1),
+        negativeOnly: !!mcuParams.movement_home_up_x,
+        position: this.props.botPosition.x
+      },
+      y: {
+        isInverted: this.props.axisInversion.y,
+        stopAtHome: !!mcuParams.movement_stop_at_home_y,
+        stopAtMax: !!mcuParams.movement_stop_at_max_y,
+        axisLength: (mcuParams.movement_axis_nr_steps_y || 0)
+          / (mcuParams.movement_step_per_mm_y || 1),
+        negativeOnly: !!mcuParams.movement_home_up_y,
+        position: this.props.botPosition.y
+      }
+    };
     return <div
       className={"controls-popup " + isOpen}>
       <i className="fa fa-crosshairs"
@@ -32,27 +56,27 @@ export class ControlsPopup extends React.Component<Props, Partial<State>> {
       <div className="controls-popup-menu-outer">
         <div className="controls-popup-menu-inner">
           <DirectionButton
-            axis="x"
+            axis={"x"}
             direction="right"
-            isInverted={this.props.axisInversion.x}
+            directionAxisProps={directionAxesProps.x}
             steps={this.state.stepSize}
             disabled={!isOpen} />
           <DirectionButton
-            axis="y"
+            axis={"y"}
             direction="up"
-            isInverted={this.props.axisInversion.y}
+            directionAxisProps={directionAxesProps.y}
             steps={this.state.stepSize}
             disabled={!isOpen} />
           <DirectionButton
-            axis="y"
+            axis={"y"}
             direction="down"
-            isInverted={this.props.axisInversion.y}
+            directionAxisProps={directionAxesProps.y}
             steps={this.state.stepSize}
             disabled={!isOpen} />
           <DirectionButton
-            axis="x"
+            axis={"x"}
             direction="left"
-            isInverted={this.props.axisInversion.x}
+            directionAxisProps={directionAxesProps.x}
             steps={this.state.stepSize}
             disabled={!isOpen} />
         </div>

--- a/webpack/css/widget_move.scss
+++ b/webpack/css/widget_move.scss
@@ -69,6 +69,7 @@
   }
   &:disabled {
     border-bottom: none;
+    box-shadow: none !important;
   }
 }
 


### PR DESCRIPTION
**Controls (and controls pop-up):**
 * Disable _Move_ widget jog buttons when movement is not possible in that direction (i.e. at axis end with `STOP AT HOME` or `STOP AT MAX` enabled).
 * Jog button hover text now includes the jog distance and direction in addition to the axis.