### PR TITLE
Bug fixes and API-side `sensor_reading` prep

### DIFF
--- a/app/controllers/api/abstract_controller.rb
+++ b/app/controllers/api/abstract_controller.rb
@@ -196,7 +196,6 @@ private
     def mark_as_seen(bot = (current_user && current_user.device))
       when_farmbot_os do
         v = fbos_version.to_s
-        Rollbar.info("VERSION IS: #{v}") if bot && v
         bot.update_attributes!(last_saw_api: Time.now, fbos_version: v) if bot
       end
     end

--- a/app/controllers/api/abstract_controller.rb
+++ b/app/controllers/api/abstract_controller.rb
@@ -195,7 +195,8 @@ private
     # We update this column every time an FBOS device talks to the API.
     def mark_as_seen(entity = (current_user && current_user.device))
       when_farmbot_os do
-        entity.update_attributes(last_saw_api: Time.now) if entity
+        entity.update_attributes(last_saw_api: Time.now,
+                                 fbos_version: fbos_version.to_s) if entity
       end
     end
   end

--- a/app/controllers/api/abstract_controller.rb
+++ b/app/controllers/api/abstract_controller.rb
@@ -197,7 +197,7 @@ private
       when_farmbot_os do
         v = fbos_version.to_s
         Rollbar.info("VERSION IS: #{v}") if bot && v
-        bot.update_attributes(last_saw_api: Time.now, fbos_version: v) if bot
+        bot.update_attributes!(last_saw_api: Time.now, fbos_version: v) if bot
       end
     end
   end

--- a/app/controllers/api/abstract_controller.rb
+++ b/app/controllers/api/abstract_controller.rb
@@ -193,10 +193,11 @@ private
 
     # Devices have a `last_saw_api` field to assist users with debugging.
     # We update this column every time an FBOS device talks to the API.
-    def mark_as_seen(entity = (current_user && current_user.device))
+    def mark_as_seen(bot = (current_user && current_user.device))
       when_farmbot_os do
-        entity.update_attributes(last_saw_api: Time.now,
-                                 fbos_version: fbos_version.to_s) if entity
+        v = fbos_version.to_s
+        Rollbar.info("VERSION IS: #{v}") if bot && v
+        bot.update_attributes(last_saw_api: Time.now, fbos_version: v) if bot
       end
     end
   end

--- a/app/controllers/api/images_controller.rb
+++ b/app/controllers/api/images_controller.rb
@@ -9,7 +9,7 @@ module Api
     SECRET = ENV.fetch("GCS_ID") { "" }
 
     def create
-        mutate Images::Create.run({device: current_device}, raw_json)
+        mutate Images::Create.run(raw_json, device: current_device)
     end
 
     def index

--- a/app/controllers/api/sensor_readings_controller.rb
+++ b/app/controllers/api/sensor_readings_controller.rb
@@ -1,0 +1,30 @@
+module Api
+  class SensorReadingsController < Api::AbstractController
+    def create
+        mutate SensorReadings::Create.run(raw_json, device: current_device)
+    end
+
+    def index
+      render json: readings
+    end
+
+    def show
+      render json: reading
+    end
+
+    def destroy
+      reading.destroy!
+      render json: ""
+    end
+
+  private
+
+    def readings
+      SensorReading.where(device: current_device)
+    end
+
+    def reading
+      @image ||= readings.find(params[:id])
+    end
+  end
+end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -12,7 +12,8 @@ class ApplicationRecord < ActiveRecord::Base
                      "sign_in_count",
                      "updated_at",
                      "current_sign_in_ip",
-                     "current_sign_in_at" ]
+                     "current_sign_in_at",
+                     "fbos_version" ]
   def the_changes
     self.saved_changes.except(*self.class::DONT_BROADCAST)
   end

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -15,6 +15,7 @@ class Device < ApplicationRecord
   has_many  :tools,           dependent: :destroy
   has_many  :images,          dependent: :destroy
   has_many  :webcam_feeds,    dependent: :destroy
+  has_many  :sensor_reading,  dependent: :destroy
   validates :timezone,     inclusion: { in: TIMEZONES,
                                         message: BAD_TZ,
                                         allow_nil: true }

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -15,7 +15,7 @@ class Device < ApplicationRecord
   has_many  :tools,           dependent: :destroy
   has_many  :images,          dependent: :destroy
   has_many  :webcam_feeds,    dependent: :destroy
-  has_many  :sensor_reading,  dependent: :destroy
+  has_many  :sensor_readings,  dependent: :destroy
   validates :timezone,     inclusion: { in: TIMEZONES,
                                         message: BAD_TZ,
                                         allow_nil: true }
@@ -29,22 +29,6 @@ class Device < ApplicationRecord
   def limited_log_list
     logs.all.last(max_log_count || DEFAULT_MAX_LOGS)
   end
-
-  # def auth_token
-  #   SessionToken.as_json(self.users.first)[:token].encoded
-  # end
-
-  # # Send a realtime message to a logged in user.
-  # def tell(message, chan = "toast")
-  #   log  = Log.new({ device:     self,
-  #                    message:    message,
-  #                    created_at: Time.now,
-  #                    channels:   [chan],
-  #                    meta:       { type: "info" } })
-  #   json = LogSerializer.new(log).as_json.to_json
-
-  #   Transport.amqp_send(json, self.id, "logs")
-  # end
 
   def self.current
     RequestStore.store[:device]

--- a/app/models/sensor_reading.rb
+++ b/app/models/sensor_reading.rb
@@ -1,0 +1,3 @@
+class SensorReading < ApplicationRecord
+  belongs_to :device
+end

--- a/app/mutations/sensor_readings/create.rb
+++ b/app/mutations/sensor_readings/create.rb
@@ -1,0 +1,16 @@
+module SensorReadings
+  class Create < Mutations::Command
+    required do
+      model   :device, class: Device
+      float   :x
+      float   :y
+      float   :z
+      integer :value
+      integer :pin
+    end
+
+    def execute
+      SensorReading.create!(inputs)
+    end
+  end
+end

--- a/app/mutations/sensor_readings/create.rb
+++ b/app/mutations/sensor_readings/create.rb
@@ -2,9 +2,9 @@ module SensorReadings
   class Create < Mutations::Command
     required do
       model   :device, class: Device
-      float   :x
-      float   :y
-      float   :z
+      float   :x, nils: true, empty_is_nil: true
+      float   :y, nils: true, empty_is_nil: true
+      float   :z, nils: true, empty_is_nil: true
       integer :value
       integer :pin
     end

--- a/app/serializers/device_serializer.rb
+++ b/app/serializers/device_serializer.rb
@@ -1,6 +1,6 @@
 class DeviceSerializer < ActiveModel::Serializer
-  attributes :id, :name, :timezone, :last_saw_api, :last_saw_mq,
-    :last_seen, :tz_offset_hrs
+  attributes :id, :name, :timezone, :last_saw_api, :last_saw_mq, :last_seen,
+             :tz_offset_hrs, :fbos_version
 
   def last_seen
     # TODO: Remove this by December 2017.

--- a/app/serializers/peripheral_serializer.rb
+++ b/app/serializers/peripheral_serializer.rb
@@ -1,7 +1,3 @@
 class PeripheralSerializer < ActiveModel::Serializer
   attributes :id, :pin, :label, :mode
-
-  def mode
-    -1 # DEPRECATED. Still here for legacy reasons. Don't use it. - RC
-  end
 end

--- a/app/serializers/peripheral_serializer.rb
+++ b/app/serializers/peripheral_serializer.rb
@@ -1,3 +1,7 @@
 class PeripheralSerializer < ActiveModel::Serializer
-  attributes :id, :pin, :label
+  attributes :id, :pin, :label, :mode
+
+  def mode
+    -1 # DEPRECATED. Still here for legacy reasons. Don't use it. - RC
+  end
 end

--- a/app/serializers/sensor_reading_serializer.rb
+++ b/app/serializers/sensor_reading_serializer.rb
@@ -1,0 +1,3 @@
+class SensorReadingSerializer < ActiveModel::Serializer
+  attributes :id, :pin, :value, :x, :y, :z
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,15 +1,16 @@
 FarmBot::Application.routes.draw do
 
   namespace :api, defaults: {format: :json}, constraints: { format: "json" } do
-    resources :images,        only: [:create, :destroy, :show, :index]
-    resources :regimens,      only: [:create, :destroy, :index, :update]
-    resources :peripherals,   only: [:create, :destroy, :index, :update]
-    resources :corpuses,      only: [:index, :show]
-    resources :logs,          only: [:index, :create, :destroy]
-    resources :sequences,     only: [:create, :update, :destroy, :index, :show]
-    resources :farm_events,   only: [:create, :update, :destroy, :index]
-    resources :tools,         only: [:create, :show, :index, :destroy, :update]
-    resources :points,        only: [:create, :show, :index, :destroy, :update] do
+    resources :images,          only: [:create, :destroy, :show, :index]
+    resources :sensor_readings, only: [:create, :destroy, :show, :index]
+    resources :regimens,        only: [:create, :destroy, :index, :update]
+    resources :peripherals,     only: [:create, :destroy, :index, :update]
+    resources :corpuses,        only: [:index, :show]
+    resources :logs,            only: [:index, :create, :destroy]
+    resources :sequences,       only: [:create, :update, :destroy, :index, :show]
+    resources :farm_events,     only: [:create, :update, :destroy, :index]
+    resources :tools,           only: [:create, :show, :index, :destroy, :update]
+    resources :points,          only: [:create, :show, :index, :destroy, :update] do
         post :search, on: :collection
     end
     resource :public_key,     only: [:show]

--- a/db/migrate/20180215171709_create_sensor_readings.rb
+++ b/db/migrate/20180215171709_create_sensor_readings.rb
@@ -1,0 +1,14 @@
+class CreateSensorReadings < ActiveRecord::Migration[5.1]
+  def change
+    create_table :sensor_readings do |t|
+      t.references :device, foreign_key: true
+      t.float :x
+      t.float :y
+      t.float :z
+      t.integer :value
+      t.integer :pin
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180215205625_update_devices_and_peripherals.rb
+++ b/db/migrate/20180215205625_update_devices_and_peripherals.rb
@@ -1,0 +1,6 @@
+class UpdateDevicesAndPeripherals < ActiveRecord::Migration[5.1]
+  def change
+    add_column :devices, :fbos_version, :string, limit: 15 # "99.99.99-rc99"
+    add_column :peripherals, :mode, :integer
+  end
+end

--- a/db/migrate/20180215224528_add_default_to_mode_on_peripherals.rb
+++ b/db/migrate/20180215224528_add_default_to_mode_on_peripherals.rb
@@ -1,6 +1,7 @@
 class AddDefaultToModeOnPeripherals < ActiveRecord::Migration[5.1]
   def up
     change_column :peripherals, :mode, :integer, default: 0
+    Peripheral.where(mode: nil).update_all(mode: 0)
   end
 
   def down

--- a/db/migrate/20180215224528_add_default_to_mode_on_peripherals.rb
+++ b/db/migrate/20180215224528_add_default_to_mode_on_peripherals.rb
@@ -1,0 +1,9 @@
+class AddDefaultToModeOnPeripherals < ActiveRecord::Migration[5.1]
+  def up
+    change_column :peripherals, :mode, :integer, default: 0
+  end
+
+  def down
+    change_column :peripherals, :mode, :integer, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180215064728) do
+ActiveRecord::Schema.define(version: 20180215171709) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -283,6 +283,18 @@ ActiveRecord::Schema.define(version: 20180215064728) do
     t.index ["device_id"], name: "index_regimens_on_device_id"
   end
 
+  create_table "sensor_readings", force: :cascade do |t|
+    t.bigint "device_id"
+    t.float "x"
+    t.float "y"
+    t.float "z"
+    t.integer "value"
+    t.integer "pin"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["device_id"], name: "index_sensor_readings_on_device_id"
+  end
+
   create_table "sequence_dependencies", id: :serial, force: :cascade do |t|
     t.string "dependency_type"
     t.integer "dependency_id"
@@ -407,6 +419,7 @@ ActiveRecord::Schema.define(version: 20180215064728) do
   add_foreign_key "peripherals", "devices"
   add_foreign_key "points", "devices"
   add_foreign_key "primary_nodes", "sequences"
+  add_foreign_key "sensor_readings", "devices"
   add_foreign_key "sequence_dependencies", "sequences"
   add_foreign_key "tool_slots", "tools"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180215205625) do
+ActiveRecord::Schema.define(version: 20180215224528) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -225,7 +225,7 @@ ActiveRecord::Schema.define(version: 20180215205625) do
     t.string "label", limit: 280
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "mode"
+    t.integer "mode", default: 0
     t.index ["device_id"], name: "index_peripherals_on_device_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180215171709) do
+ActiveRecord::Schema.define(version: 20180215205625) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,6 +38,7 @@ ActiveRecord::Schema.define(version: 20180215171709) do
     t.string "timezone", limit: 280
     t.datetime "last_saw_api"
     t.datetime "last_saw_mq"
+    t.string "fbos_version", limit: 15
     t.index ["timezone"], name: "index_devices_on_timezone"
   end
 
@@ -224,6 +225,7 @@ ActiveRecord::Schema.define(version: 20180215171709) do
     t.string "label", limit: 280
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "mode"
     t.index ["device_id"], name: "index_peripherals_on_device_id"
   end
 

--- a/lib/log_service_support.rb
+++ b/lib/log_service_support.rb
@@ -29,7 +29,7 @@ class LogService
     if(major_version >= 6)
       device_id = delivery_info.routing_key.split(".")[1].gsub("device_", "").to_i
       if save?(log)
-        device       = Device.find(device_id)
+        device = Device.find(device_id)
         db_log = Logs::Create.run!(log, device: device)
         db_log.save!
         maybe_clear_logs(device)

--- a/spec/controllers/api/devices/devices_controller_index_spec.rb
+++ b/spec/controllers/api/devices/devices_controller_index_spec.rb
@@ -21,5 +21,9 @@ describe Api::DevicesController do
       get :show, format: :json # FIXME: Y U NO DEFAULT JSON?
       expect(response.status).to eq(401)
     end
+
+    it 'updates fbos_version when appropriate' do
+      pending
+    end
   end
 end

--- a/spec/controllers/api/devices/devices_controller_index_spec.rb
+++ b/spec/controllers/api/devices/devices_controller_index_spec.rb
@@ -21,9 +21,5 @@ describe Api::DevicesController do
       get :show, format: :json # FIXME: Y U NO DEFAULT JSON?
       expect(response.status).to eq(401)
     end
-
-    it 'updates fbos_version when appropriate' do
-      pending
-    end
   end
 end

--- a/spec/controllers/api/sensor_readings/controller_spec.rb
+++ b/spec/controllers/api/sensor_readings/controller_spec.rb
@@ -14,7 +14,7 @@ describe Api::SensorReadingsController do
         body: { pin: 13, value: 128, x: nil, y: 1, z: 2 }.to_json,
         params: { format: :json }
 
-      expect(response.status).to eq(200)
+      expect(response.status).to  eq(200)
       expect(json[:id]).to        be_kind_of(Integer)
       expect(json[:value]).to     eq(128)
       expect(json[:device_id]).to eq(nil) # Use the serializer, not as_json.
@@ -23,6 +23,41 @@ describe Api::SensorReadingsController do
       expect(json[:z]).to         eq(2)
       expect(json[:pin]).to       eq(13)
       expect(before < SensorReading.count).to be_truthy
+    end
+
+    it 'shows one reading' do
+      sign_in user
+      SensorReading.destroy_all
+      id = reading.id
+      get :show, params: { format: :json, id: id }
+      expect(json).to be_kind_of(Hash)
+      reading.reload
+      [ :id, :value, :x, :y, :z, :pin ].map do |attr|
+        expect(json[attr]).to eq(reading.send(attr))
+      end
+    end
+
+    it 'shows all readings' do
+      sign_in user
+      SensorReading.destroy_all
+      id = reading.id
+      get :index, params: { format: :json }
+      expect(json).to be_kind_of(Array)
+      expect(json.length).to eq(user.device.sensor_readings.length)
+      keys = json.first.keys
+      expect(json.map{|x| x[:id] }).to include(id)
+      expect(keys).to include(:x, :y, :z, :value, :pin)
+    end
+
+    it 'destroys a reading' do
+      sign_in user
+      SensorReading.destroy_all
+      id = reading.id
+      before = SensorReading.count
+      expect(before).to eq(1)
+      delete :destroy, params: { format: :json, id: id }
+      expect(SensorReading.where(id: id).count).to eq(0)
+      expect(before).to be > SensorReading.count
     end
 
     it 'requires logged in user' do

--- a/spec/controllers/api/sensor_readings/controller_spec.rb
+++ b/spec/controllers/api/sensor_readings/controller_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe Api::SensorReadingsController do
+  include Devise::Test::ControllerHelpers
+
+  describe 'CRUD actions' do
+    let(:user)     { FactoryBot.create(:user) }
+    let (:reading) { FactoryBot.create(:sensor_reading, device: user.device) }
+
+    it 'makes a sensor reading' do
+      sign_in user
+      before = SensorReading.count
+      post :create,
+        body: { pin: 13, value: 128, x: nil, y: 1, z: 2 }.to_json,
+        params: { format: :json }
+
+      expect(response.status).to eq(200)
+      expect(json[:id]).to        be_kind_of(Integer)
+      expect(json[:value]).to     eq(128)
+      expect(json[:device_id]).to eq(nil) # Use the serializer, not as_json.
+      expect(json[:x]).to         eq(nil)
+      expect(json[:y]).to         eq(1)
+      expect(json[:z]).to         eq(2)
+      expect(json[:pin]).to       eq(13)
+      expect(before < SensorReading.count).to be_truthy
+    end
+
+    it 'requires logged in user' do
+      post :create, params: {}
+      expect(response.status).to eq(401)
+    end
+  end
+end

--- a/spec/factories/sensor_readings.rb
+++ b/spec/factories/sensor_readings.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :sensor_reading do
+    device
+    x { rand(1..500) }
+    y { rand(1..500) }
+    z { rand(1..500) }
+    value { rand(0..1024) }
+    pin { rand(1..540) }
+  end
+end

--- a/spec/models/sensor_reading_spec.rb
+++ b/spec/models/sensor_reading_spec.rb
@@ -1,0 +1,14 @@
+require "spec_helper"
+
+RSpec.describe SensorReading, type: :model do
+  let(:sensor_reading) { FactoryBot.create(:sensor_reading) }
+
+  it "Has basic attributes" do
+    expect(sensor_reading.device).to be_kind_of(Device)
+    expect(sensor_reading.value).to  be_kind_of(Integer)
+    expect(sensor_reading.pin).to    be_kind_of(Integer)
+    expect(sensor_reading.x).to      be_kind_of(Float)
+    expect(sensor_reading.y).to      be_kind_of(Float)
+    expect(sensor_reading.z).to      be_kind_of(Float)
+  end
+end

--- a/webpack/api/api.ts
+++ b/webpack/api/api.ts
@@ -119,6 +119,8 @@ export class API {
   get webAppConfigPath() { return `${this.baseUrl}/api/web_app_config/`; }
   /** /api/fbos_config */
   get fbosConfigPath() { return `${this.baseUrl}/api/fbos_config/`; }
+  /** /api/sensor_readings */
+  get sensorReadingPath() { return `${this.baseUrl}/api/sensor_readings`; }
   /** /api/users/verify/:token */
   verificationPath = (token: string) => ("/api/users/verify/" + token);
 }

--- a/webpack/devices/interfaces.ts
+++ b/webpack/devices/interfaces.ts
@@ -46,6 +46,7 @@ export interface DeviceAccountSettings {
   name: string;
   timezone?: string | undefined;
   tz_offset_hrs: number;
+  fbos_version?: string | undefined;
   last_saw_api?: string | undefined;
   last_saw_mq?: string | undefined;
 }

--- a/webpack/interfaces.ts
+++ b/webpack/interfaces.ts
@@ -21,6 +21,14 @@ export interface SelectOptionsParams {
   z?: number;
 }
 
+export interface SensorReading {
+  id?: number | undefined;
+  x: number | undefined;
+  y: number | undefined;
+  z: number | undefined;
+  value: number;
+  pin: number;
+}
 export interface Log {
   id?: number | undefined;
   message: string;

--- a/webpack/resources/reducer.ts
+++ b/webpack/resources/reducer.ts
@@ -74,7 +74,8 @@ export function emptyState(): RestResources {
         User: [],
         FbosConfig: [],
         FirmwareConfig: [],
-        WebAppConfig: []
+        WebAppConfig: [],
+        SensorReading: []
       },
       byKindAndId: {},
       references: {}
@@ -158,6 +159,7 @@ export let resourceReducer = generateReducer
       case "WebAppConfig":
       case "FbosConfig":
       case "FirmwareConfig":
+      case "SensorReading":
       case "Image":
         removeFromIndex(s.index, resource);
         break;

--- a/webpack/resources/tagged_resources.ts
+++ b/webpack/resources/tagged_resources.ts
@@ -7,6 +7,7 @@ import {
   GenericPointer,
   PlantPointer,
   ToolSlotPointer,
+  SensorReading,
 } from "../interfaces";
 import { Peripheral } from "../controls/peripherals/interfaces";
 import { User } from "../auth/interfaces";
@@ -25,19 +26,20 @@ export type ResourceName =
   | "Crop"
   | "Device"
   | "FarmEvent"
+  | "FbosConfig"
+  | "FirmwareConfig"
+  | "Image"
+  | "Log"
   | "Peripheral"
   | "Plant"
-  | "Log"
-  | "Image"
   | "Point"
   | "Regimen"
+  | "SensorReading"
   | "Sequence"
   | "Tool"
   | "User"
-  | "WebcamFeed"
-  | "FbosConfig"
-  | "FirmwareConfig"
-  | "WebAppConfig";
+  | "WebAppConfig"
+  | "WebcamFeed";
 
 export interface TaggedResourceBase {
   kind: ResourceName;
@@ -81,21 +83,22 @@ export interface Resource<T extends ResourceName, U extends object>
 }
 
 export type TaggedResource =
-  | TaggedPoint
   | TaggedCrop
   | TaggedDevice
   | TaggedFarmEvent
+  | TaggedFbosConfig
+  | TaggedFirmwareConfig
   | TaggedImage
   | TaggedLog
   | TaggedPeripheral
+  | TaggedPoint
   | TaggedRegimen
+  | TaggedSensorReading
   | TaggedSequence
   | TaggedTool
   | TaggedUser
-  | TaggedWebcamFeed
-  | TaggedFbosConfig
   | TaggedWebAppConfig
-  | TaggedFirmwareConfig;
+  | TaggedWebcamFeed;
 
 export type TaggedRegimen = Resource<"Regimen", Regimen>;
 export type TaggedTool = Resource<"Tool", Tool>;
@@ -108,6 +111,7 @@ export type TaggedPeripheral = Resource<"Peripheral", Peripheral>;
 export type TaggedFbosConfig = Resource<"FbosConfig", FbosConfig>;
 export type TaggedFirmwareConfig = Resource<"FirmwareConfig", FirmwareConfig>;
 export type TaggedWebAppConfig = Resource<"WebAppConfig", WebAppConfig>;
+export type TaggedSensorReading = Resource<"SensorReading", SensorReading>;
 
 type PointUnion = GenericPointer | PlantPointer | ToolSlotPointer;
 

--- a/webpack/sync/actions.ts
+++ b/webpack/sync/actions.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { Log, Point } from "../interfaces";
+import { Log, Point, SensorReading } from "../interfaces";
 import { API } from "../api";
 import { Sequence } from "../sequences/interfaces";
 import { Tool } from "../tools/interfaces";
@@ -51,4 +51,5 @@ export function fetchSyncData(dispatch: Function) {
   fetch<Regimen[]>("Regimen", API.current.regimensPath);
   fetch<Sequence[]>("Sequence", API.current.sequencesPath);
   fetch<Tool[]>("Tool", API.current.toolsPath);
+  fetch<SensorReading[]>("SensorReading", API.current.sensorReadingPath);
 }


### PR DESCRIPTION
# What's New?

 * Added "sensor readings" to API, database and frontend as `TaggedSensorReading` (no UI components yet).
 * Track `fbos_version` the same way we track `last_seen` on the API side.
 * Add `mode` col back to peripherals table (oops)
