### PR TITLE
Fix blinky test

### DIFF
--- a/spec/controllers/api/points/create_spec.rb
+++ b/spec/controllers/api/points/create_spec.rb
@@ -124,7 +124,7 @@ describe Api::PointsController do
                   x: 0,
                   y: 0,
                   z: 0,
-                  tool_id: (Tool.last.try(:id || 0) + 100) }
+                  tool_id: (Tool.count + 100) }
       old_tool_count = ToolSlot.count
       post :create, body: payload.to_json, params: {format: :json}
       expect(response.status).to eq(422)


### PR DESCRIPTION
Just a late addition to fix a test that would sometimes fail due to the random order of tests.