### PR TITLE
Better error message sequence deletion error message

### DIFF
--- a/app/mutations/sequences/delete.rb
+++ b/app/mutations/sequences/delete.rb
@@ -8,6 +8,7 @@ module Sequences
     end
 
     def validate
+      check_if_any_pin_bindings_using_this
       check_if_any_regimens_using_this
       check_if_any_sequences_using_this
       FarmEvent.if_still_using(sequence) do
@@ -20,6 +21,16 @@ module Sequences
        return ""
     end
   private
+
+    def check_if_any_pin_bindings_using_this
+      in_use = PinBinding
+        .where(sequence_id: sequence.id)
+        .pluck(:pin_num)
+        .map { |x| "pin #{x}"}
+      names = in_use.join(", ")
+      msg = IN_USE % ["pin bindings", names]
+      add_error(:sequence, :in_use, msg) if in_use.any?
+    end
 
     def check_if_any_sequences_using_this
       # Finds CeleryScript nodes that are using `sequence_id` xyz, but excludes


### PR DESCRIPTION
# Why?

 * Deleting a sequence that is in use by a `PinBinding` currently causes a 500 error.