### PR TITLE
V6.2.0 Final Touches

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "enzyme": "^3.1.0",
     "enzyme-adapter-react-16": "^1.1.0",
     "extract-text-webpack-plugin": "^3.0.1",
-    "farmbot": "5.4.0-rc11",
+    "farmbot": "5.4.0",
     "farmbot-toastr": "^1.0.3",
     "fastclick": "^1.0.6",
     "file-loader": "^1.1.5",

--- a/webpack/sequences/step_tiles/tile_move_absolute.tsx
+++ b/webpack/sequences/step_tiles/tile_move_absolute.tsx
@@ -28,7 +28,7 @@ import { overwrite } from "../../api/crud";
 import { Xyz } from "../../devices/interfaces";
 import { TileMoveAbsSelect, InputBox } from "./tile_move_absolute/index";
 import { ToolTips } from "../../constants";
-import { extractParent } from "../locals_list";
+// import { extractParent } from "../locals_list";
 import {
   StepWrapper,
   StepHeader,

--- a/webpack/sequences/step_tiles/tile_move_absolute.tsx
+++ b/webpack/sequences/step_tiles/tile_move_absolute.tsx
@@ -94,14 +94,14 @@ export class TileMoveAbsolute extends Component<StepParams, MoveAbsState> {
 
   getAxisValue = (axis: Xyz): string => {
     let number: number | undefined;
-    const { locals } = this.props.currentSequence.body.args;
-    if (!locals) { return "-9"; }
-    const { body } = this.props.currentSequence.body.args.locals;
-    const parent = extractParent(body);
-    const maybe = ((parent && parent.args.data_value) || this.args.location);
-    const l = this.args.location.kind === "identifier" ?
-      maybe : this.args.location;
-
+    // const { locals } = this.props.currentSequence.body.args;
+    // if (!locals) { return "-9"; }
+    // const { body } = this.props.currentSequence.body.args.locals;
+    // const parent = extractParent(body);
+    // const maybe = ((parent && parent.args.data_value) || this.args.location);
+    // const l = this.args.location.kind === "identifier" ?
+    //   maybe : this.args.location;
+    const l = this.args.location;
     switch (l.kind) {
       case "coordinate":
         number = l.args[axis];

--- a/webpack/sequences/step_tiles/tile_move_absolute.tsx
+++ b/webpack/sequences/step_tiles/tile_move_absolute.tsx
@@ -94,6 +94,8 @@ export class TileMoveAbsolute extends Component<StepParams, MoveAbsState> {
 
   getAxisValue = (axis: Xyz): string => {
     let number: number | undefined;
+    const { locals } = this.props.currentSequence.body.args;
+    if (!locals) { return "-9"; }
     const { body } = this.props.currentSequence.body.args.locals;
     const parent = extractParent(body);
     const maybe = ((parent && parent.args.data_value) || this.args.location);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2258,9 +2258,9 @@ farmbot-toastr@^1.0.0, farmbot-toastr@^1.0.3:
     farmbot-toastr "^1.0.0"
     typescript "^2.3.4"
 
-farmbot@5.4.0-rc11:
-  version "5.4.0-rc11"
-  resolved "https://registry.yarnpkg.com/farmbot/-/farmbot-5.4.0-rc11.tgz#3214d390bca9db361f5d4c672f49873caa2d512d"
+farmbot@5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/farmbot/-/farmbot-5.4.0.tgz#9172db92141e4de3c213a0357f04c2dcc01276c9"
   dependencies:
     mqtt "2.15.0"
     typescript "^2.4.2"


### PR DESCRIPTION
# What's New?

 * Disable a feature that's not quite ready for use.
 * Remove `rc` label from FBJS.

Enjoy Farmbot 6.2, folks :tada: 