### PR TITLE
Recovery Release (6.2.1)

### DIFF
--- a/app/controllers/api/images_controller.rb
+++ b/app/controllers/api/images_controller.rb
@@ -70,7 +70,7 @@ module Api
 
     def policy_signature
       @policy_signature ||= Base64.encode64(
-        OpenSSL::HMAC.digest(OpenSSL::Digest::Digest.new('sha1'),
+        OpenSSL::HMAC.digest(OpenSSL::Digest.new('sha1'),
         SECRET,
         policy)).gsub("\n",'')
     end

--- a/app/controllers/api/sequences_controller.rb
+++ b/app/controllers/api/sequences_controller.rb
@@ -33,7 +33,9 @@ module Api
     end
 
     def sequences
-      @sequences ||= Sequence.where(device: current_device)
+      @sequences ||= Sequence
+                      .includes(:primary_nodes, :edge_nodes)
+                      .where(device: current_device)
     end
 
     def sequence

--- a/app/lib/celery_script/fetch_celery.rb
+++ b/app/lib/celery_script/fetch_celery.rb
@@ -12,12 +12,12 @@ module CeleryScript
     # To speed up querying, we create an in-memory index for frequently
     # looked up attributes such as :id, :kind, :parent_id, :primary_node_id
     def edge_nodes
-      @edge_nodes ||= Indexer.new(EdgeNode.where(sequence: sequence))
+      @edge_nodes ||= Indexer.new(sequence.edge_nodes)
     end
 
     # See docs for #edge_nodes()
     def primary_nodes
-      @primary_nodes ||= Indexer.new(PrimaryNode.where(sequence: sequence))
+      @primary_nodes ||= Indexer.new(sequence.primary_nodes)
     end
 
     # The topmost node is always `NOTHING`. The term "root node" refers to
@@ -98,10 +98,6 @@ module CeleryScript
     end
 
     def validate
-      # Legacy sequences won't have EdgeNode/PrimaryNode relations.
-      # We need to run the conversion before we can continue.
-      CeleryScript::StoreCelery
-        .run!(sequence: sequence) unless sequence.migrated_nodes
       # A sequence lacking a `sequence` node is a syntax error.
       # This should never show up in the frontend, but *is* helpful for devs
       # when debugging.

--- a/app/lib/celery_script/fetch_celery.rb
+++ b/app/lib/celery_script/fetch_celery.rb
@@ -7,7 +7,8 @@ require_relative "./csheap"
 module CeleryScript
   class FetchCelery < Mutations::Command
   private  # = = = = = = =
-
+    # A safety measure for when you need to do square bracket access.
+    NOTHING  = Struct.new(:kind).new("nothing")
     # This class is too CPU intensive to make multiple SQL requests.
     # To speed up querying, we create an in-memory index for frequently
     # looked up attributes such as :id, :kind, :parent_id, :primary_node_id
@@ -53,7 +54,7 @@ module CeleryScript
     # Pass this method a PrimaryNode and it will return an array filled with
     # that node's children (or an empty array, since body is always optional).
     def get_body_elements(node)
-      next_node = node.body
+      next_node = primary_nodes.by.id[node.body_id].first || NOTHING
       results = []
       until next_node.kind == "nothing"
         results.push(next_node)

--- a/app/lib/celery_script/fetch_celery.rb
+++ b/app/lib/celery_script/fetch_celery.rb
@@ -51,14 +51,19 @@ module CeleryScript
       {}.merge!(attach_edges(node)).merge!(attach_primary_nodes(node))
     end
 
+    # If you don't do this in memory, you will get N+1s all over the place - RC
+    def find_by_id_in_memory(id)
+      primary_nodes.by.id[id].try(:first) || NOTHING
+    end
+
     # Pass this method a PrimaryNode and it will return an array filled with
     # that node's children (or an empty array, since body is always optional).
     def get_body_elements(node)
-      next_node = primary_nodes.by.id[node.body_id].first || NOTHING
+      next_node = find_by_id_in_memory(node.body_id)
       results = []
       until next_node.kind == "nothing"
         results.push(next_node)
-        next_node = next_node.next
+        next_node = find_by_id_in_memory(node.next_id)
       end
       results
     end

--- a/app/models/primary_node.rb
+++ b/app/models/primary_node.rb
@@ -6,7 +6,8 @@ class PrimaryNode < ApplicationRecord
   belongs_to            :sequence
   validates_presence_of :sequence
   has_many   :edge_nodes
-  BAD_KIND = "`kind` must be one of: " + CeleryScriptSettingsBag::ANY_NODE_NAME.join(", ")
+  BAD_KIND = "`kind` must be one of: " +
+              CeleryScriptSettingsBag::ANY_NODE_NAME.join(", ")
   validates :kind, inclusion: { in: CeleryScriptSettingsBag::ANY_NODE_NAME,
                                 message: BAD_KIND,
                                 allow_nil: false }
@@ -23,7 +24,7 @@ class PrimaryNode < ApplicationRecord
 
   def parent
     self.class.find_by(id: parent_id)
-    end
+  end
 
   def body
     self.class.find_by(id: body_id)

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@types/redux": "^3.6.31",
     "axios": "^0.18.0",
     "boxed_value": "^1.0.0",
-    "browser-speech": "^1.0.0",
+    "browser-speech": "1.1.0",
     "coveralls": "^3.0.0",
     "css-loader": "^0.28.7",
     "enzyme": "^3.1.0",

--- a/spec/controllers/api/configs/fbos_configs_controller_spec.rb
+++ b/spec/controllers/api/configs/fbos_configs_controller_spec.rb
@@ -31,7 +31,8 @@ describe Api::FbosConfigsController do
       }.to_a.map do |key, value|
         actual   = json[key]
         expected = value
-        fail "#{key} should be #{expected} but got #{actual}" unless (actual == expected)
+        correct  = actual == expected
+        fail "#{key} should be #{expected} but got #{actual}" unless correct
       end
 
       { created_at: String, updated_at: String }

--- a/spec/controllers/api/configs/fbos_configs_controller_spec.rb
+++ b/spec/controllers/api/configs/fbos_configs_controller_spec.rb
@@ -28,7 +28,11 @@ describe Api::FbosConfigsController do
         os_auto_update:          true,
         firmware_hardware:       "arduino",
         api_migrated:            false
-      }.to_a.map { |key, value| expect(json[key]).to eq(value) }
+      }.to_a.map do |key, value|
+        actual   = json[key]
+        expected = value
+        fail "#{key} should be #{expected} but got #{actual}" unless (actual == expected)
+      end
 
       { created_at: String, updated_at: String }
         .to_a.map { |key, value| expect(json[key]).to be_kind_of(value) }

--- a/spec/mutations/flat_ir_stuff/fetch_celery_spec.rb
+++ b/spec/mutations/flat_ir_stuff/fetch_celery_spec.rb
@@ -25,7 +25,7 @@ describe CeleryScript::FetchCelery do
     [
       #KIND                 PARENT           NEXT             BODY
       ["nothing",           __NOTHING______, __NOTHING______, __NOTHING______],
-      ["sequence",        __NOTHING______, __NOTHING______, "move_absolute"],
+      ["sequence",          __NOTHING______, __NOTHING______, "move_absolute"],
       ["move_absolute",     "sequence",      "move_relative", __NOTHING______],
       ["coordinate",        "move_absolute", __NOTHING______, __NOTHING______],
       ["move_relative",     "move_absolute", "write_pin",     __NOTHING______],

--- a/webpack/util/stop_ie.ts
+++ b/webpack/util/stop_ie.ts
@@ -1,17 +1,30 @@
+function flunk() {
+  // DO NOT USE i18next here.
+  // IE Cannot handle it.
+  const READ_THE_COMMENT_ABOVE = "This app only works with modern browsers.";
+  alert(READ_THE_COMMENT_ABOVE);
+  window.location.href = "https://www.google.com/chrome/";
+}
+
+const REQUIRED_GLOBALS = [
+  "Promise",
+  "console",
+  "WebSocket",
+  "Intl",
+  "Set"
+];
+
+const REQUIRED_ARRAY_METHODS = [
+  "includes",
+  "map",
+  "filter"
+];
 
 /** We don't support IE. This method stops users from trying to use the site.
  * It's unfortunate that we need to do this, but the site simply won't work on
  * old browsers and our error logs were getting full of IE related bugs. */
 export function stopIE() {
-  function flunk() {
-    // DO NOT USE i18next here.
-    // IE Cannot handle it.
-    const READ_THE_COMMENT_ABOVE = "This app only works with modern browsers.";
-    alert(READ_THE_COMMENT_ABOVE);
-    window.location.href = "https://www.google.com/chrome/";
-  }
   try {
-    const REQUIRED_GLOBALS = ["Promise", "console", "WebSocket", "Intl"];
     // Can't use Array.proto.map because IE.
     // Can't translate the text because IE (no promises)
     for (let i = 0; i < REQUIRED_GLOBALS.length; i++) {
@@ -19,7 +32,7 @@ export function stopIE() {
         flunk();
       }
     }
-    const REQUIRED_ARRAY_METHODS = ["includes", "map", "filter"];
+
     for (let i = 0; i < REQUIRED_ARRAY_METHODS.length; i++) {
       if (!Array.prototype.hasOwnProperty(REQUIRED_ARRAY_METHODS[i])) {
         flunk();

--- a/yarn.lock
+++ b/yarn.lock
@@ -847,9 +847,9 @@ browser-resolve@^1.11.2:
   dependencies:
     resolve "1.1.7"
 
-browser-speech@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/browser-speech/-/browser-speech-1.0.2.tgz#88ae8d4c1b1a114420e2b029c901f936b5438127"
+browser-speech@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/browser-speech/-/browser-speech-1.1.0.tgz#2eaef472b047a4b9a0a5268e47025064364696ae"
 
 browserify-aes@^1.0.0, browserify-aes@^1.0.4:
   version "1.1.1"


### PR DESCRIPTION
# What's New?

 * Require browser to support [set objects](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set)
 * Stop a nasty N+1 from happening in `api/sequences`.
 * Upgrade `browser-speech` (legacy browser issues on some  devices)
