### PR TITLE
Show *all* dependencies when deleting a sequence

### DIFF
--- a/app/models/farm_event.rb
+++ b/app/models/farm_event.rb
@@ -25,4 +25,8 @@ class FarmEvent < ApplicationRecord
   def self.if_still_using(executable)
     yield if self.where(executable: executable).any?
   end
+
+  def fancy_name
+    executable.fancy_name
+  end
 end

--- a/app/models/pin_binding.rb
+++ b/app/models/pin_binding.rb
@@ -1,4 +1,8 @@
 class PinBinding < ApplicationRecord
   belongs_to :device
   belongs_to :sequence
+
+  def fancy_name
+    "pin #{pin_num}"
+  end
 end

--- a/app/models/regimen.rb
+++ b/app/models/regimen.rb
@@ -28,4 +28,8 @@ class Regimen < ApplicationRecord
   def notable_changes?
     true
   end
+
+  def fancy_name
+    name
+  end
 end

--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -72,4 +72,9 @@ class Sequence < ApplicationRecord
   def body_as_json
     return destroyed? ? nil : CeleryScript::FetchCelery.run!(sequence: self)
   end
+
+
+  def fancy_name
+    name
+  end
 end

--- a/app/mutations/sequences/delete.rb
+++ b/app/mutations/sequences/delete.rb
@@ -2,7 +2,7 @@ module Sequences
   class Delete < Mutations::Command
     IN_USE        = "Sequence is in still in use by"
     THE_FOLLOWING = " the following %{resource}: %{items}"
-    AND           = "and"
+    AND           = " and"
 
     required do
       model :device, class: Device

--- a/app/mutations/sequences/delete.rb
+++ b/app/mutations/sequences/delete.rb
@@ -1,6 +1,8 @@
 module Sequences
   class Delete < Mutations::Command
-    IN_USE = "The following %s are still relying on this sequence: %s"
+    IN_USE        = "Sequence is in still in use by"
+    THE_FOLLOWING = " the following %{resource}: %{items}"
+    AND           = "and"
 
     required do
       model :device, class: Device
@@ -8,61 +10,72 @@ module Sequences
     end
 
     def validate
-      check_if_any_pin_bindings_using_this
-      check_if_any_regimens_using_this
-      check_if_any_sequences_using_this
-      FarmEvent.if_still_using(sequence) do
-        add_error :sequence, :required, FarmEvent::FE_USE
-      end
+      add_error :sequence, :sequence, (IN_USE + all_deps) if all_deps.present?
     end
 
     def execute
-       sequence.destroy!
-       return ""
+      sequence.destroy!
+      return ""
     end
+
   private
 
-    def check_if_any_pin_bindings_using_this
-      in_use = PinBinding
+    def pin_bindings
+      @pin_bindings ||= PinBinding
         .where(sequence_id: sequence.id)
-        .pluck(:pin_num)
-        .map { |x| "pin #{x}"}
-      names = in_use.join(", ")
-      msg = IN_USE % ["pin bindings", names]
-      add_error(:sequence, :in_use, msg) if in_use.any?
+        .to_a
     end
 
-    def check_if_any_sequences_using_this
-      # Finds CeleryScript nodes that are using `sequence_id` xyz, but excludes
-      # nodes within the current sequence, since that would make deletion
-      # impossible.
-
-      in_use_ids = EdgeNode
+    def sibling_ids
+      @sibling_ids ||= EdgeNode
         .where(kind: "sequence_id", value: sequence.id)
         .pluck(:sequence_id)
         .uniq
         .without(sequence.id)
-      in_use_names = Sequence.where(id: in_use_ids)
-        .pluck(:name)
-        .map(&:inspect)
-      if in_use_names.any?
-        names = in_use_names.join(", ")
-        add_error(:sequence, :in_use, (IN_USE % ["sequences", names]))
+    end
+
+    def sibling_sequences
+      @sibling_sequences ||= Sequence.find(sibling_ids).uniq
+    end
+
+    def regimens
+      @regimens ||= Regimen
+        .includes(:regimen_items)
+        .where(regimen_items: {sequence_id: sequence.id})
+        .to_a
+    end
+
+    def farm_events
+      @farm_events ||= FarmEvent
+        .includes(:executable)
+        .where(executable: sequence)
+        .uniq
+        .to_a
+    end
+
+    def format_dep_list(klass, items)
+      if items.empty?
+        ""
+      else
+        binding.pry if items.present? && !items.first.respond_to?(:fancy_name)
+        THE_FOLLOWING % {
+          resource: FarmEvent.table_name.humanize,
+          items: items.map(&:fancy_name).join(", ")
+        }
       end
     end
 
-    def check_if_any_regimens_using_this
-      regimen_items = RegimenItem
-                        .joins(:sequence, :regimen)
-                        .where(sequence_id: sequence.id )
-      if regimen_items.count > 0
-        names = regimen_items.map(&:regimen)
-                             .map(&:name)
-                             .uniq
-                             .join(", ")
-        msg = IN_USE % [ "regimens", names ]
-        add_error(:sequence, :required, msg)
-      end
+    def all_deps
+      @all_deps ||= []
+        .concat(farm_events)       # FarmEvent
+        .concat(pin_bindings)      # PinBinding
+        .concat(regimens)          # Regimen
+        .concat(sibling_sequences) # Sequence
+        .compact
+        .group_by { |x| x.class }
+        .to_a
+        .map  { |(klass, items)| format_dep_list(klass, items) }
+        .join(AND)
     end
   end
 end

--- a/app/mutations/sequences/delete.rb
+++ b/app/mutations/sequences/delete.rb
@@ -57,7 +57,6 @@ module Sequences
       if items.empty?
         ""
       else
-        binding.pry if items.present? && !items.first.respond_to?(:fancy_name)
         THE_FOLLOWING % {
           resource: FarmEvent.table_name.humanize,
           items: items.map(&:fancy_name).join(", ")

--- a/app/mutations/sequences/delete.rb
+++ b/app/mutations/sequences/delete.rb
@@ -54,14 +54,10 @@ module Sequences
     end
 
     def format_dep_list(klass, items)
-      if items.empty?
-        ""
-      else
-        THE_FOLLOWING % {
-          resource: FarmEvent.table_name.humanize,
-          items: items.map(&:fancy_name).join(", ")
-        }
-      end
+      THE_FOLLOWING % {
+        resource: FarmEvent.table_name.humanize,
+        items: items.map(&:fancy_name).join(", ")
+      } unless items.empty?
     end
 
     def all_deps
@@ -74,6 +70,7 @@ module Sequences
         .group_by { |x| x.class }
         .to_a
         .map  { |(klass, items)| format_dep_list(klass, items) }
+        .compact
         .join(AND)
     end
   end

--- a/spec/mutations/sequences/delete_spec.rb
+++ b/spec/mutations/sequences/delete_spec.rb
@@ -4,12 +4,13 @@ describe Sequences::Delete do
   let(:sequence)     { FakeSequence.create()  }
 
   it "Cant delete sequences in use by farm events" do
-    FactoryBot.create(:farm_event, executable: sequence)
+    fe = FactoryBot.create(:farm_event, executable: sequence)
     result = Sequences::Delete.run(device: sequence.device, sequence: sequence)
     expect(result.success?).to be false
     errors = result.errors.message
     expect(errors.keys).to include("sequence")
-    expect(errors["sequence"]).to include("in use by some farm events")
+    expect(errors["sequence"]).to include("in use")
+    expect(errors["sequence"]).to include(fe.fancy_name)
   end
 
   it "refuses to delete a sequence that a regimen depends on" do
@@ -20,8 +21,9 @@ describe Sequences::Delete do
     expect(result.success?).to be false
     errors = result.errors.message
     expect(errors.keys).to include("sequence")
-    expect(errors["sequence"]).to include("regimens are still relying on " +
-                                          "this sequence")
+    expect(errors["sequence"]).to include("in use")
+    expect(errors["sequence"]).to include(regimen_item1.regimen.fancy_name)
+    expect(errors["sequence"]).to include(regimen_item2.regimen.fancy_name)
   end
 
   it "deletes a sequence" do
@@ -43,6 +45,7 @@ describe Sequences::Delete do
     expect(result.success?).to be(false)
     expect(result.errors.has_key?("sequence")).to be(true)
     message = result.errors["sequence"].message
-    expect(message).to include("sequences are still relying on this sequence")
+    expect(message).to include("in use")
+    expect(message).to include("dep")
   end
 end

--- a/ubuntu_example.sh
+++ b/ubuntu_example.sh
@@ -37,7 +37,7 @@ sudo apt-get update && sudo apt-get install yarn
 sudo apt-get install libpq-dev postgresql-contrib --yes
 
 # Install FarmBot Web App
-git clone https://github.com/FarmBot/Farmbot-Web-App --depth=10
+git clone https://github.com/FarmBot/Farmbot-Web-App --depth=10 --branch=master
 cd Farmbot-Web-App
 gem install bundler
 npm install yarn


### PR DESCRIPTION
# Bug

 * You want to delete a sequence.
 * It is in use by a farm event, regimen, pin binding, and another sequence.
 * When you delete it, it only says that it is in use by another pin binding, until you delete the pin binding and try again, then it says it is still in use by a farm event... then a regimen... etc..

# Fix

 * Show _all_ deps when deleting a sequence.