### PR TITLE
Minor fixes and additions

### DIFF
--- a/webpack/css/regimens.scss
+++ b/webpack/css/regimens.scss
@@ -18,6 +18,9 @@
     margin-left: 0.75rem;
     color: $dark_gray;
   }
+  input {
+    background-color: $white !important;
+  }
 }
 
 // Regimen Editor

--- a/webpack/css/sequences.scss
+++ b/webpack/css/sequences.scss
@@ -83,8 +83,8 @@
   }
 }
 
-.sequence-list-items {
-  margin-right: 15px;
+.sequence-list-items,
+.regimen-list {
   button {
     label {
       width: 90%;
@@ -99,6 +99,10 @@
     float: right;
     margin-top: 0.75rem;
   }
+}
+
+.sequence-list-items {
+  margin-right: 15px;
 }
 
 .sequence-list-panel,

--- a/webpack/farm_designer/farm_events/__tests__/map_state_to_props_test.ts
+++ b/webpack/farm_designer/farm_events/__tests__/map_state_to_props_test.ts
@@ -240,10 +240,16 @@ describe("mapResourcesToCalendar(): regimen farm events", () => {
     expect(calendar.getAll()).toEqual(fakeRegimenFE);
   });
 
-  it("doesn't return calendar row after event is over", () => {
+  it(`returns "*Empty*" calendar row after event is over`, () => {
     const testTime = moment("2017-12-27T01:00:00.000Z");
     const calendar =
       mapResourcesToCalendar(fakeRegFEResources().index, testTime);
-    expect(calendar.getAll()).toEqual([]);
+    expect(calendar.getAll()).toEqual([{
+      "day": expect.any(Number),
+      "items": [expect.objectContaining({ "heading": "*Empty*" })],
+      "month": "Dec",
+      "sortKey": expect.any(Number),
+      "year": 17
+    }]);
   });
 });

--- a/webpack/farm_designer/farm_events/map_state_to_props.ts
+++ b/webpack/farm_designer/farm_events/map_state_to_props.ts
@@ -73,6 +73,10 @@ export let regimenCalendarAdder = (index: ResourceIndex) =>
         c.insert(oo);
       }
     });
+    // Display empty regimens in UI so that they can be edited or deleted.
+    if (f.end_time && Object.keys(c.value).length === 0) {
+      c.insert(occurrence(moment(f.end_time), f, tz_offset_hrs, { empty: true }));
+    }
   };
 
 export let addSequenceToCalendar =

--- a/webpack/nav/__tests__/sync_button_test.tsx
+++ b/webpack/nav/__tests__/sync_button_test.tsx
@@ -26,8 +26,17 @@ describe("<SyncButton/>", function () {
   it("is gray when inconsistent", () => {
     const p = fakeProps();
     p.consistent = false;
+    p.bot.hardware.informational_settings.sync_status = "sync_now";
     const result = shallow(<SyncButton {...p} />);
     expect(result.hasClass("gray")).toBeTruthy();
+  });
+
+  it("is not gray when disconnected", () => {
+    const p = fakeProps();
+    p.consistent = false;
+    p.bot.hardware.informational_settings.sync_status = "unknown";
+    const result = shallow(<SyncButton {...p} />);
+    expect(result.hasClass("gray")).toBeFalsy();
   });
 
   it("defaults to `disconnected` and `red` when uncertain", () => {

--- a/webpack/nav/sync_button.tsx
+++ b/webpack/nav/sync_button.tsx
@@ -33,7 +33,9 @@ export function SyncButton({ user, bot, dispatch, consistent }: NavButtonProps) 
   }
   let { sync_status } = bot.hardware.informational_settings;
   sync_status = sync_status || "unknown";
-  const color = consistent ? (COLOR_MAPPING[sync_status] || "red") : "gray";
+  const color = !consistent && sync_status === "sync_now"
+    ? "gray"
+    : (COLOR_MAPPING[sync_status] || "red");
   const text = t(TEXT_MAPPING[sync_status] || "DISCONNECTED");
   const spinnerEl = (sync_status === "syncing") ? spinner : "";
 

--- a/webpack/regimens/list/__tests__/index_test.tsx
+++ b/webpack/regimens/list/__tests__/index_test.tsx
@@ -6,22 +6,24 @@ import { fakeRegimen } from "../../../__test_support__/fake_state/resources";
 
 describe("<RegimensList />", () => {
   function fakeProps(): RegimensListProps {
-    const regimen = fakeRegimen();
-    regimen.body.name = "Fake Regimen";
+    const regimen1 = fakeRegimen();
+    regimen1.body.name = "Fake Regimen 1";
+    const regimen2 = fakeRegimen();
+    regimen2.body.name = "Fake Regimen 2";
     return {
       dispatch: jest.fn(),
-      regimens: [regimen, regimen],
+      regimens: [regimen1, regimen2],
       regimen: undefined
     };
   }
   it("renders", () => {
-    const wrapper = mount(<RegimensList {...fakeProps() } />);
-    expect(wrapper.text()).toContain("Regimen");
-    expect(wrapper.text()).toContain("Fake Regimen Fake Regimen");
+    const wrapper = mount(<RegimensList {...fakeProps()} />);
+    ["Regimens", "Fake Regimen 1", "Fake Regimen 2"]
+      .map(string => expect(wrapper.text()).toContain(string));
   });
 
   it("sets search term", () => {
-    const wrapper = shallow(<RegimensList {...fakeProps() } />);
+    const wrapper = shallow(<RegimensList {...fakeProps()} />);
     wrapper.find("input").simulate("change",
       { currentTarget: { value: "term" } });
     expect(wrapper.state().searchTerm).toEqual("term");

--- a/webpack/regimens/list/__tests__/regimen_list_item_test.tsx
+++ b/webpack/regimens/list/__tests__/regimen_list_item_test.tsx
@@ -1,8 +1,10 @@
 import * as React from "react";
 import { RegimenListItemProps } from "../../interfaces";
 import { RegimenListItem } from "../regimen_list_item";
-import { render } from "enzyme";
+import { render, shallow } from "enzyme";
 import { fakeRegimen } from "../../../__test_support__/fake_state/resources";
+import { SpecialStatus } from "../../../resources/tagged_resources";
+import { Actions } from "../../../constants";
 
 describe("<RegimenListItem/>", () => {
   const fakeProps = (): RegimenListItemProps => {
@@ -22,6 +24,13 @@ describe("<RegimenListItem/>", () => {
     expect(html).toContain(props.regimen.body.color);
   });
 
+  it("shows unsaved data indicator", () => {
+    const props = fakeProps();
+    props.regimen.specialStatus = SpecialStatus.DIRTY;
+    const wrapper = render(<RegimenListItem {...props} />);
+    expect(wrapper.text()).toContain("Foo *");
+  });
+
   it("shows in-use indicator", () => {
     const props = fakeProps();
     props.regimen.body.in_use = true;
@@ -32,5 +41,17 @@ describe("<RegimenListItem/>", () => {
   it("doesn't show in-use indicator", () => {
     const wrapper = render(<RegimenListItem {...fakeProps()} />);
     expect(wrapper.find(".in-use").length).toEqual(0);
+  });
+
+  it("selects regimen", () => {
+    const props = fakeProps();
+    const wrapper = shallow(<RegimenListItem {...props} />);
+    wrapper.find("button").simulate("click");
+    expect(props.dispatch).toHaveBeenCalledWith({
+      type: Actions.SELECT_REGIMEN,
+      payload: expect.objectContaining({
+        uuid: props.regimen.uuid
+      })
+    });
   });
 });

--- a/webpack/regimens/list/__tests__/regimen_list_item_test.tsx
+++ b/webpack/regimens/list/__tests__/regimen_list_item_test.tsx
@@ -5,16 +5,32 @@ import { render } from "enzyme";
 import { fakeRegimen } from "../../../__test_support__/fake_state/resources";
 
 describe("<RegimenListItem/>", () => {
-  it("renders the base case", () => {
-    const props: RegimenListItemProps = {
+  const fakeProps = (): RegimenListItemProps => {
+    return {
       length: 1,
       regimen: fakeRegimen(),
       dispatch: jest.fn(),
       index: 0
     };
+  };
+
+  it("renders the base case", () => {
+    const props = fakeProps();
     const el = render(<RegimenListItem {...props} />);
     const html = el.html();
     expect(html).toContain(props.regimen.body.name);
     expect(html).toContain(props.regimen.body.color);
+  });
+
+  it("shows in-use indicator", () => {
+    const props = fakeProps();
+    props.regimen.body.in_use = true;
+    const wrapper = render(<RegimenListItem {...props} />);
+    expect(wrapper.find(".in-use").length).toEqual(1);
+  });
+
+  it("doesn't show in-use indicator", () => {
+    const wrapper = render(<RegimenListItem {...fakeProps()} />);
+    expect(wrapper.find(".in-use").length).toEqual(0);
   });
 });

--- a/webpack/regimens/list/regimen_list_item.tsx
+++ b/webpack/regimens/list/regimen_list_item.tsx
@@ -7,9 +7,11 @@ import {
   TaggedRegimen,
   isTaggedRegimen
 } from "../../resources/tagged_resources";
+import { t } from "i18next";
+import { Content } from "../../constants";
 
 export function RegimenListItem({ regimen, dispatch }: RegimenListItemProps) {
-  const name = regimen.body.name || "";
+  const name = (regimen.body.name || "") + (regimen.specialStatus ? " *" : "");
   const color = (regimen.body.color) || "gray";
   const style = [`block`, `full-width`, `fb-button`, `${color}`];
   lastUrlChunk() === urlFriendly(name) && style.push("active");
@@ -20,7 +22,9 @@ export function RegimenListItem({ regimen, dispatch }: RegimenListItemProps) {
     <button
       className={style.join(" ")}
       onClick={select(dispatch, regimen)}>
-      {name} {regimen.specialStatus && ("*")}
+      <label>{name}</label>
+      {regimen.body.in_use &&
+        <i className="in-use fa fa-hdd-o" title={t(Content.IN_USE)} />}
     </button>
   </Link>;
 }


### PR DESCRIPTION
**Farm Events:**
 * Render empty Regimen Farm Events in the calendar to allow editing or deletion.

**Regimens:**
 * Display an indicator next to names in the regimen list when the regimen is a dependency of another resource (Farm Events). _Currently only updates upon app load._