### PR TITLE
Performance Tweaks for Realtime Logs

### DIFF
--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -68,7 +68,7 @@ class Device < ApplicationRecord
   end
 
   # Send a realtime message to a logged in user.
-  def tell(message)
+  def tell(message, transport = Transport)
     log  = Log.new({ device:     self,
                      message:    message,
                      created_at: Time.now,
@@ -76,6 +76,7 @@ class Device < ApplicationRecord
                      meta:       { type: "info" } })
     json = LogSerializer.new(log).as_json.to_json
 
-    Transport.amqp_send(json, self.id, "logs")
+    transport.amqp_send(json, self.id, "logs")
+    log
   end
 end

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -66,4 +66,16 @@ class Device < ApplicationRecord
   def tz_offset_hrs
     Time.now.in_time_zone(self.timezone || "UTC").utc_offset / 1.hour
   end
+
+  # Send a realtime message to a logged in user.
+  def tell(message)
+    log  = Log.new({ device:     self,
+                     message:    message,
+                     created_at: Time.now,
+                     channels:   [],
+                     meta:       { type: "info" } })
+    json = LogSerializer.new(log).as_json.to_json
+
+    Transport.amqp_send(json, self.id, "logs")
+  end
 end

--- a/load_tester.rb
+++ b/load_tester.rb
@@ -1,0 +1,7 @@
+devices = Device.all
+
+1_000_000.times do |num|
+  puts "Load test #{num}"
+  devices.map { |x| Transport.amqp_send({}.to_json, x.id, "logs") }
+  sleep 1
+end

--- a/load_tester.rb
+++ b/load_tester.rb
@@ -1,7 +1,0 @@
-devices = Device.all
-
-1_000_000.times do |num|
-  puts "Load test #{num}"
-  devices.map { |x| x.tell("LOAD TEST IN PROGRESS: #{num}") }
-  sleep 0.05
-end

--- a/load_tester.rb
+++ b/load_tester.rb
@@ -2,6 +2,6 @@ devices = Device.all
 
 1_000_000.times do |num|
   puts "Load test #{num}"
-  devices.map { |x| Transport.amqp_send({}.to_json, x.id, "logs") }
-  sleep 1
+  devices.map { |x| x.tell("LOAD TEST IN PROGRESS: #{num}") }
+  sleep 0.1
 end

--- a/load_tester.rb
+++ b/load_tester.rb
@@ -3,5 +3,5 @@ devices = Device.all
 1_000_000.times do |num|
   puts "Load test #{num}"
   devices.map { |x| x.tell("LOAD TEST IN PROGRESS: #{num}") }
-  sleep 0.1
+  sleep 0.05
 end

--- a/spec/models/device_spec.rb
+++ b/spec/models/device_spec.rb
@@ -33,4 +33,11 @@ describe Device do
     device.trim_log_list!
     expect(device.logs.count).to eq(device.max_log_count)
   end
+
+  it 'uses `tell` to send device messages' do
+    dbl = double("fake transport layer")
+    expect(dbl).to receive(:amqp_send)
+    result = device.tell("Hello!", dbl)
+    expect(result.message).to eq("Hello!")
+  end
 end


### PR DESCRIPTION
# What's New?

 * Apply `throttle` to incoming event handler for logs.
 * Prevents UI lockup when the bot sends a ton of logs at one time.