### PR TITLE
Remove references to "log.meta" in UI

### DIFF
--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -22,18 +22,15 @@ class Image < ApplicationRecord
     size: { in: 0..7.megabytes } # Worst case scenario for 1280x1280 BMP.
   }
 
-
-  if(ENV.has_key?("GCS_BUCKET"))
-    bucket = ENV.fetch("GCS_BUCKET")
-    CONFIG.merge!({
-      storage:         :fog,
-      fog_host:        "http://#{bucket}.storage.googleapis.com",
-      fog_directory:   bucket,
-      fog_credentials: { provider:                         "Google",
-                         google_storage_access_key_id:     ENV.fetch("GCS_KEY"),
-                         google_storage_secret_access_key: ENV.fetch("GCS_ID")}
-    })
-  end
+  bucket = ENV["GCS_BUCKET"]
+  CONFIG.merge!({
+    storage:         :fog,
+    fog_host:        "http://#{bucket}.storage.googleapis.com",
+    fog_directory:   bucket,
+    fog_credentials: { provider:                         "Google",
+                        google_storage_access_key_id:     ENV.fetch("GCS_KEY"),
+                        google_storage_secret_access_key: ENV.fetch("GCS_ID")}
+  }) if bucket
 
   has_attached_file :attachment, CONFIG
 

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -32,7 +32,7 @@ class Log < ApplicationRecord
   #  TODO: Remove these once FBOS stops using the `meta` field.
   def meta
     {
-      type:          self.type,
+      type:          self.type || "info",
       major_version: self.major_version,
       minor_version: self.minor_version,
       verbosity:     self.verbosity,

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -43,7 +43,7 @@ class Log < ApplicationRecord
   end
 
   def meta=(hash)
-    hash.map      { |(key,value)| self.send("#{key}=", value)  }
+    hash.map      { |(key, value)| self.send("#{key}=", value)  }
     self.meta
   end
   # End Legacy shims ===========================================================

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -32,7 +32,7 @@ class Log < ApplicationRecord
   #  TODO: Remove these once FBOS stops using the `meta` field.
   def meta
     {
-      type:          self.type || "info",
+      type:          self.type,
       major_version: self.major_version,
       minor_version: self.minor_version,
       verbosity:     self.verbosity,

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -43,7 +43,6 @@ class Log < ApplicationRecord
   end
 
   def meta=(hash)
-    meta.keys.map { |key| self.send("#{key}=", nil) }
     hash.map      { |(key,value)| self.send("#{key}=", value)  }
     self.meta
   end

--- a/db/migrate/20180330143232_migrate_away_from_meta_column.rb
+++ b/db/migrate/20180330143232_migrate_away_from_meta_column.rb
@@ -5,9 +5,13 @@ class MigrateAwayFromMetaColumn < ActiveRecord::Migration[5.1]
     # Migrate via log[name] = log.meta[name]
     Device.all.map { |d| d.trim_log_list!(5) }
     Log.all.map do |log|
-      log.meta.map do |(key,value)|
-        log[key.to_sym] = log.meta[value]
-        log.save!
+      old_meta = log[:meta] || {}
+      (old_meta).map do |(key,value)|
+        old_value = old_meta[value]
+        if old_value
+          log[key.to_sym] = old_value
+          log.save!
+        end
       end
     end
   end

--- a/db/migrate/20180331183559_ensure_log_has_type.rb
+++ b/db/migrate/20180331183559_ensure_log_has_type.rb
@@ -1,0 +1,5 @@
+class EnsureLogHasType < ActiveRecord::Migration[5.1]
+  def change
+    Log.where(type: nil).update_all(type: "info")
+  end
+end

--- a/db/migrate/20180331183559_ensure_log_has_type.rb
+++ b/db/migrate/20180331183559_ensure_log_has_type.rb
@@ -1,5 +1,8 @@
 class EnsureLogHasType < ActiveRecord::Migration[5.1]
-  def change
+  def up
     Log.where(type: nil).update_all(type: "info")
+  end
+
+  def down
   end
 end

--- a/db/migrate/20180401141611_repair_logs.rb
+++ b/db/migrate/20180401141611_repair_logs.rb
@@ -1,0 +1,15 @@
+class RepairLogs < ActiveRecord::Migration[5.1]
+  def up
+    Log
+      .where
+      .not(meta: nil)
+      .select { |x| (x[:meta] || {})[:type] != x.type }
+      .map do |x|
+        old_type = (x[:meta] || {})[:type]
+        x.update_attributes!(type: old_type) if old_type
+      end
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180330143232) do
+ActiveRecord::Schema.define(version: 20180331183559) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/controllers/api/regimens/regimens_update_spec.rb
+++ b/spec/controllers/api/regimens/regimens_update_spec.rb
@@ -36,5 +36,22 @@ describe Api::RegimensController do
       expect(json[:name]).to eq("something new")
       expect(existing.name).to eq("something new")
     end
+
+    it 'catches bad regimen_items' do
+      sign_in user
+      existing = Regimens::Create.run!(device: user.device, name: "x", color: "red", regimen_items: [])
+      payload = {
+        "id"            => existing.id,
+        "name"          => "something new",
+        "color"         => "blue",
+        "regimen_items" => [ { "time_offset" => 950700000, "sequence_id" => 0 } ]
+        }
+      put :update, params: payload
+
+      expect(response.status).to eq(422)
+      expect(json[:regimen_items]).to be
+      expect(json[:regimen_items])
+        .to include("Failed to instantiate nested RegimenItem.")
+    end
   end
 end

--- a/webpack/__test_support__/log.ts
+++ b/webpack/__test_support__/log.ts
@@ -3,9 +3,7 @@ import { Log } from "../interfaces";
 export let log: Log = {
   id: 1234567,
   message: "Farmbot is up and Running!",
-  meta: {
-    type: "info"
-  },
+  type: "info",
   channels: [
     "toast"
   ],

--- a/webpack/__test_support__/resource_index_builder.ts
+++ b/webpack/__test_support__/resource_index_builder.ts
@@ -320,9 +320,7 @@ const log: TaggedLog = {
   body: {
     id: 1091396, created_at: 1510010193,
     message: "Farmbot Movement complete.",
-    meta: {
-      type: "success"
-    },
+    type: "success",
     channels: []
   },
   uuid: "Log.1091396.70"

--- a/webpack/connectivity/__tests__/connect_device/index_test.ts
+++ b/webpack/connectivity/__tests__/connect_device/index_test.ts
@@ -71,7 +71,7 @@ function fakeLog(meta_type: ALLOWED_MESSAGE_TYPES,
   channels: ALLOWED_CHANNEL_NAMES[] = ["toast"]): Log {
   return {
     message: "toasty!",
-    meta: { type: meta_type },
+    type: meta_type,
     channels,
     created_at: -1
   };

--- a/webpack/connectivity/connect_device.ts
+++ b/webpack/connectivity/connect_device.ts
@@ -50,7 +50,7 @@ export function actOnChannelName(
 /** Take a log message (of type toast) and determines the correct kind of toast
  * to execute. */
 export function showLogOnScreen(log: Log) {
-  switch (log.meta.type) {
+  switch (log.type) {
     case "success":
       return success(log.message, TITLE);
     case "busy":
@@ -137,7 +137,7 @@ export const onLogs = (dispatch: Function, getState: GetState) => throttle((msg:
     //                   inband signalling (for now).
     // TODO:             Make a `bot/device_123/offline` channel.
     const died =
-      msg.message.includes("is offline") && msg.meta.type === "error";
+      msg.message.includes("is offline") && msg.type === "error";
     died && dispatchNetworkDown("bot.mqtt");
   }
 }, THROTTLE_MS);

--- a/webpack/interfaces.ts
+++ b/webpack/interfaces.ts
@@ -40,13 +40,11 @@ export interface DeviceConfig {
 export interface Log {
   id?: number | undefined;
   message: string;
-  meta: {
-    type: ALLOWED_MESSAGE_TYPES;
-    x?: number;
-    y?: number;
-    z?: number;
-    verbosity?: number;
-  };
+  type: ALLOWED_MESSAGE_TYPES;
+  x?: number;
+  y?: number;
+  z?: number;
+  verbosity?: number;
   channels: string[];
   created_at: number;
 }

--- a/webpack/logs/__tests__/index_test.tsx
+++ b/webpack/logs/__tests__/index_test.tsx
@@ -41,18 +41,14 @@ describe("<Logs />", () => {
       id: 1,
       created_at: -1,
       message: "Fake log message 1",
-      meta: {
-        type: "info"
-      },
+      type: "info",
       channels: []
     },
     {
       id: 2,
       created_at: -1,
       message: "Fake log message 2",
-      meta: {
-        type: "success"
-      },
+      type: "success",
       channels: []
     }];
     return logs.map((body: Log): TaggedLog => {
@@ -76,7 +72,7 @@ describe("<Logs />", () => {
   };
 
   it("renders", () => {
-    const wrapper = mount(<Logs {...fakeProps() } />);
+    const wrapper = mount(<Logs {...fakeProps()} />);
     ["Logs", ToolTips.LOGS, "Type", "Message", "Time", "Info",
       "Fake log message 1", "Success", "Fake log message 2"]
       .map(string =>
@@ -87,7 +83,7 @@ describe("<Logs />", () => {
   });
 
   it("filters logs", () => {
-    const wrapper = mount(<Logs {...fakeProps() } />);
+    const wrapper = mount(<Logs {...fakeProps()} />);
     wrapper.setState({ info: 0 });
     expect(wrapper.text()).not.toContain("Fake log message 1");
     const filterBtn = wrapper.find("button").first();
@@ -97,10 +93,10 @@ describe("<Logs />", () => {
 
   it("shows position", () => {
     const p = fakeProps();
-    p.logs[0].body.meta.x = 100;
-    p.logs[1].body.meta.x = 0;
-    p.logs[1].body.meta.y = 1;
-    p.logs[1].body.meta.z = 2;
+    p.logs[0].body.x = 100;
+    p.logs[1].body.x = 0;
+    p.logs[1].body.y = 1;
+    p.logs[1].body.z = 2;
     const wrapper = mount(<Logs {...p} />);
     expect(wrapper.text()).toContain("Unknown");
     expect(wrapper.text()).toContain("0, 1, 2");
@@ -108,19 +104,19 @@ describe("<Logs />", () => {
 
   it("shows verbosity", () => {
     const p = fakeProps();
-    p.logs[0].body.meta.verbosity = -999;
+    p.logs[0].body.verbosity = -999;
     const wrapper = mount(<Logs {...p} />);
     expect(wrapper.text()).toContain(-999);
   });
 
   it("loads filter setting", () => {
     mockStorj[NumericSetting.warn_log] = 3;
-    const wrapper = mount(<Logs {...fakeProps() } />);
+    const wrapper = mount(<Logs {...fakeProps()} />);
     expect(wrapper.state().warn).toEqual(3);
   });
 
   it("shows overall filter status", () => {
-    const wrapper = mount(<Logs {...fakeProps() } />);
+    const wrapper = mount(<Logs {...fakeProps()} />);
     wrapper.setState({
       success: 3, busy: 3, warn: 3, error: 3, info: 3, fun: 3, debug: 3
     });
@@ -131,7 +127,7 @@ describe("<Logs />", () => {
 
   it("toggles filter", () => {
     mockStorj[NumericSetting.warn_log] = 3;
-    const wrapper = mount(<Logs {...fakeProps() } />);
+    const wrapper = mount(<Logs {...fakeProps()} />);
     // tslint:disable-next-line:no-any
     const instance = wrapper.instance() as any;
     expect(wrapper.state().warn).toEqual(3);
@@ -143,7 +139,7 @@ describe("<Logs />", () => {
 
   it("sets filter", () => {
     mockStorj[NumericSetting.warn_log] = 3;
-    const wrapper = mount(<Logs {...fakeProps() } />);
+    const wrapper = mount(<Logs {...fakeProps()} />);
     // tslint:disable-next-line:no-any
     const instance = wrapper.instance() as any;
     expect(wrapper.state().warn).toEqual(3);

--- a/webpack/logs/__tests__/state_to_props_test.ts
+++ b/webpack/logs/__tests__/state_to_props_test.ts
@@ -13,9 +13,7 @@ describe("mapStateToProps()", () => {
       id: 1,
       created_at: -1,
       message: "Fake log message",
-      meta: {
-        type: "info"
-      },
+      type: "info",
       channels: []
     };
     return times(count, () => log).map((body: Log): TaggedLog => {

--- a/webpack/logs/components/logs_table.tsx
+++ b/webpack/logs/components/logs_table.tsx
@@ -11,7 +11,7 @@ interface LogsRowProps {
 }
 const LogsRow = ({ tlog, timeOffset }: LogsRowProps) => {
   const log = tlog.body;
-  const { x, y, z, verbosity, type } = log.meta;
+  const { x, y, z, verbosity, type } = log;
   const time = formatLogTime(log.created_at, timeOffset);
   return <tr key={tlog.uuid}>
     <td>
@@ -67,8 +67,7 @@ const filterByVerbosity = (state: LogsState, logs: TaggedLog[]) => {
       return !log.body.message.toLowerCase().includes("filtered");
     })
     .filter((log: TaggedLog) => {
-      const type = (log.body.meta || {}).type;
-      const { verbosity } = log.body.meta;
+      const { type, verbosity } = log.body;
       const filterLevel = state[type as keyof LogsState];
       const displayLog = verbosity
         ? verbosity <= filterLevel

--- a/webpack/nav/__tests__/ticker_list_test.tsx
+++ b/webpack/nav/__tests__/ticker_list_test.tsx
@@ -31,9 +31,7 @@ describe("<TickerList />", () => {
   const log: Log = {
     id: 1234567,
     message: "Farmbot is up and Running!",
-    meta: {
-      type: "info"
-    },
+    type: "info",
     channels: [
       "toast"
     ],
@@ -87,7 +85,7 @@ describe("<TickerList />", () => {
   it("all logs filtered out", () => {
     ["success", "busy", "warn", "error", "info", "fun", "debug"]
       .map(logType => mockStorj[logType + "_log"] = 0);
-    log.meta.verbosity = 1;
+    log.verbosity = 1;
     const wrapper = mount(<TickerList
       logs={[log]} tickerListOpen={false} toggle={jest.fn()} timeOffset={0} />);
     const labels = wrapper.find("label");

--- a/webpack/nav/ticker_list.tsx
+++ b/webpack/nav/ticker_list.tsx
@@ -10,8 +10,7 @@ import { Session, safeNumericSetting } from "../session";
 import { isNumber } from "lodash";
 
 const logFilter = (log: Log): Log | undefined => {
-  const type = (log.meta || {}).type;
-  const { verbosity } = log.meta;
+  const { type, verbosity } = log;
   const filterLevel = Session.deprecatedGetNum(safeNumericSetting(type + "_log"));
   const filterLevelCompare = isNumber(filterLevel) ? filterLevel : 1;
   const displayLog = verbosity
@@ -28,7 +27,8 @@ const getfirstTickerLog = (logs: Log[]): Log => {
   if (logs.length == 0) {
     return {
       message: t("No logs yet."),
-      meta: { type: "debug", verbosity: -1 },
+      type: "debug",
+      verbosity: -1,
       channels: [], created_at: NaN
     };
   } else {
@@ -38,7 +38,8 @@ const getfirstTickerLog = (logs: Log[]): Log => {
     } else {
       return {
         message: t("No logs to display. Visit Logs page to view filters."),
-        meta: { type: "debug", verbosity: -1 },
+        type: "debug",
+        verbosity: -1,
         channels: [], created_at: NaN
       };
     }
@@ -47,7 +48,7 @@ const getfirstTickerLog = (logs: Log[]): Log => {
 
 const Ticker = (log: Log, index: number, timeOffset: number) => {
   const time = formatLogTime(log.created_at, timeOffset);
-  const type = (log.meta || {}).type;
+  const { type } = log;
   // TODO: Should utilize log's `uuid` instead of index.
   return <div key={index} className="status-ticker-wrapper">
     <div className={`saucer ${type}`} />


### PR DESCRIPTION
Also, migrates some logs that did not have a `type` field (default value it "info").