### PR TITLE
Handle Uncaught Promises

### DIFF
--- a/webpack/apology.tsx
+++ b/webpack/apology.tsx
@@ -28,10 +28,10 @@ export function Apology(_: {}) {
           </span>
         </li>
         <li>
-          Send the error information (below) to our developer team via the
+          Send a report to our developer team via the
         <a href="http://forum.farmbot.org/c/software">FarmBot software
         forum</a>. Including additional information (such as steps leading up
-                  to the error) help us identify solutions more quickly.
+                    to the error) helps us identify solutions more quickly.
         </li>
       </ol>
     </p>

--- a/webpack/connectivity/__tests__/connect_device/index_test.ts
+++ b/webpack/connectivity/__tests__/connect_device/index_test.ts
@@ -179,7 +179,7 @@ describe("onOnline", () => {
 
 describe("changeLastClientConnected", () => {
   it("tells farmbot when the last browser session was opened", () => {
-    const setUserEnv = jest.fn();
+    const setUserEnv = jest.fn(() => Promise.resolve({}));
     const fakeFarmbot = { setUserEnv: setUserEnv as any } as Farmbot;
     changeLastClientConnected(fakeFarmbot)();
     expect(setUserEnv).toHaveBeenCalledWith(expect.objectContaining({

--- a/webpack/connectivity/connect_device.ts
+++ b/webpack/connectivity/connect_device.ts
@@ -103,7 +103,7 @@ export const onOffline = () => {
 export const changeLastClientConnected = (bot: Farmbot) => () => {
   bot.setUserEnv({
     "LAST_CLIENT_CONNECTED": JSON.stringify(new Date())
-  });
+  }).catch(() => { });
 };
 
 const onStatus = (dispatch: Function, getState: GetState) =>

--- a/webpack/controls/direction_button.tsx
+++ b/webpack/controls/direction_button.tsx
@@ -6,7 +6,7 @@ import { DirectionButtonProps, Payl } from "./interfaces";
 export function directionDisabled(props: DirectionButtonProps): boolean {
   const {
     stopAtHome, stopAtMax, axisLength, position, isInverted, negativeOnly
-   } = props.directionAxisProps;
+  } = props.directionAxisProps;
   const { direction } = props;
   const loc = position || 0;
   const jog = calculateDistance(props);
@@ -36,7 +36,7 @@ export function calculateDistance(props: DirectionButtonProps) {
   const isNegative = (direction === "down") || (direction === "left");
   const inverter = isInverted ? -1 : 1;
   const multiplier = isNegative ? -1 : 1;
-  const distance = (props.steps || 250) * multiplier * inverter;
+  const distance = props.steps * multiplier * inverter;
   return distance;
 }
 

--- a/webpack/controls/jog_buttons.tsx
+++ b/webpack/controls/jog_buttons.tsx
@@ -13,7 +13,7 @@ export function JogButtons(props: JogMovementControlsProps) {
         <td>
           <button
             className="i fa fa-camera arrow-button fb-button"
-            onClick={() => getDevice().takePhoto()} />
+            onClick={() => getDevice().takePhoto().catch(() => { })} />
         </td>
         <td />
         <td />

--- a/webpack/controls_popup.tsx
+++ b/webpack/controls_popup.tsx
@@ -82,7 +82,7 @@ export class ControlsPopup extends React.Component<Props, Partial<State>> {
             disabled={!isOpen} />
           <button
             className="i fa fa-camera arrow-button fb-button brown"
-            onClick={() => getDevice().takePhoto()} />
+            onClick={() => getDevice().takePhoto().catch(() => { })} />
         </div>
       </div>
     </div>;

--- a/webpack/devices/components/hardware_settings/__tests__/calibration_row_test.tsx
+++ b/webpack/devices/components/hardware_settings/__tests__/calibration_row_test.tsx
@@ -1,5 +1,5 @@
 const mockDevice = {
-  calibrate: jest.fn()
+  calibrate: jest.fn(() => Promise.resolve({}))
 };
 jest.mock("../../../../device", () => ({
   getDevice: () => (mockDevice)

--- a/webpack/devices/components/hardware_settings/__tests__/homing_row_test.tsx
+++ b/webpack/devices/components/hardware_settings/__tests__/homing_row_test.tsx
@@ -1,5 +1,5 @@
 const mockDevice = {
-  findHome: jest.fn()
+  findHome: jest.fn(() => Promise.resolve({}))
 };
 
 jest.mock("../../../../device", () => ({

--- a/webpack/devices/components/hardware_settings/calibration_row.tsx
+++ b/webpack/devices/components/hardware_settings/calibration_row.tsx
@@ -8,10 +8,8 @@ import { ToolTips } from "../../../constants";
 import { Row, Col } from "../../../ui/index";
 import { CalibrationRowProps } from "../interfaces";
 
-function calibrate(axis: Axis) {
-  getDevice()
-    .calibrate({ axis });
-}
+const calibrate =
+  (axis: Axis) => getDevice().calibrate({ axis }).catch(() => { });
 
 export function CalibrationRow(props: CalibrationRowProps) {
 

--- a/webpack/devices/components/hardware_settings/homing_row.tsx
+++ b/webpack/devices/components/hardware_settings/homing_row.tsx
@@ -11,7 +11,8 @@ import { SpacePanelToolTip } from "../space_panel_tool_tip";
 import { Row, Col } from "../../../ui/index";
 
 const speed = Farmbot.defaults.speed;
-const findHome = (axis: Axis) => getDevice().findHome({ speed, axis });
+const findHome =
+  (axis: Axis) => getDevice().findHome({ speed, axis }).catch(() => { });
 
 export function HomingRow(props: HomingRowProps) {
   const { hardware, botDisconnected } = props;

--- a/webpack/error_boundary.tsx
+++ b/webpack/error_boundary.tsx
@@ -12,12 +12,8 @@ export class ErrorBoundary extends React.Component<Props, State> {
   }
 
   componentDidCatch(error: Error) {
-    try {
-      this.setState({ hasError: true });
-      catchErrors(error);
-    } catch (e) {
-      this.setState({ hasError: true });
-    }
+    try { catchErrors(error); } catch (e) { }
+    this.setState({ hasError: true });
   }
 
   no = () => <Apology />;

--- a/webpack/farmware/__tests__/farmware_forms_test.tsx
+++ b/webpack/farmware/__tests__/farmware_forms_test.tsx
@@ -1,6 +1,6 @@
 const mockDevice = {
-  execScript: jest.fn(),
-  setUserEnv: jest.fn()
+  execScript: jest.fn(() => Promise.resolve({})),
+  setUserEnv: jest.fn(() => Promise.resolve({}))
 };
 
 jest.mock("../../device", () => ({

--- a/webpack/farmware/__tests__/farmware_panel_test.tsx
+++ b/webpack/farmware/__tests__/farmware_panel_test.tsx
@@ -1,9 +1,9 @@
 const mockDevice = {
-  installFarmware: jest.fn(() => { return Promise.resolve(); }),
-  updateFarmware: jest.fn(() => { return Promise.resolve(); }),
-  removeFarmware: jest.fn(() => { return Promise.resolve(); }),
-  execScript: jest.fn(() => { return Promise.resolve(); }),
-  installFirstPartyFarmware: jest.fn(),
+  installFarmware: jest.fn(() => Promise.resolve()),
+  updateFarmware: jest.fn(() => Promise.resolve()),
+  removeFarmware: jest.fn(() => Promise.resolve()),
+  execScript: jest.fn(() => Promise.resolve()),
+  installFirstPartyFarmware: jest.fn(() => Promise.resolve())
 };
 
 jest.mock("../../device", () => ({
@@ -34,7 +34,7 @@ describe("<FarmwarePanel/>: actions", () => {
   }
 
   it("calls install", () => {
-    const panel = mount(<FarmwarePanel {...fakeProps() } />);
+    const panel = mount(<FarmwarePanel {...fakeProps()} />);
     const buttons = panel.find("button");
     expect(buttons.at(0).text()).toEqual("Install");
     panel.setState({ packageUrl: "install this" });
@@ -43,7 +43,7 @@ describe("<FarmwarePanel/>: actions", () => {
   });
 
   it("farmware not selected", () => {
-    const panel = mount(<FarmwarePanel {...fakeProps() } />);
+    const panel = mount(<FarmwarePanel {...fakeProps()} />);
     panel.setState({ selectedFarmware: undefined });
     const updateBtn = panel.find("button").at(3);
     expect(updateBtn.text()).toEqual("Update");
@@ -56,7 +56,7 @@ describe("<FarmwarePanel/>: actions", () => {
   });
 
   it("calls update", () => {
-    const panel = mount(<FarmwarePanel {...fakeProps() } />);
+    const panel = mount(<FarmwarePanel {...fakeProps()} />);
     const buttons = panel.find("button");
     expect(buttons.at(3).text()).toEqual("Update");
     panel.setState({ selectedFarmware: "update this" });
@@ -65,7 +65,7 @@ describe("<FarmwarePanel/>: actions", () => {
   });
 
   it("calls remove", () => {
-    const panel = mount(<FarmwarePanel {...fakeProps() } />);
+    const panel = mount(<FarmwarePanel {...fakeProps()} />);
     const removeBtn = panel.find("button").at(2);
     expect(removeBtn.text()).toEqual("Remove");
     panel.setState({ selectedFarmware: "remove this" });
@@ -83,7 +83,7 @@ describe("<FarmwarePanel/>: actions", () => {
   });
 
   it("calls run", () => {
-    const panel = mount(<FarmwarePanel {...fakeProps() } />);
+    const panel = mount(<FarmwarePanel {...fakeProps()} />);
     const buttons = panel.find("button");
     expect(buttons.at(4).text()).toEqual("Run");
     panel.setState({ selectedFarmware: "run this" });
@@ -92,14 +92,14 @@ describe("<FarmwarePanel/>: actions", () => {
   });
 
   it("sets url to install", () => {
-    const panel = shallow(<FarmwarePanel {...fakeProps() } />);
+    const panel = shallow(<FarmwarePanel {...fakeProps()} />);
     const input = panel.find("input").first();
     input.simulate("change", { currentTarget: { value: "inputted url" } });
     expect(panel.state().packageUrl).toEqual("inputted url");
   });
 
   it("selects a farmware", () => {
-    const panel = shallow(<FarmwarePanel {...fakeProps() } />);
+    const panel = shallow(<FarmwarePanel {...fakeProps()} />);
     const dropdown = panel.find("FBSelect").first();
     dropdown.simulate("change", { value: "selected farmware" });
     expect(panel.state().selectedFarmware).toEqual("selected farmware");
@@ -131,7 +131,7 @@ describe("<FarmwarePanel/>: farmware list", () => {
     const firstPartyFarmware = fakeFarmwares().farmware_0;
     if (firstPartyFarmware) { firstPartyFarmware.name = "first-party farmware"; }
     p.farmwares.farmware_1 = firstPartyFarmware;
-    const panel = shallow(<FarmwarePanel {...p } />);
+    const panel = shallow(<FarmwarePanel {...p} />);
     expect(panel.find("FBSelect").props().list).toEqual([{
       label: "My Farmware 0.0.0", value: "My Farmware"
     }]);
@@ -145,7 +145,7 @@ describe("<FarmwarePanel/>: farmware list", () => {
   it("toggles first party farmware display", () => {
     jest.resetAllMocks();
     const p = fakeProps();
-    const panel = shallow(<FarmwarePanel {...p } />);
+    const panel = shallow(<FarmwarePanel {...p} />);
     panel.find(FarmwareConfigMenu).simulate("toggle", {});
     expect(p.onToggle).toHaveBeenCalled();
   });
@@ -158,7 +158,7 @@ describe("<FarmwarePanel/>: farmware list", () => {
       otherFarmware.meta.description = "Does other things.";
     }
     p.farmwares.farmware_1 = otherFarmware;
-    const panel = mount(<FarmwarePanel {...p } />);
+    const panel = mount(<FarmwarePanel {...p} />);
     expect(panel.text()).not.toContain("Does things.");
     panel.setState({ selectedFarmware: "My Farmware" });
     expect(panel.text()).toContain("Does things.");
@@ -166,7 +166,7 @@ describe("<FarmwarePanel/>: farmware list", () => {
   });
 
   it("all 1st party farmwares are installed", () => {
-    const panel = shallow(<FarmwarePanel {...fakeProps() } />);
+    const panel = shallow(<FarmwarePanel {...fakeProps()} />);
     // tslint:disable-next-line:no-any
     const instance = panel.instance() as any;
     const allInstalled = instance.firstPartyFarmwaresPresent([
@@ -175,7 +175,7 @@ describe("<FarmwarePanel/>: farmware list", () => {
   });
 
   it("some 1st party farmwares are missing", () => {
-    const panel = shallow(<FarmwarePanel {...fakeProps() } />);
+    const panel = shallow(<FarmwarePanel {...fakeProps()} />);
     // tslint:disable-next-line:no-any
     const instance = panel.instance() as any;
     const allInstalled = instance.firstPartyFarmwaresPresent([
@@ -199,7 +199,7 @@ describe("<FarmwareConfigMenu />", () => {
 
   it("calls install 1st party farmwares", () => {
     const wrapper = mount(
-      <FarmwareConfigMenu {...fakeProps() } />);
+      <FarmwareConfigMenu {...fakeProps()} />);
     const button = wrapper.find("button").first();
     expect(button.hasClass("fa-download")).toBeTruthy();
     button.simulate("click");
@@ -210,7 +210,7 @@ describe("<FarmwareConfigMenu />", () => {
     const p = fakeProps();
     p.firstPartyFwsInstalled = true;
     const wrapper = mount(
-      <FarmwareConfigMenu {...p } />);
+      <FarmwareConfigMenu {...p} />);
     const button = wrapper.find("button").first();
     expect(button.hasClass("fa-download")).toBeTruthy();
     button.simulate("click");

--- a/webpack/farmware/__tests__/farmware_panel_test.tsx
+++ b/webpack/farmware/__tests__/farmware_panel_test.tsx
@@ -4,7 +4,6 @@ const mockDevice = {
   removeFarmware: jest.fn(() => Promise.resolve()),
   execScript: jest.fn(() => Promise.resolve()),
   installFirstPartyFarmware: jest.fn(() => {
-    debugger;
     return Promise.resolve({});
   })
 };

--- a/webpack/farmware/__tests__/farmware_panel_test.tsx
+++ b/webpack/farmware/__tests__/farmware_panel_test.tsx
@@ -3,7 +3,10 @@ const mockDevice = {
   updateFarmware: jest.fn(() => Promise.resolve()),
   removeFarmware: jest.fn(() => Promise.resolve()),
   execScript: jest.fn(() => Promise.resolve()),
-  installFirstPartyFarmware: jest.fn(() => Promise.resolve())
+  installFirstPartyFarmware: jest.fn(() => {
+    debugger;
+    return Promise.resolve({});
+  })
 };
 
 jest.mock("../../device", () => ({

--- a/webpack/farmware/camera_calibration/__tests__/actions_test.ts
+++ b/webpack/farmware/camera_calibration/__tests__/actions_test.ts
@@ -1,5 +1,5 @@
 const mockDevice = {
-  execScript: jest.fn()
+  execScript: jest.fn(() => Promise.resolve({}))
 };
 jest.mock("../../../device", () => ({
   getDevice: () => (mockDevice)

--- a/webpack/farmware/camera_calibration/actions.ts
+++ b/webpack/farmware/camera_calibration/actions.ts
@@ -14,6 +14,7 @@ export function scanImage(imageId: number) {
           label: "CAMERA_CALIBRATION_selected_image",
           value: "" + imageId
         }
-      }]);
+      }])
+      .catch(() => { });
   };
 }

--- a/webpack/farmware/camera_calibration/actions.ts
+++ b/webpack/farmware/camera_calibration/actions.ts
@@ -2,19 +2,18 @@ import { getDevice } from "../../device";
 
 export function calibrate() {
   return function () {
-    getDevice().execScript("camera-calibration");
+    getDevice().execScript("camera-calibration").catch(() => { });
   };
 }
 
 export function scanImage(imageId: number) {
   return function () {
-    getDevice()
-      .execScript("historical-camera-calibration", [{
-        kind: "pair", args: {
-          label: "CAMERA_CALIBRATION_selected_image",
-          value: "" + imageId
-        }
-      }])
-      .catch(() => { });
+    const p = getDevice().execScript("historical-camera-calibration", [{
+      kind: "pair", args: {
+        label: "CAMERA_CALIBRATION_selected_image",
+        value: "" + imageId
+      }
+    }]);
+    p && p.catch(() => { });
   };
 }

--- a/webpack/farmware/farmware_forms.tsx
+++ b/webpack/farmware/farmware_forms.tsx
@@ -17,7 +17,7 @@ export function FarmwareForms(props: FarmwareFormsProps): JSX.Element {
 
   function inputChange(key: string, e: React.SyntheticEvent<HTMLInputElement>) {
     const value = e.currentTarget.value;
-    getDevice().setUserEnv({ [key]: value });
+    getDevice().setUserEnv({ [key]: value }).catch(() => { });
   }
 
   function getEnvName(farmwareName: string, configName: string) {
@@ -35,7 +35,7 @@ export function FarmwareForms(props: FarmwareFormsProps): JSX.Element {
       const value = getValue(farmwareName, x);
       return { kind: "pair", args: { value, label } };
     });
-    getDevice().execScript(farmwareName, pairs);
+    getDevice().execScript(farmwareName, pairs).catch(() => { });
   }
 
   const { farmwares, user_env } = props;

--- a/webpack/farmware/farmware_panel.tsx
+++ b/webpack/farmware/farmware_panel.tsx
@@ -28,9 +28,8 @@ export function FarmwareConfigMenu(props: FarmwareConfigMenuProps) {
       <button
         className="fb-button gray fa fa-download"
         onClick={() => {
-          const y = getDevice().installFirstPartyFarmware();
-          debugger;
-          y.catch(() => { });
+          const p = getDevice().installFirstPartyFarmware();
+          p && p.catch(() => { });
         }}
         disabled={props.firstPartyFwsInstalled} />
     </fieldset>

--- a/webpack/farmware/farmware_panel.tsx
+++ b/webpack/farmware/farmware_panel.tsx
@@ -27,7 +27,11 @@ export function FarmwareConfigMenu(props: FarmwareConfigMenuProps) {
       </label>
       <button
         className="fb-button gray fa fa-download"
-        onClick={() => getDevice().installFirstPartyFarmware()}
+        onClick={() => {
+          const y = getDevice().installFirstPartyFarmware();
+          debugger;
+          y.catch(() => { });
+        }}
         disabled={props.firstPartyFwsInstalled} />
     </fieldset>
     <fieldset>
@@ -57,7 +61,8 @@ export class FarmwarePanel extends React.Component<FWProps, Partial<FWState>> {
     this
       .ifFarmwareSelected(label => getDevice()
         .updateFarmware(label)
-        .then(() => this.setState({ selectedFarmware: undefined })));
+        .then(() => this.setState({ selectedFarmware: undefined }))
+        .catch(() => { }));
   }
 
   remove = () => {
@@ -69,7 +74,8 @@ export class FarmwarePanel extends React.Component<FWProps, Partial<FWState>> {
         if (!isFirstParty || confirm(Content.FIRST_PARTY_WARNING)) {
           getDevice()
             .removeFarmware(label)
-            .then(() => this.setState({ selectedFarmware: undefined }));
+            .then(() => this.setState({ selectedFarmware: undefined }))
+            .catch(() => { });
         }
       });
   }
@@ -85,7 +91,8 @@ export class FarmwarePanel extends React.Component<FWProps, Partial<FWState>> {
     if (this.state.packageUrl) {
       getDevice()
         .installFarmware(this.state.packageUrl)
-        .then(() => this.setState({ packageUrl: "" }));
+        .then(() => this.setState({ packageUrl: "" }))
+        .catch(() => { });
     } else {
       alert(t("Enter a URL"));
     }

--- a/webpack/farmware/weed_detector/__tests__/weed_detector_test.tsx
+++ b/webpack/farmware/weed_detector/__tests__/weed_detector_test.tsx
@@ -1,5 +1,5 @@
 const mockDevice = {
-  execScript: jest.fn(),
+  execScript: jest.fn(() => Promise.resolve()),
 };
 
 jest.mock("../../../device", () => ({

--- a/webpack/farmware/weed_detector/actions.tsx
+++ b/webpack/farmware/weed_detector/actions.tsx
@@ -72,12 +72,13 @@ export function scanImage(imageId: number) {
     getDevice()
       .execScript("historical-plant-detection", [{
         kind: "pair", args: { label: label, value: "" + imageId }
-      }]);
+      }])
+      .catch(() => { });
   };
 }
 
 export function test() {
   return function () {
-    getDevice().execScript("plant-detection");
+    getDevice().execScript("plant-detection").catch(() => { });
   };
 }

--- a/webpack/farmware/weed_detector/remote_env/actions.ts
+++ b/webpack/farmware/weed_detector/remote_env/actions.ts
@@ -6,5 +6,5 @@ import { formatEnvKey } from "./translators";
 export function envSave(key: WDENVKey, value: number) {
   getDevice()
     .setUserEnv({ [key]: JSON.stringify(formatEnvKey(key, value)) })
-    .then(() => { }, () => { });
+    .catch(() => { });
 }


### PR DESCRIPTION
# Why?

 * There were a couple places where we were not `.catch()`ing promises, leading to a bunch of "noise" in the error logger. This PR handles those situations to reduce the number of uncaught exceptions.