### PR TITLE
BUG FIX: 500 error when missing optional fields

### DIFF
--- a/app/mutations/logs/create.rb
+++ b/app/mutations/logs/create.rb
@@ -19,15 +19,15 @@ module Logs
       # at this point and we need the ability to perform SQL queries. The `meta`
       # field is no longer useful nor is it a clean solution.
       #
-      # Too many bots expect logs to be in the same shape as before and they
-      # also create logs with the expectation that logs have a `meta` field.
+      # Legacy FBOS versions expect logs to be in the same shape as before
+      # and they also produce logs with the expectation that logs have a `meta`
+      # field.
       #
-      # We will keep the `meta` field aroundn for now, but ideally, API users
+      # We will keep the `meta` field around for now, but ideally, API users
       # should access `log.FOO` instead of `log.meta.FOO` for future
       # compatibility.
       #
-      # TODO: Make the fields below mandadtory (allowing nil in some cases, but
-      #       always requiring the key) and delete the `meta` field.
+      # TODO: delete the `meta` field by 6 JUN 18
       string  :type, in: Log::TYPES
       integer :x
       integer :y
@@ -78,7 +78,8 @@ module Logs
 
     # Helper for dealing with the gradual removal of the meta field.
     def transitional_field(name, default = nil)
-      return inputs[name] || meta[name] || meta[name.to_s] || default
+      m = meta || {} # New logs wont have `meta`.
+      return inputs[name] || m[name] || m[name.to_s] || default
     end
   end
 end

--- a/spec/controllers/api/logs/logs_spec.rb
+++ b/spec/controllers/api/logs/logs_spec.rb
@@ -59,6 +59,16 @@ describe Api::LogsController do
       end
     end
 
+    it 'creates one log with only required fields' do
+      sign_in user
+      before_count = Log.count
+      body = { message: "HELLO", type: "info" }
+      post :create, body: body.to_json, params: {format: :json}
+      expect(response.status).to eq(200)
+      expect(Log.count).to be > before_count
+      expect(json[:message]).to eq("HELLO")
+    end
+
     it 'disallows blacklisted (sensitive) words in logs' do
       Log.destroy_all
       stub = { meta: { x: 1, y: 2, z: 3, type: "info" },


### PR DESCRIPTION
# Why?

 * If you `POST` a log that is missing optional fields, a 500 error is raised.

# What's New?

 * Make optional fields actually optional.