### PR TITLE
Farm Designer

### DIFF
--- a/db/migrate/20180412224141_add_xy_swap_to_web_app_configs.rb
+++ b/db/migrate/20180412224141_add_xy_swap_to_web_app_configs.rb
@@ -1,0 +1,8 @@
+class AddXySwapToWebAppConfigs < ActiveRecord::Migration[5.1]
+  def change
+    add_column  :web_app_configs,
+                :xy_swap,
+                :boolean,
+                default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180412191221) do
+ActiveRecord::Schema.define(version: 20180412224141) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -468,6 +468,7 @@ ActiveRecord::Schema.define(version: 20180412191221) do
     t.string "photo_filter_begin"
     t.string "photo_filter_end"
     t.boolean "discard_unsaved", default: false
+    t.boolean "xy_swap", default: false
     t.index ["device_id"], name: "index_web_app_configs_on_device_id"
   end
 

--- a/webpack/__test_support__/fake_state/resources.ts
+++ b/webpack/__test_support__/fake_state/resources.ts
@@ -210,7 +210,8 @@ export function fakeWebAppConfig(): TaggedWebAppConfig {
     enable_browser_speak: false,
     photo_filter_begin: "2018-01-11T20:20:38.362Z",
     photo_filter_end: "2018-01-22T15:32:41.970Z",
-    discard_unsaved: false
+    discard_unsaved: false,
+    xy_swap: false,
   });
 }
 

--- a/webpack/__test_support__/map_transform_props.ts
+++ b/webpack/__test_support__/map_transform_props.ts
@@ -1,0 +1,9 @@
+import { MapTransformProps } from "../farm_designer/map/interfaces";
+
+export const fakeMapTransformProps = (): MapTransformProps => {
+  return {
+    quadrant: 2,
+    gridSize: { x: 3000, y: 1500 },
+    xySwap: false,
+  };
+};

--- a/webpack/__tests__/app_test.tsx
+++ b/webpack/__tests__/app_test.tsx
@@ -17,21 +17,22 @@ import { mount } from "enzyme";
 import { bot } from "../__test_support__/fake_state/bot";
 import { fakeUser } from "../__test_support__/fake_state/resources";
 
-describe("<App />: Controls Pop-Up", () => {
-  function fakeProps(): AppProps {
-    return {
-      timeOffset: 0, // Default to UTC
-      dispatch: jest.fn(),
-      loaded: [],
-      logs: [],
-      user: fakeUser(),
-      bot: bot,
-      consistent: true,
-      axisInversion: { x: false, y: false, z: false },
-      firmwareConfig: undefined,
-    };
-  }
+const fakeProps = (): AppProps => {
+  return {
+    timeOffset: 0, // Default to UTC
+    dispatch: jest.fn(),
+    loaded: [],
+    logs: [],
+    user: fakeUser(),
+    bot: bot,
+    consistent: true,
+    axisInversion: { x: false, y: false, z: false },
+    firmwareConfig: undefined,
+    xySwap: false,
+  };
+};
 
+describe("<App />: Controls Pop-Up", () => {
   function controlsPopUp(page: string, exists: boolean) {
     it(`doesn't render controls pop-up on ${page} page`, () => {
       mockPath = "/app/" + page;
@@ -58,21 +59,6 @@ describe("<App />: Controls Pop-Up", () => {
 });
 
 describe("<App />: Loading", () => {
-  function fakeProps(): AppProps {
-    const p: AppProps = {
-      dispatch: jest.fn(),
-      loaded: [],
-      logs: [],
-      user: fakeUser(),
-      bot: bot,
-      consistent: true,
-      timeOffset: 0,
-      axisInversion: { x: false, y: false, z: false },
-      firmwareConfig: undefined,
-    };
-    return p;
-  }
-
   it("MUST_LOADs not loaded", () => {
     const wrapper = mount(<App {...fakeProps()} />);
     expect(wrapper.text()).toContain("Loading...");
@@ -94,20 +80,6 @@ describe("<App />: Loading", () => {
 });
 
 describe("<App />: NavBar", () => {
-  function fakeProps(): AppProps {
-    return {
-      dispatch: jest.fn(),
-      loaded: [],
-      logs: [],
-      user: fakeUser(),
-      bot: bot,
-      consistent: true,
-      timeOffset: 0,
-      axisInversion: { x: false, y: false, z: false },
-      firmwareConfig: undefined,
-    };
-  }
-
   it("displays links", () => {
     const wrapper = mount(<App {...fakeProps()} />);
     expect(wrapper.text())

--- a/webpack/__tests__/controls_popup_test.tsx
+++ b/webpack/__tests__/controls_popup_test.tsx
@@ -10,18 +10,28 @@ import * as React from "react";
 import { ControlsPopup } from "../controls_popup";
 import { mount } from "enzyme";
 import { bot } from "../__test_support__/fake_state/bot";
+import { ControlsPopupProps } from "../controls/interfaces";
 
 describe("<ControlsPopup />", () => {
   beforeEach(function () {
     jest.clearAllMocks();
   });
 
-  const wrapper = mount(<ControlsPopup
-    dispatch={jest.fn()}
-    axisInversion={{ x: true, y: false, z: false }}
-    botPosition={{ x: undefined, y: undefined, z: undefined }}
-    mcuParams={bot.hardware.mcu_params}
-    xySwap={false} />);
+  const fakeProps = (): ControlsPopupProps => {
+    return {
+      dispatch: jest.fn(),
+      axisInversion: { x: false, y: false, z: false },
+      botPosition: { x: undefined, y: undefined, z: undefined },
+      firmwareSettings: bot.hardware.mcu_params,
+      xySwap: false,
+      arduinoBusy: false,
+      stepSize: 100,
+    };
+  };
+
+  const p = fakeProps();
+  p.axisInversion.x = true;
+  const wrapper = mount(<ControlsPopup {...p} />);
 
   it("Has a false initial state", () => {
     expect(wrapper.state("isOpen")).toBeFalsy();
@@ -56,12 +66,9 @@ describe("<ControlsPopup />", () => {
   });
 
   it("swaps axes", () => {
-    const swapped = mount(<ControlsPopup
-      dispatch={jest.fn()}
-      axisInversion={{ x: false, y: false, z: false }}
-      botPosition={{ x: undefined, y: undefined, z: undefined }}
-      mcuParams={bot.hardware.mcu_params}
-      xySwap={true} />);
+    const swappedProps = fakeProps();
+    swappedProps.xySwap = true;
+    const swapped = mount(<ControlsPopup {...swappedProps} />);
     swapped.setState({ isOpen: true });
     expect(swapped.state("isOpen")).toBeTruthy();
     const button = swapped.find("button").at(1);

--- a/webpack/__tests__/controls_popup_test.tsx
+++ b/webpack/__tests__/controls_popup_test.tsx
@@ -20,7 +20,8 @@ describe("<ControlsPopup />", () => {
     dispatch={jest.fn()}
     axisInversion={{ x: true, y: false, z: false }}
     botPosition={{ x: undefined, y: undefined, z: undefined }}
-    mcuParams={bot.hardware.mcu_params} />);
+    mcuParams={bot.hardware.mcu_params}
+    xySwap={false} />);
 
   it("Has a false initial state", () => {
     expect(wrapper.state("isOpen")).toBeFalsy();
@@ -52,5 +53,21 @@ describe("<ControlsPopup />", () => {
     wrapper.setState({ isOpen: false });
     [0, 1, 2, 3].map((i) => wrapper.find("button").at(i).simulate("click"));
     expect(mockDevice.moveRelative).not.toHaveBeenCalled();
+  });
+
+  it("swaps axes", () => {
+    const swapped = mount(<ControlsPopup
+      dispatch={jest.fn()}
+      axisInversion={{ x: false, y: false, z: false }}
+      botPosition={{ x: undefined, y: undefined, z: undefined }}
+      mcuParams={bot.hardware.mcu_params}
+      xySwap={true} />);
+    swapped.setState({ isOpen: true });
+    expect(swapped.state("isOpen")).toBeTruthy();
+    const button = swapped.find("button").at(1);
+    expect(button.props().title).toBe("move x axis (100)");
+    button.simulate("click");
+    expect(mockDevice.moveRelative)
+      .toHaveBeenCalledWith({ speed: 100, x: 100, y: 0, z: 0 });
   });
 });

--- a/webpack/app.tsx
+++ b/webpack/app.tsx
@@ -23,6 +23,7 @@ import { Session } from "./session";
 import { BooleanSetting } from "./session_keys";
 import { getPathArray } from "./history";
 import { FirmwareConfig } from "./config_storage/firmware_configs";
+import { getWebAppConfigValue } from "./config_storage/actions";
 
 /** Remove 300ms delay on touch devices - https://github.com/ftlabs/fastclick */
 const fastClick = require("fastclick");
@@ -40,6 +41,7 @@ export interface AppProps {
   consistent: boolean;
   timeOffset: number;
   axisInversion: Record<Xyz, boolean>;
+  xySwap: boolean;
   firmwareConfig: FirmwareConfig | undefined;
 }
 
@@ -62,6 +64,7 @@ function mapStateToProps(props: Everything): AppProps {
       y: !!Session.deprecatedGetBool(BooleanSetting.y_axis_inverted),
       z: !!Session.deprecatedGetBool(BooleanSetting.z_axis_inverted),
     },
+    xySwap: !!getWebAppConfigValue(() => props)(BooleanSetting.xy_swap),
     firmwareConfig: validFwConfig(getFirmwareConfig(props.resources.index))
   };
 }
@@ -118,7 +121,8 @@ export class App extends React.Component<AppProps, {}> {
           dispatch={this.props.dispatch}
           axisInversion={this.props.axisInversion}
           botPosition={validBotLocationData(location_data).position}
-          mcuParams={this.props.firmwareConfig || mcu_params} />}
+          mcuParams={this.props.firmwareConfig || mcu_params}
+          xySwap={this.props.xySwap} />}
     </div>;
   }
 }

--- a/webpack/app.tsx
+++ b/webpack/app.tsx
@@ -121,8 +121,10 @@ export class App extends React.Component<AppProps, {}> {
           dispatch={this.props.dispatch}
           axisInversion={this.props.axisInversion}
           botPosition={validBotLocationData(location_data).position}
-          mcuParams={this.props.firmwareConfig || mcu_params}
-          xySwap={this.props.xySwap} />}
+          firmwareSettings={this.props.firmwareConfig || mcu_params}
+          xySwap={this.props.xySwap}
+          arduinoBusy={!!this.props.bot.hardware.informational_settings.busy}
+          stepSize={this.props.bot.stepSize} />}
     </div>;
   }
 }

--- a/webpack/config_storage/web_app_configs.ts
+++ b/webpack/config_storage/web_app_configs.ts
@@ -44,6 +44,7 @@ export interface WebAppConfig {
   photo_filter_begin: string;
   photo_filter_end: string;
   discard_unsaved: boolean;
+  xy_swap: boolean;
 }
 
 export type NumberConfigKey = "id"
@@ -85,4 +86,5 @@ export type BooleanConfigKey = "confirm_step_deletion"
     |"show_first_party_farmware"
     |"enable_browser_speak"
     |"show_images"
-    |"discard_unsaved";
+    |"discard_unsaved"
+    |"xy_swap";

--- a/webpack/controls/__tests__/controls_test.tsx
+++ b/webpack/controls/__tests__/controls_test.tsx
@@ -38,6 +38,7 @@ describe("<Controls />", () => {
       botToMqttStatus: "up",
       firmwareSettings: bot.hardware.mcu_params,
       shouldDisplay: () => true,
+      xySwap: false,
     };
   }
 

--- a/webpack/controls/__tests__/jog_buttons_test.tsx
+++ b/webpack/controls/__tests__/jog_buttons_test.tsx
@@ -23,11 +23,10 @@ describe("<JogButtons/>", function () {
 
   const jogButtonProps = (): JogMovementControlsProps => {
     return {
-      bot: bot,
-      x_axis_inverted: false,
-      y_axis_inverted: false,
-      z_axis_inverted: false,
-      disabled: false,
+      stepSize: 100,
+      botPosition: { x: undefined, y: undefined, z: undefined },
+      axisInversion: { x: false, y: false, z: false },
+      arduinoBusy: false,
       firmwareSettings: bot.hardware.mcu_params,
       xySwap: false,
     };
@@ -41,7 +40,7 @@ describe("<JogButtons/>", function () {
 
   it("is disabled", () => {
     const p = jogButtonProps();
-    p.disabled = true;
+    p.arduinoBusy = true;
     const jogButtons = mount(<JogButtons {...p} />);
     jogButtons.find("button").at(3).simulate("click");
     expect(mockDevice.home).not.toHaveBeenCalled();
@@ -71,6 +70,7 @@ describe("<JogButtons/>", function () {
 
   it("has swapped xy jog buttons", () => {
     const p = jogButtonProps();
+    (p.stepSize as number | undefined) = undefined;
     p.xySwap = true;
     const jogButtons = mount(<JogButtons {...p} />);
     const button = jogButtons.find("button").at(6);

--- a/webpack/controls/__tests__/move_test.tsx
+++ b/webpack/controls/__tests__/move_test.tsx
@@ -7,12 +7,19 @@ jest.mock("../../session", () => {
   };
 });
 
+jest.mock("../../config_storage/actions", () => {
+  return {
+    toggleWebAppBool: jest.fn()
+  };
+});
+
 import * as React from "react";
 import { mount } from "enzyme";
 import { Move } from "../move";
 import { bot } from "../../__test_support__/fake_state/bot";
 import { MoveProps } from "../interfaces";
 import { Session } from "../../session";
+import { toggleWebAppBool } from "../../config_storage/actions";
 
 describe("<Move />", () => {
   beforeEach(function () {
@@ -32,6 +39,7 @@ describe("<Move />", () => {
       z_axis_inverted: false,
       botToMqttStatus: "up",
       firmwareSettings: bot.hardware.mcu_params,
+      xySwap: false,
     };
   }
 
@@ -62,8 +70,7 @@ describe("<Move />", () => {
   });
 
   it("toggle: invert jog button", () => {
-    const p = fakeProps();
-    const wrapper = mount(<Move {...p} />);
+    const wrapper = mount(<Move {...fakeProps()} />);
     // tslint:disable-next-line:no-any
     const instance = wrapper.instance() as any;
     instance.toggle("x")();
@@ -71,11 +78,18 @@ describe("<Move />", () => {
   });
 
   it("toggle: encoder data display", () => {
-    const p = fakeProps();
-    const wrapper = mount(<Move {...p} />);
+    const wrapper = mount(<Move {...fakeProps()} />);
     // tslint:disable-next-line:no-any
     const instance = wrapper.instance() as any;
     instance.toggle_encoder_data("raw_encoders")();
     expect(Session.invertBool).toHaveBeenCalledWith("raw_encoders");
+  });
+
+  it("toggle: xy swap", () => {
+    const wrapper = mount(<Move {...fakeProps()} />);
+    // tslint:disable-next-line:no-any
+    const instance = wrapper.instance() as any;
+    instance.toggle_xy_swap();
+    expect(toggleWebAppBool).toHaveBeenCalledWith("xy_swap");
   });
 });

--- a/webpack/controls/__tests__/move_test.tsx
+++ b/webpack/controls/__tests__/move_test.tsx
@@ -31,7 +31,7 @@ describe("<Move />", () => {
       dispatch: jest.fn(),
       bot: bot,
       user: undefined,
-      disabled: false,
+      arduinoBusy: false,
       raw_encoders: false,
       scaled_encoders: false,
       x_axis_inverted: false,

--- a/webpack/controls/controls.tsx
+++ b/webpack/controls/controls.tsx
@@ -32,6 +32,7 @@ export class Controls extends React.Component<Props, {}> {
       z_axis_inverted: !!Session.deprecatedGetBool(BooleanSetting.z_axis_inverted),
       botToMqttStatus: this.props.botToMqttStatus,
       firmwareSettings: this.props.firmwareSettings,
+      xySwap: this.props.xySwap,
     };
     const showWebcamWidget = !Session.deprecatedGetBool(BooleanSetting.hide_webcam_widget);
     return <Page className="controls">

--- a/webpack/controls/controls.tsx
+++ b/webpack/controls/controls.tsx
@@ -24,7 +24,7 @@ export class Controls extends React.Component<Props, {}> {
       bot: this.props.bot,
       user: this.props.user,
       dispatch: this.props.dispatch,
-      disabled: arduinoBusy,
+      arduinoBusy,
       raw_encoders: !!Session.deprecatedGetBool(BooleanSetting.raw_encoders),
       scaled_encoders: !!Session.deprecatedGetBool(BooleanSetting.scaled_encoders),
       x_axis_inverted: !!Session.deprecatedGetBool(BooleanSetting.x_axis_inverted),

--- a/webpack/controls/direction_axes_props.ts
+++ b/webpack/controls/direction_axes_props.ts
@@ -1,11 +1,11 @@
-import { validBotLocationData } from "../util";
-import { JogMovementControlsProps } from "./interfaces";
+import { DirectionAxesProps } from "./interfaces";
+import { McuParams } from "farmbot";
 
 const _ = (nr_steps: number | undefined, steps_mm: number | undefined) => {
   return (nr_steps || 0) / (steps_mm || 1);
 };
 
-function calculateAxialLengths(props: JogMovementControlsProps) {
+function calculateAxialLengths(props: { firmwareSettings: McuParams }) {
   const fwParams = props.firmwareSettings;
 
   return {
@@ -15,35 +15,33 @@ function calculateAxialLengths(props: JogMovementControlsProps) {
   };
 }
 
-export function buildDirectionProps(props: JogMovementControlsProps) {
-  const { firmwareSettings } = props;
-  const { location_data } = props.bot.hardware;
-  const botLocationData = validBotLocationData(location_data);
+export function buildDirectionProps(props: DirectionAxesProps) {
+  const { firmwareSettings, botPosition } = props;
   const lengths = calculateAxialLengths(props);
   return {
     x: {
-      isInverted: props.x_axis_inverted,
+      isInverted: props.axisInversion.x,
       stopAtHome: !!firmwareSettings.movement_stop_at_home_x,
       stopAtMax: !!firmwareSettings.movement_stop_at_max_x,
       axisLength: lengths.x,
       negativeOnly: !!firmwareSettings.movement_home_up_x,
-      position: botLocationData.position.x
+      position: botPosition.x
     },
     y: {
-      isInverted: props.y_axis_inverted,
+      isInverted: props.axisInversion.y,
       stopAtHome: !!firmwareSettings.movement_stop_at_home_y,
       stopAtMax: !!firmwareSettings.movement_stop_at_max_y,
       axisLength: lengths.y,
       negativeOnly: !!firmwareSettings.movement_home_up_y,
-      position: botLocationData.position.y
+      position: botPosition.y
     },
     z: {
-      isInverted: props.z_axis_inverted,
+      isInverted: props.axisInversion.z,
       stopAtHome: !!firmwareSettings.movement_stop_at_home_z,
       stopAtMax: !!firmwareSettings.movement_stop_at_max_z,
       axisLength: lengths.z,
       negativeOnly: !!firmwareSettings.movement_home_up_z,
-      position: botLocationData.position.z
+      position: botPosition.z
     },
   };
 }

--- a/webpack/controls/interfaces.ts
+++ b/webpack/controls/interfaces.ts
@@ -25,7 +25,7 @@ export interface MoveProps {
   dispatch: Function;
   bot: BotState;
   user: TaggedUser | undefined;
-  disabled: boolean | undefined;
+  arduinoBusy: boolean;
   raw_encoders: boolean;
   scaled_encoders: boolean;
   x_axis_inverted: boolean;
@@ -95,14 +95,20 @@ export interface StepSizeSelectorProps {
   selector: (num: number) => void;
 }
 
-export interface JogMovementControlsProps {
-  x_axis_inverted: boolean;
-  y_axis_inverted: boolean;
-  z_axis_inverted: boolean;
-  bot: BotState;
+export interface DirectionAxesProps {
+  axisInversion: Record<Xyz, boolean>;
+  botPosition: BotPosition;
   firmwareSettings: McuParams;
-  disabled: boolean | undefined;
+}
+
+export interface JogMovementControlsProps extends DirectionAxesProps {
+  stepSize: number;
+  arduinoBusy: boolean;
   xySwap: boolean;
+}
+
+export interface ControlsPopupProps extends JogMovementControlsProps {
+  dispatch: Function;
 }
 
 export interface ToggleButtonProps {

--- a/webpack/controls/interfaces.ts
+++ b/webpack/controls/interfaces.ts
@@ -18,6 +18,7 @@ export interface Props {
   botToMqttStatus: NetworkState;
   firmwareSettings: McuParams;
   shouldDisplay: ShouldDisplay;
+  xySwap: boolean;
 }
 
 export interface MoveProps {
@@ -32,6 +33,7 @@ export interface MoveProps {
   z_axis_inverted: boolean;
   botToMqttStatus: NetworkState;
   firmwareSettings: McuParams;
+  xySwap: boolean;
 }
 
 export interface DirectionButtonProps {
@@ -100,6 +102,7 @@ export interface JogMovementControlsProps {
   bot: BotState;
   firmwareSettings: McuParams;
   disabled: boolean | undefined;
+  xySwap: boolean;
 }
 
 export interface ToggleButtonProps {

--- a/webpack/controls/jog_buttons.tsx
+++ b/webpack/controls/jog_buttons.tsx
@@ -5,11 +5,15 @@ import { JogMovementControlsProps } from "./interfaces";
 import { getDevice } from "../device";
 import { buildDirectionProps } from "./direction_axes_props";
 
+const DEFAULT_STEP_SIZE = 100;
+
 export function JogButtons(props: JogMovementControlsProps) {
+  const { stepSize, xySwap, arduinoBusy } = props;
   const directionAxesProps = buildDirectionProps(props);
-  const rightLeft = props.xySwap ? "y" : "x";
-  const upDown = props.xySwap ? "x" : "y";
-  return <table className="jog-table" style={{ border: 0 }}>
+  const rightLeft = xySwap ? "y" : "x";
+  const upDown = xySwap ? "x" : "y";
+
+  return <table className="jog-table">
     <tbody>
       <tr>
         <td>
@@ -24,8 +28,8 @@ export function JogButtons(props: JogMovementControlsProps) {
             axis={upDown}
             direction="up"
             directionAxisProps={directionAxesProps[upDown]}
-            steps={props.bot.stepSize || 1000}
-            disabled={props.disabled} />
+            steps={stepSize || DEFAULT_STEP_SIZE}
+            disabled={arduinoBusy} />
         </td>
         <td />
         <td />
@@ -34,8 +38,8 @@ export function JogButtons(props: JogMovementControlsProps) {
             axis="z"
             direction="up"
             directionAxisProps={directionAxesProps.z}
-            steps={props.bot.stepSize || 1000}
-            disabled={props.disabled} />
+            steps={stepSize || DEFAULT_STEP_SIZE}
+            disabled={arduinoBusy} />
         </td>
       </tr>
       <tr>
@@ -43,7 +47,7 @@ export function JogButtons(props: JogMovementControlsProps) {
           <button
             className="i fa fa-home arrow-button fb-button"
             onClick={() => homeAll(100)}
-            disabled={props.disabled || false} />
+            disabled={arduinoBusy || false} />
         </td>
         <td />
         <td>
@@ -51,24 +55,24 @@ export function JogButtons(props: JogMovementControlsProps) {
             axis={rightLeft}
             direction="left"
             directionAxisProps={directionAxesProps[rightLeft]}
-            steps={props.bot.stepSize || 1000}
-            disabled={props.disabled} />
+            steps={stepSize || DEFAULT_STEP_SIZE}
+            disabled={arduinoBusy} />
         </td>
         <td>
           <DirectionButton
             axis={upDown}
             direction="down"
             directionAxisProps={directionAxesProps[upDown]}
-            steps={props.bot.stepSize || 1000}
-            disabled={props.disabled} />
+            steps={stepSize || DEFAULT_STEP_SIZE}
+            disabled={arduinoBusy} />
         </td>
         <td>
           <DirectionButton
             axis={rightLeft}
             direction="right"
             directionAxisProps={directionAxesProps[rightLeft]}
-            steps={props.bot.stepSize || 1000}
-            disabled={props.disabled} />
+            steps={stepSize || DEFAULT_STEP_SIZE}
+            disabled={arduinoBusy} />
         </td>
         <td />
         <td>
@@ -76,8 +80,8 @@ export function JogButtons(props: JogMovementControlsProps) {
             axis="z"
             direction="down"
             directionAxisProps={directionAxesProps.z}
-            steps={props.bot.stepSize || 1000}
-            disabled={props.disabled} />
+            steps={stepSize || DEFAULT_STEP_SIZE}
+            disabled={arduinoBusy} />
         </td>
       </tr>
       <tr>

--- a/webpack/controls/jog_buttons.tsx
+++ b/webpack/controls/jog_buttons.tsx
@@ -7,6 +7,8 @@ import { buildDirectionProps } from "./direction_axes_props";
 
 export function JogButtons(props: JogMovementControlsProps) {
   const directionAxesProps = buildDirectionProps(props);
+  const rightLeft = props.xySwap ? "y" : "x";
+  const upDown = props.xySwap ? "x" : "y";
   return <table className="jog-table" style={{ border: 0 }}>
     <tbody>
       <tr>
@@ -19,9 +21,9 @@ export function JogButtons(props: JogMovementControlsProps) {
         <td />
         <td>
           <DirectionButton
-            axis="y"
+            axis={upDown}
             direction="up"
-            directionAxisProps={directionAxesProps.y}
+            directionAxisProps={directionAxesProps[upDown]}
             steps={props.bot.stepSize || 1000}
             disabled={props.disabled} />
         </td>
@@ -46,25 +48,25 @@ export function JogButtons(props: JogMovementControlsProps) {
         <td />
         <td>
           <DirectionButton
-            axis="x"
+            axis={rightLeft}
             direction="left"
-            directionAxisProps={directionAxesProps.x}
+            directionAxisProps={directionAxesProps[rightLeft]}
             steps={props.bot.stepSize || 1000}
             disabled={props.disabled} />
         </td>
         <td>
           <DirectionButton
-            axis="y"
+            axis={upDown}
             direction="down"
-            directionAxisProps={directionAxesProps.y}
+            directionAxisProps={directionAxesProps[upDown]}
             steps={props.bot.stepSize || 1000}
             disabled={props.disabled} />
         </td>
         <td>
           <DirectionButton
-            axis="x"
+            axis={rightLeft}
             direction="right"
-            directionAxisProps={directionAxesProps.x}
+            directionAxisProps={directionAxesProps[rightLeft]}
             steps={props.bot.stepSize || 1000}
             disabled={props.disabled} />
         </td>

--- a/webpack/controls/move.tsx
+++ b/webpack/controls/move.tsx
@@ -60,10 +60,10 @@ export class Move extends React.Component<MoveProps, {}> {
         helpText={ToolTips.MOVE}>
         <Popover position={Position.BOTTOM_RIGHT}>
           <i className="fa fa-gear" />
-          <div>
-            <label>
+          <div className="move-settings-menu">
+            <p>
               {t("Invert Jog Buttons")}
-            </label>
+            </p>
             <fieldset>
               <label>
                 {t("X Axis")}
@@ -88,9 +88,10 @@ export class Move extends React.Component<MoveProps, {}> {
                 className={"fb-button fb-toggle-button " + zBtnColor}
                 onClick={this.toggle("z")} />
             </fieldset>
-            <label>
+
+            <p>
               {t("Display Encoder Data")}
-            </label>
+            </p>
             <fieldset>
               <label>
                 {t("Scaled encoder position")}
@@ -107,9 +108,10 @@ export class Move extends React.Component<MoveProps, {}> {
                 className={"fb-button fb-toggle-button " + rawBtnColor}
                 onClick={this.toggle_encoder_data("raw_encoders")} />
             </fieldset>
-            <label>
+
+            <p>
               {t("Swap jog buttons")}
-            </label>
+            </p>
             <fieldset>
               <label>
                 {t("x and y axis")}

--- a/webpack/controls/move.tsx
+++ b/webpack/controls/move.tsx
@@ -15,6 +15,8 @@ import { AxisDisplayGroup } from "./axis_display_group";
 import { Session } from "../session";
 import { INVERSION_MAPPING, ENCODER_MAPPING } from "../devices/reducer";
 import { minFwVersionCheck, validBotLocationData } from "../util";
+import { toggleWebAppBool } from "../config_storage/actions";
+import { BooleanSetting } from "../session_keys";
 
 export class Move extends React.Component<MoveProps, {}> {
 
@@ -25,11 +27,14 @@ export class Move extends React.Component<MoveProps, {}> {
   toggle_encoder_data =
     (name: EncoderDisplay) => () => Session.invertBool(ENCODER_MAPPING[name]);
 
+  toggle_xy_swap = () =>
+    this.props.dispatch(toggleWebAppBool(BooleanSetting.xy_swap));
+
   render() {
     const { location_data, informational_settings } = this.props.bot.hardware;
     const { firmware_version } = informational_settings;
     const { x_axis_inverted, y_axis_inverted, z_axis_inverted,
-      raw_encoders, scaled_encoders } = this.props;
+      raw_encoders, scaled_encoders, xySwap } = this.props;
 
     const btnColor = (flag: boolean) => { return flag ? "green" : "red"; };
     const xBtnColor = btnColor(x_axis_inverted);
@@ -37,6 +42,7 @@ export class Move extends React.Component<MoveProps, {}> {
     const zBtnColor = btnColor(z_axis_inverted);
     const rawBtnColor = btnColor(raw_encoders);
     const scaledBtnColor = btnColor(scaled_encoders);
+    const xySwapBtnColor = btnColor(xySwap);
 
     const locationData = validBotLocationData(location_data);
     const motor_coordinates = locationData.position;
@@ -101,6 +107,17 @@ export class Move extends React.Component<MoveProps, {}> {
                 className={"fb-button fb-toggle-button " + rawBtnColor}
                 onClick={this.toggle_encoder_data("raw_encoders")} />
             </fieldset>
+            <label>
+              {t("Swap jog buttons")}
+            </label>
+            <fieldset>
+              <label>
+                {t("x and y axis")}
+              </label>
+              <button
+                className={"fb-button fb-toggle-button " + xySwapBtnColor}
+                onClick={this.toggle_xy_swap} />
+            </fieldset>
           </div>
         </Popover>
         <EStopButton
@@ -125,7 +142,8 @@ export class Move extends React.Component<MoveProps, {}> {
             y_axis_inverted={y_axis_inverted}
             z_axis_inverted={z_axis_inverted}
             disabled={this.props.disabled}
-            firmwareSettings={this.props.firmwareSettings} />
+            firmwareSettings={this.props.firmwareSettings}
+            xySwap={this.props.xySwap} />
           <Row>
             <Col xs={3}>
               <label>{t("X AXIS")}</label>

--- a/webpack/controls/move.tsx
+++ b/webpack/controls/move.tsx
@@ -137,11 +137,14 @@ export class Move extends React.Component<MoveProps, {}> {
             selector={num => this.props.dispatch(changeStepSize(num))}
             selected={this.props.bot.stepSize} />
           <JogButtons
-            bot={this.props.bot}
-            x_axis_inverted={x_axis_inverted}
-            y_axis_inverted={y_axis_inverted}
-            z_axis_inverted={z_axis_inverted}
-            disabled={this.props.disabled}
+            stepSize={this.props.bot.stepSize}
+            botPosition={locationData.position}
+            axisInversion={{
+              x: x_axis_inverted,
+              y: y_axis_inverted,
+              z: z_axis_inverted
+            }}
+            arduinoBusy={this.props.arduinoBusy}
             firmwareSettings={this.props.firmwareSettings}
             xySwap={this.props.xySwap} />
           <Row>
@@ -169,7 +172,7 @@ export class Move extends React.Component<MoveProps, {}> {
           <AxisInputBoxGroup
             position={motor_coordinates}
             onCommit={input => moveAbs(input)}
-            disabled={this.props.disabled} />
+            disabled={this.props.arduinoBusy} />
         </MustBeOnline>
       </WidgetBody>
     </Widget>;

--- a/webpack/controls/state_to_props.ts
+++ b/webpack/controls/state_to_props.ts
@@ -12,6 +12,8 @@ import * as _ from "lodash";
 import {
   validFwConfig, shouldDisplay, determineInstalledOsVersion
 } from "../util";
+import { BooleanSetting } from "../session_keys";
+import { getWebAppConfigValue } from "../config_storage/actions";
 
 export function mapStateToProps(props: Everything): Props {
   const peripherals = _.uniq(selectAllPeripherals(props.resources.index));
@@ -23,6 +25,7 @@ export function mapStateToProps(props: Everything): Props {
   const { mcu_params } = props.bot.hardware;
   const installedOsVersion = determineInstalledOsVersion(
     props.bot, maybeGetDevice(props.resources.index));
+  const getWebAppConfigVal = getWebAppConfigValue(() => props);
 
   return {
     feeds: selectAllWebcamFeeds(resources.index),
@@ -34,5 +37,6 @@ export function mapStateToProps(props: Everything): Props {
     botToMqttStatus,
     firmwareSettings: fwConfig || mcu_params,
     shouldDisplay: shouldDisplay(installedOsVersion, props.bot.minOsFeatureData),
+    xySwap: !!getWebAppConfigVal(BooleanSetting.xy_swap),
   };
 }

--- a/webpack/controls_popup.tsx
+++ b/webpack/controls_popup.tsx
@@ -15,6 +15,7 @@ interface Props {
   axisInversion: Record<Xyz, boolean>;
   botPosition: BotPosition;
   mcuParams: McuParams;
+  xySwap: boolean;
 }
 
 export class ControlsPopup extends React.Component<Props, Partial<State>> {
@@ -29,7 +30,7 @@ export class ControlsPopup extends React.Component<Props, Partial<State>> {
 
   public render() {
     const isOpen = this.state.isOpen ? "open" : "";
-    const { mcuParams } = this.props;
+    const { mcuParams, xySwap } = this.props;
     const directionAxesProps = {
       x: {
         isInverted: this.props.axisInversion.x,
@@ -50,6 +51,8 @@ export class ControlsPopup extends React.Component<Props, Partial<State>> {
         position: this.props.botPosition.y
       }
     };
+    const rightLeft = xySwap ? "y" : "x";
+    const upDown = xySwap ? "x" : "y";
     return <div
       className={"controls-popup " + isOpen}>
       <i className="fa fa-crosshairs"
@@ -57,27 +60,27 @@ export class ControlsPopup extends React.Component<Props, Partial<State>> {
       <div className="controls-popup-menu-outer">
         <div className="controls-popup-menu-inner">
           <DirectionButton
-            axis={"x"}
+            axis={rightLeft}
             direction="right"
-            directionAxisProps={directionAxesProps.x}
+            directionAxisProps={directionAxesProps[rightLeft]}
             steps={this.state.stepSize}
             disabled={!isOpen} />
           <DirectionButton
-            axis={"y"}
+            axis={upDown}
             direction="up"
-            directionAxisProps={directionAxesProps.y}
+            directionAxisProps={directionAxesProps[upDown]}
             steps={this.state.stepSize}
             disabled={!isOpen} />
           <DirectionButton
-            axis={"y"}
+            axis={upDown}
             direction="down"
-            directionAxisProps={directionAxesProps.y}
+            directionAxisProps={directionAxesProps[upDown]}
             steps={this.state.stepSize}
             disabled={!isOpen} />
           <DirectionButton
-            axis={"x"}
+            axis={rightLeft}
             direction="left"
-            directionAxisProps={directionAxesProps.x}
+            directionAxisProps={directionAxesProps[rightLeft]}
             steps={this.state.stepSize}
             disabled={!isOpen} />
           <button

--- a/webpack/controls_popup.tsx
+++ b/webpack/controls_popup.tsx
@@ -1,56 +1,25 @@
 import * as React from "react";
 
 import { DirectionButton } from "./controls/direction_button";
-import { Xyz, BotPosition } from "./devices/interfaces";
-import { McuParams } from "farmbot";
 import { getDevice } from "./device";
+import { buildDirectionProps } from "./controls/direction_axes_props";
+import { ControlsPopupProps } from "./controls/interfaces";
 
 interface State {
   isOpen: boolean;
-  stepSize: number;
 }
 
-interface Props {
-  dispatch: Function;
-  axisInversion: Record<Xyz, boolean>;
-  botPosition: BotPosition;
-  mcuParams: McuParams;
-  xySwap: boolean;
-}
-
-export class ControlsPopup extends React.Component<Props, Partial<State>> {
-
-  state: State = {
-    isOpen: false,
-    stepSize: 100
-  };
+export class ControlsPopup
+  extends React.Component<ControlsPopupProps, Partial<State>> {
+  state: State = { isOpen: false };
 
   private toggle = (property: keyof State) => () =>
     this.setState({ [property]: !this.state[property] });
 
   public render() {
     const isOpen = this.state.isOpen ? "open" : "";
-    const { mcuParams, xySwap } = this.props;
-    const directionAxesProps = {
-      x: {
-        isInverted: this.props.axisInversion.x,
-        stopAtHome: !!mcuParams.movement_stop_at_home_x,
-        stopAtMax: !!mcuParams.movement_stop_at_max_x,
-        axisLength: (mcuParams.movement_axis_nr_steps_x || 0)
-          / (mcuParams.movement_step_per_mm_x || 1),
-        negativeOnly: !!mcuParams.movement_home_up_x,
-        position: this.props.botPosition.x
-      },
-      y: {
-        isInverted: this.props.axisInversion.y,
-        stopAtHome: !!mcuParams.movement_stop_at_home_y,
-        stopAtMax: !!mcuParams.movement_stop_at_max_y,
-        axisLength: (mcuParams.movement_axis_nr_steps_y || 0)
-          / (mcuParams.movement_step_per_mm_y || 1),
-        negativeOnly: !!mcuParams.movement_home_up_y,
-        position: this.props.botPosition.y
-      }
-    };
+    const { stepSize, xySwap, arduinoBusy } = this.props;
+    const directionAxesProps = buildDirectionProps(this.props);
     const rightLeft = xySwap ? "y" : "x";
     const upDown = xySwap ? "x" : "y";
     return <div
@@ -63,26 +32,26 @@ export class ControlsPopup extends React.Component<Props, Partial<State>> {
             axis={rightLeft}
             direction="right"
             directionAxisProps={directionAxesProps[rightLeft]}
-            steps={this.state.stepSize}
-            disabled={!isOpen} />
+            steps={stepSize}
+            disabled={!isOpen || arduinoBusy} />
           <DirectionButton
             axis={upDown}
             direction="up"
             directionAxisProps={directionAxesProps[upDown]}
-            steps={this.state.stepSize}
-            disabled={!isOpen} />
+            steps={stepSize}
+            disabled={!isOpen || arduinoBusy} />
           <DirectionButton
             axis={upDown}
             direction="down"
             directionAxisProps={directionAxesProps[upDown]}
-            steps={this.state.stepSize}
-            disabled={!isOpen} />
+            steps={stepSize}
+            disabled={!isOpen || arduinoBusy} />
           <DirectionButton
             axis={rightLeft}
             direction="left"
             directionAxisProps={directionAxesProps[rightLeft]}
-            steps={this.state.stepSize}
-            disabled={!isOpen} />
+            steps={stepSize}
+            disabled={!isOpen || arduinoBusy} />
           <button
             className="i fa fa-camera arrow-button fb-button brown"
             onClick={() => getDevice().takePhoto().catch(() => { })} />

--- a/webpack/css/global.scss
+++ b/webpack/css/global.scss
@@ -319,7 +319,7 @@ fieldset {
   }
 }
 
-.webcam-stream-unavailable text {
+.webcam-stream-unavailable p {
   width: 100%;
   position: absolute;
   top: 50%;

--- a/webpack/css/global.scss
+++ b/webpack/css/global.scss
@@ -484,6 +484,18 @@ ul {
   font-size: 1.2rem;
 }
 
+.move-settings-menu {
+  label {
+    margin-top: 7px;
+  }
+  p {
+    margin-top: 0.7rem;
+    font-size: 1.4rem;
+    color: $medium_gray;
+    font-weight: 400;
+  }
+}
+
 .controls-popup,
 .controls-popup-menu-outer {
   position: fixed;

--- a/webpack/css/widget_move.scss
+++ b/webpack/css/widget_move.scss
@@ -51,6 +51,7 @@
   margin: auto;
   margin-top: 15px;
   width: auto;
+  border: 0;
 }
 
 .arrow-button {

--- a/webpack/farm_designer/map/__tests__/bot_extents_test.tsx
+++ b/webpack/farm_designer/map/__tests__/bot_extents_test.tsx
@@ -95,6 +95,33 @@ describe("<VirtualFarmBot/>", () => {
     expect(maxLines.at(1).props()).toEqual({ "x1": 2998, "x2": 2900, "y1": 100, "y2": 100 });
   });
 
+  it("renders max line in correct location", () => {
+    const p = fakeProps();
+    p.stopAtHome.x = false;
+    p.stopAtHome.y = false;
+    p.botSize = {
+      x: { value: 100, isDefault: false },
+      y: { value: 100, isDefault: true }
+    };
+    const wrapper = shallow(<BotExtents {...p} />);
+    const maxLines = wrapper.find("#max-lines").find("line");
+    expect(maxLines.at(0).props()).toEqual({ "x1": 100, "x2": 100, "y1": 2, "y2": 100 });
+  });
+
+  it("renders max line in correct location with swapped axes", () => {
+    const p = fakeProps();
+    p.stopAtHome.x = false;
+    p.stopAtHome.y = false;
+    p.mapTransformProps.xySwap = true;
+    p.botSize = {
+      x: { value: 100, isDefault: false },
+      y: { value: 100, isDefault: true }
+    };
+    const wrapper = shallow(<BotExtents {...p} />);
+    const maxLines = wrapper.find("#max-lines").find("line");
+    expect(maxLines.at(0).props()).toEqual({ "x1": 2, "x2": 100, "y1": 100, "y2": 100 });
+  });
+
   it("renders no lines", () => {
     const p = fakeProps();
     p.stopAtHome.x = false;

--- a/webpack/farm_designer/map/__tests__/bot_extents_test.tsx
+++ b/webpack/farm_designer/map/__tests__/bot_extents_test.tsx
@@ -3,6 +3,7 @@ import { BotExtents } from "../bot_extents";
 import { shallow } from "enzyme";
 import { bot } from "../../../__test_support__/fake_state/bot";
 import { BotExtentsProps } from "../interfaces";
+import { fakeMapTransformProps } from "../../../__test_support__/map_transform_props";
 
 describe("<VirtualFarmBot/>", () => {
   function fakeProps(): BotExtentsProps {
@@ -10,9 +11,7 @@ describe("<VirtualFarmBot/>", () => {
     mcuParams.movement_stop_at_home_x = 1;
     mcuParams.movement_stop_at_home_y = 1;
     return {
-      mapTransformProps: {
-        quadrant: 2, gridSize: { x: 3000, y: 1500 }
-      },
+      mapTransformProps: fakeMapTransformProps(),
       stopAtHome: { x: true, y: true },
       botSize: {
         x: { value: 3000, isDefault: true },
@@ -23,7 +22,7 @@ describe("<VirtualFarmBot/>", () => {
 
   it("renders home lines", () => {
     const p = fakeProps();
-    const wrapper = shallow(<BotExtents {...p } />);
+    const wrapper = shallow(<BotExtents {...p} />);
     const homeLines = wrapper.find("#home-lines").find("line");
     expect(homeLines.at(0).props()).toEqual({ "x1": 2, "x2": 2, "y1": 2, "y2": 1500 });
     expect(homeLines.at(1).props()).toEqual({ "x1": 2, "x2": 3000, "y1": 2, "y2": 2 });
@@ -38,7 +37,7 @@ describe("<VirtualFarmBot/>", () => {
       x: { value: 100, isDefault: false },
       y: { value: 100, isDefault: false }
     };
-    const wrapper = shallow(<BotExtents {...p } />);
+    const wrapper = shallow(<BotExtents {...p} />);
     const homeLines = wrapper.find("#home-lines").find("line");
     expect(homeLines.at(0).props()).toEqual({ "x1": 2, "x2": 2, "y1": 2, "y2": 100 });
     expect(homeLines.at(1).props()).toEqual({ "x1": 2, "x2": 100, "y1": 2, "y2": 2 });
@@ -54,7 +53,7 @@ describe("<VirtualFarmBot/>", () => {
       x: { value: 3000, isDefault: true },
       y: { value: 100, isDefault: false }
     };
-    const wrapper = shallow(<BotExtents {...p } />);
+    const wrapper = shallow(<BotExtents {...p} />);
     const homeLines = wrapper.find("#home-lines").find("line");
     expect(homeLines.at(0).props()).toEqual({ "x1": 2, "x2": 3000, "y1": 2, "y2": 2 });
     expect(homeLines.at(1).html()).toBeFalsy();
@@ -71,7 +70,7 @@ describe("<VirtualFarmBot/>", () => {
       x: { value: 100, isDefault: false },
       y: { value: 100, isDefault: false }
     };
-    const wrapper = shallow(<BotExtents {...p } />);
+    const wrapper = shallow(<BotExtents {...p} />);
     const homeLines = wrapper.find("#home-lines").find("line");
     expect(homeLines.at(0).html()).toBeFalsy();
     expect(homeLines.at(1).html()).toBeFalsy();
@@ -87,7 +86,7 @@ describe("<VirtualFarmBot/>", () => {
       x: { value: 100, isDefault: false },
       y: { value: 100, isDefault: false }
     };
-    const wrapper = shallow(<BotExtents {...p } />);
+    const wrapper = shallow(<BotExtents {...p} />);
     const homeLines = wrapper.find("#home-lines").find("line");
     expect(homeLines.at(0).props()).toEqual({ "x1": 2998, "x2": 2998, "y1": 2, "y2": 100 });
     expect(homeLines.at(1).props()).toEqual({ "x1": 2998, "x2": 2900, "y1": 2, "y2": 2 });
@@ -100,7 +99,7 @@ describe("<VirtualFarmBot/>", () => {
     const p = fakeProps();
     p.stopAtHome.x = false;
     p.stopAtHome.y = false;
-    const wrapper = shallow(<BotExtents {...p } />);
+    const wrapper = shallow(<BotExtents {...p} />);
     const homeLines = wrapper.find("#home-lines").find("line");
     expect(homeLines.at(0).html()).toBeFalsy();
     expect(homeLines.at(1).html()).toBeFalsy();

--- a/webpack/farm_designer/map/__tests__/drag_helpers_test.tsx
+++ b/webpack/farm_designer/map/__tests__/drag_helpers_test.tsx
@@ -4,13 +4,12 @@ import { shallow } from "enzyme";
 import { DragHelpersProps } from "../interfaces";
 import { fakePlant } from "../../../__test_support__/fake_state/resources";
 import { Color } from "../../../ui/index";
+import { fakeMapTransformProps } from "../../../__test_support__/map_transform_props";
 
 describe("<DragHelpers/>", () => {
   function fakeProps(): DragHelpersProps {
     return {
-      mapTransformProps: {
-        quadrant: 2, gridSize: { x: 3000, y: 1500 }
-      },
+      mapTransformProps: fakeMapTransformProps(),
       plant: fakePlant(),
       dragging: false,
       zoomLvl: 1.8,
@@ -20,7 +19,7 @@ describe("<DragHelpers/>", () => {
   }
 
   it("doesn't render drag helpers", () => {
-    const wrapper = shallow(<DragHelpers {...fakeProps() } />);
+    const wrapper = shallow(<DragHelpers {...fakeProps()} />);
     expect(wrapper.find("text").length).toEqual(0);
     expect(wrapper.find("rect").length).toBeLessThanOrEqual(1);
     expect(wrapper.find("use").length).toEqual(0);
@@ -29,7 +28,7 @@ describe("<DragHelpers/>", () => {
   it("renders drag helpers", () => {
     const p = fakeProps();
     p.dragging = true;
-    const wrapper = shallow(<DragHelpers {...p } />);
+    const wrapper = shallow(<DragHelpers {...p} />);
     expect(wrapper.find("#coordinates-tooltip").length).toEqual(1);
     expect(wrapper.find("#long-crosshair").length).toEqual(1);
     expect(wrapper.find("#short-crosshair").length).toEqual(1);
@@ -42,7 +41,7 @@ describe("<DragHelpers/>", () => {
     p.dragging = true;
     p.plant.body.x = 104;
     p.plant.body.y = 199;
-    const wrapper = shallow(<DragHelpers {...p } />);
+    const wrapper = shallow(<DragHelpers {...p} />);
     expect(wrapper.find("text").length).toEqual(1);
     expect(wrapper.find("text").text()).toEqual("100, 200");
     expect(wrapper.find("text").props().fontSize).toEqual("1.25rem");
@@ -53,7 +52,7 @@ describe("<DragHelpers/>", () => {
     const p = fakeProps();
     p.dragging = true;
     p.zoomLvl = 0.9;
-    const wrapper = shallow(<DragHelpers {...p } />);
+    const wrapper = shallow(<DragHelpers {...p} />);
     expect(wrapper.find("text").length).toEqual(1);
     expect(wrapper.find("text").text()).toEqual("100, 200");
     expect(wrapper.find("text").props().fontSize).toEqual("3rem");
@@ -64,7 +63,7 @@ describe("<DragHelpers/>", () => {
     const p = fakeProps();
     p.dragging = true;
     p.plant.body.id = 5;
-    const wrapper = shallow(<DragHelpers {...p } />);
+    const wrapper = shallow(<DragHelpers {...p} />);
     const crosshair = wrapper.find("#short-crosshair");
     expect(crosshair.length).toEqual(1);
     const segment = crosshair.find("#crosshair-segment-5");
@@ -83,7 +82,7 @@ describe("<DragHelpers/>", () => {
     const p = fakeProps();
     p.dragging = true;
     p.zoomLvl = 0.9;
-    const wrapper = shallow(<DragHelpers {...p } />);
+    const wrapper = shallow(<DragHelpers {...p} />);
     const crosshair = wrapper.find("#short-crosshair");
     expect(crosshair.length).toEqual(1);
     expect(crosshair.find("rect").first().props())
@@ -98,7 +97,7 @@ describe("<DragHelpers/>", () => {
     p.plant.body.x = 100;
     p.plant.body.y = 100;
     p.activeDragXY = { x: 100, y: 0, z: 0 };
-    const wrapper = shallow(<DragHelpers {...p } />);
+    const wrapper = shallow(<DragHelpers {...p} />);
     const indicators = wrapper.find("#alignment-indicator");
     expect(indicators.length).toEqual(1);
     const segment = indicators.find("#alignment-indicator-segment-5");
@@ -119,7 +118,7 @@ describe("<DragHelpers/>", () => {
     p.plant.body.x = 100;
     p.plant.body.y = 100;
     p.activeDragXY = { x: 0, y: 100, z: 0 };
-    const wrapper = shallow(<DragHelpers {...p } />);
+    const wrapper = shallow(<DragHelpers {...p} />);
     const indicator = wrapper.find("#alignment-indicator");
     const segments = indicator.find("use");
     expect(segments.length).toEqual(2);
@@ -136,7 +135,7 @@ describe("<DragHelpers/>", () => {
     p.plant.body.x = 100;
     p.plant.body.y = 100;
     p.activeDragXY = { x: 100, y: 100, z: 0 };
-    const wrapper = shallow(<DragHelpers {...p } />);
+    const wrapper = shallow(<DragHelpers {...p} />);
     const indicator = wrapper.find("#alignment-indicator");
     const masterSegment = indicator.find("#alignment-indicator-segment-6");
     const segmentProps = masterSegment.find("rect").props();

--- a/webpack/farm_designer/map/__tests__/drawn_point_test.tsx
+++ b/webpack/farm_designer/map/__tests__/drawn_point_test.tsx
@@ -1,13 +1,12 @@
 import * as React from "react";
 import { DrawnPoint, DrawnPointProps } from "../drawn_point";
 import { mount } from "enzyme";
+import { fakeMapTransformProps } from "../../../__test_support__/map_transform_props";
 
 describe("<DrawnPoint/>", () => {
   function fakeProps(): DrawnPointProps {
     return {
-      mapTransformProps: {
-        quadrant: 2, gridSize: { x: 3000, y: 1500 }
-      },
+      mapTransformProps: fakeMapTransformProps(),
       data: {
         cx: 10,
         cy: 20,
@@ -18,7 +17,7 @@ describe("<DrawnPoint/>", () => {
   }
 
   it("renders point", () => {
-    const wrapper = mount(<DrawnPoint {...fakeProps() } />);
+    const wrapper = mount(<DrawnPoint {...fakeProps()} />);
     expect(wrapper.find("g").props().stroke).toEqual("red");
     expect(wrapper.find("circle").first().props()).toEqual({
       id: "point-radius", strokeDasharray: "4 5",

--- a/webpack/farm_designer/map/__tests__/garden_map_test.tsx
+++ b/webpack/farm_designer/map/__tests__/garden_map_test.tsx
@@ -251,6 +251,23 @@ describe("<GardenPlant/>", () => {
     });
   });
 
+  it("selects location: zoom undefined", async () => {
+    const p = fakeProps();
+    const wrapper = shallow(<GardenMap {...p} />);
+    Object.defineProperty(window, "getComputedStyle", {
+      value: () => { return { zoom: undefined }; }, configurable: true
+    });
+    expect(wrapper.state()).toEqual({});
+    mockPath = "/app/designer/plants/move_to";
+    await wrapper.find("#drop-area-svg").simulate("click", {
+      pageX: 1000, pageY: 2000, preventDefault: jest.fn()
+    });
+    expect(p.dispatch).toHaveBeenCalledWith({
+      payload: { x: 580, y: 1790, z: 0 },
+      type: Actions.CHOOSE_LOCATION
+    });
+  });
+
   it("starts drawing point", async () => {
     const p = fakeProps();
     const wrapper = shallow(<GardenMap {...p} />);

--- a/webpack/farm_designer/map/__tests__/garden_plant_test.tsx
+++ b/webpack/farm_designer/map/__tests__/garden_plant_test.tsx
@@ -19,13 +19,12 @@ import { GardenPlantProps } from "../interfaces";
 import { fakePlant } from "../../../__test_support__/fake_state/resources";
 import { BooleanSetting } from "../../../session_keys";
 import { Actions } from "../../../constants";
+import { fakeMapTransformProps } from "../../../__test_support__/map_transform_props";
 
 describe("<GardenPlant/>", () => {
   function fakeProps(): GardenPlantProps {
     return {
-      mapTransformProps: {
-        quadrant: 2, gridSize: { x: 3000, y: 1500 }
-      },
+      mapTransformProps: fakeMapTransformProps(),
       plant: fakePlant(),
       selected: false,
       grayscale: false,
@@ -39,7 +38,7 @@ describe("<GardenPlant/>", () => {
 
   it("renders plant", () => {
     mockStorj[BooleanSetting.disable_animations] = true;
-    const wrapper = shallow(<GardenPlant {...fakeProps() } />);
+    const wrapper = shallow(<GardenPlant {...fakeProps()} />);
     expect(wrapper.find("image").length).toEqual(1);
     expect(wrapper.find("image").props().opacity).toEqual(1);
     expect(wrapper.find("text").length).toEqual(0);
@@ -50,14 +49,14 @@ describe("<GardenPlant/>", () => {
 
   it("renders plant animations", () => {
     mockStorj[BooleanSetting.disable_animations] = false;
-    const wrapper = shallow(<GardenPlant {...fakeProps() } />);
+    const wrapper = shallow(<GardenPlant {...fakeProps()} />);
     expect(wrapper.find(".soil-cloud").length).toEqual(1);
     expect(wrapper.find(".animate").length).toEqual(1);
   });
 
   it("Calls the onClick callback", () => {
     const p = fakeProps();
-    const wrapper = shallow(<GardenPlant {...p } />);
+    const wrapper = shallow(<GardenPlant {...p} />);
     wrapper.find("image").at(0).simulate("click");
     expect(p.dispatch).toHaveBeenCalledWith({
       type: Actions.SELECT_PLANT,
@@ -67,7 +66,7 @@ describe("<GardenPlant/>", () => {
 
   it("begins hover", () => {
     const p = fakeProps();
-    const wrapper = shallow(<GardenPlant {...p } />);
+    const wrapper = shallow(<GardenPlant {...p} />);
     wrapper.find("image").at(0).simulate("mouseEnter");
     expect(p.dispatch).toHaveBeenCalledWith({
       type: Actions.HOVER_PLANT_LIST_ITEM,
@@ -77,7 +76,7 @@ describe("<GardenPlant/>", () => {
 
   it("ends hover", () => {
     const p = fakeProps();
-    const wrapper = shallow(<GardenPlant {...p } />);
+    const wrapper = shallow(<GardenPlant {...p} />);
     wrapper.find("image").at(0).simulate("mouseLeave");
     expect(p.dispatch).toHaveBeenCalledWith({
       type: Actions.HOVER_PLANT_LIST_ITEM,
@@ -87,14 +86,14 @@ describe("<GardenPlant/>", () => {
 
   it("has color", () => {
     const p = fakeProps();
-    const wrapper = shallow(<GardenPlant {...p } />);
+    const wrapper = shallow(<GardenPlant {...p} />);
     expect(wrapper.find("image").props().filter).toEqual("");
   });
 
   it("has no color", () => {
     const p = fakeProps();
     p.grayscale = true;
-    const wrapper = shallow(<GardenPlant {...p } />);
+    const wrapper = shallow(<GardenPlant {...p} />);
     expect(wrapper.find("image").props().filter).toEqual("url(#grayscale)");
   });
 });

--- a/webpack/farm_designer/map/__tests__/garden_point_test.tsx
+++ b/webpack/farm_designer/map/__tests__/garden_point_test.tsx
@@ -3,19 +3,18 @@ import { GardenPoint } from "../garden_point";
 import { shallow } from "enzyme";
 import { GardenPointProps } from "../interfaces";
 import { fakePoint } from "../../../__test_support__/fake_state/resources";
+import { fakeMapTransformProps } from "../../../__test_support__/map_transform_props";
 
 describe("<GardenPoint/>", () => {
   function fakeProps(): GardenPointProps {
     return {
-      mapTransformProps: {
-        quadrant: 2, gridSize: { x: 3000, y: 1500 }
-      },
+      mapTransformProps: fakeMapTransformProps(),
       point: fakePoint()
     };
   }
 
   it("renders point", () => {
-    const wrapper = shallow(<GardenPoint {...fakeProps() } />);
+    const wrapper = shallow(<GardenPoint {...fakeProps()} />);
     expect(wrapper.find("#point-radius").props().r).toEqual(100);
     expect(wrapper.find("#point-center").props().r).toEqual(2);
   });

--- a/webpack/farm_designer/map/__tests__/grid_test.tsx
+++ b/webpack/farm_designer/map/__tests__/grid_test.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { Grid } from "../grid";
 import { shallow } from "enzyme";
 import { GridProps } from "../interfaces";
+import { fakeMapTransformProps } from "../../../__test_support__/map_transform_props";
 
 describe("<Grid/>", () => {
   beforeEach(function () {
@@ -10,16 +11,14 @@ describe("<Grid/>", () => {
 
   function fakeProps(): GridProps {
     return {
-      mapTransformProps: {
-        quadrant: 2, gridSize: { x: 3000, y: 1500 }
-      },
+      mapTransformProps: fakeMapTransformProps(),
       dispatch: jest.fn(),
       onClick: jest.fn()
     };
   }
 
   it("renders grid", () => {
-    const wrapper = shallow(<Grid {...fakeProps() } />);
+    const wrapper = shallow(<Grid {...fakeProps()} />);
     expect(wrapper.find("#major-grid").props().width).toEqual(3000);
     expect(wrapper.find("#minor-grid").props().width).toEqual(3000);
     expect(wrapper.find("#axis-arrows").find("line").first().props())

--- a/webpack/farm_designer/map/__tests__/map_background_test.tsx
+++ b/webpack/farm_designer/map/__tests__/map_background_test.tsx
@@ -2,19 +2,18 @@ import * as React from "react";
 import { MapBackground } from "../map_background";
 import { shallow } from "enzyme";
 import { MapBackgroundProps } from "../interfaces";
+import { fakeMapTransformProps } from "../../../__test_support__/map_transform_props";
 
 describe("<MapBackground/>", () => {
   function fakeProps(): MapBackgroundProps {
     return {
-      mapTransformProps: {
-        quadrant: 2, gridSize: { x: 3000, y: 1500 }
-      },
+      mapTransformProps: fakeMapTransformProps(),
       plantAreaOffset: { x: 100, y: 100 }
     };
   }
 
   it("renders map background", () => {
-    const wrapper = shallow(<MapBackground {...fakeProps() } />);
+    const wrapper = shallow(<MapBackground {...fakeProps()} />);
     expect(wrapper.find("#bed-interior").props().width).toEqual(3180);
     expect(wrapper.find("#bed-border").props().width).toEqual(3200);
   });

--- a/webpack/farm_designer/map/__tests__/map_image_test.tsx
+++ b/webpack/farm_designer/map/__tests__/map_image_test.tsx
@@ -4,6 +4,7 @@ import { MapImage, MapImageProps } from "../map_image";
 import { SpecialStatus } from "../../../resources/tagged_resources";
 import { cloneDeep } from "lodash";
 import { trim } from "../../../util";
+import { fakeMapTransformProps } from "../../../__test_support__/map_transform_props";
 
 describe("<MapImage />", () => {
   const fakeProps = (): MapImageProps => {
@@ -29,15 +30,12 @@ describe("<MapImage />", () => {
         scale: undefined,
         calibrationZ: undefined
       },
-      mapTransformProps: {
-        gridSize: { x: 0, y: 0 },
-        quadrant: 1
-      },
+      mapTransformProps: fakeMapTransformProps(),
     };
   };
 
   it("doesn't render image", () => {
-    const wrapper = mount(<MapImage {...fakeProps() } />);
+    const wrapper = mount(<MapImage {...fakeProps()} />);
     expect(wrapper.html()).toEqual("<image></image>");
   });
 
@@ -77,10 +75,9 @@ describe("<MapImage />", () => {
     scale: "0.8041",
     calibrationZ: "0"
   };
-  INPUT_SET_1.mapTransformProps = {
-    gridSize: { x: 5900, y: 2900 },
-    quadrant: 3
-  };
+  INPUT_SET_1.mapTransformProps = fakeMapTransformProps();
+  INPUT_SET_1.mapTransformProps.gridSize = { x: 5900, y: 2900 },
+    INPUT_SET_1.mapTransformProps.quadrant = 3;
   INPUT_SET_1.sizeOverride = { width: 480, height: 640 };
 
   const INPUT_SET_2 = cloneDeep(INPUT_SET_1);

--- a/webpack/farm_designer/map/__tests__/selection_box_test.tsx
+++ b/webpack/farm_designer/map/__tests__/selection_box_test.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { SelectionBox, SelectionBoxProps } from "../selection_box";
 import { shallow } from "enzyme";
+import { fakeMapTransformProps } from "../../../__test_support__/map_transform_props";
 
 describe("<SelectionBox/>", () => {
   function fakeProps(): SelectionBoxProps {
@@ -11,14 +12,12 @@ describe("<SelectionBox/>", () => {
         x1: 240,
         y1: 130
       },
-      mapTransformProps: {
-        quadrant: 2, gridSize: { x: 3000, y: 1500 }
-      }
+      mapTransformProps: fakeMapTransformProps(),
     };
   }
 
   it("renders selection box", () => {
-    const wrapper = shallow(<SelectionBox {...fakeProps() } />);
+    const wrapper = shallow(<SelectionBox {...fakeProps()} />);
     const boxProps = wrapper.find("rect").props();
     expect(boxProps.x).toEqual(40);
     expect(boxProps.y).toEqual(30);
@@ -29,14 +28,14 @@ describe("<SelectionBox/>", () => {
   it("doesn't render selection box: partially undefined", () => {
     const p = fakeProps();
     p.selectionBox.x1 = undefined;
-    const wrapper = shallow(<SelectionBox {...p } />);
+    const wrapper = shallow(<SelectionBox {...p} />);
     expect(wrapper.html()).toEqual("<g id=\"selection-box\"></g>");
   });
 
   it("renders selection box: quadrant 4", () => {
     const p = fakeProps();
     p.mapTransformProps.quadrant = 4;
-    const wrapper = shallow(<SelectionBox {...p } />);
+    const wrapper = shallow(<SelectionBox {...p} />);
     const boxProps = wrapper.find("rect").props();
     expect(boxProps.x).toEqual(2760);
     expect(boxProps.y).toEqual(1370);

--- a/webpack/farm_designer/map/__tests__/spread_overlap_helper_test.tsx
+++ b/webpack/farm_designer/map/__tests__/spread_overlap_helper_test.tsx
@@ -11,6 +11,7 @@ import {
 import { shallow } from "enzyme";
 import { SpreadOverlapHelperProps } from "../interfaces";
 import { fakePlant } from "../../../__test_support__/fake_state/resources";
+import { fakeMapTransformProps } from "../../../__test_support__/map_transform_props";
 
 describe("<SpreadOverlapHelper/>", () => {
   function fakeProps(): SpreadOverlapHelperProps {
@@ -19,9 +20,7 @@ describe("<SpreadOverlapHelper/>", () => {
     plant.body.y = 100;
     plant.body.radius = 25;
     return {
-      mapTransformProps: {
-        quadrant: 2, gridSize: { x: 3000, y: 1500 }
-      },
+      mapTransformProps: fakeMapTransformProps(),
       plant,
       dragging: false,
       zoomLvl: 1,
@@ -36,7 +35,7 @@ describe("<SpreadOverlapHelper/>", () => {
     // Center distance: 900mm (inactive plant at x=100, y=100)
     // Overlap: -650mm (default spread = radius * 10 = 250mm)
     // Percentage overlap of inactive plant: 0%
-    const wrapper = shallow(<SpreadOverlapHelper {...p } />);
+    const wrapper = shallow(<SpreadOverlapHelper {...p} />);
     const indicator = wrapper.find(".overlap-circle").props();
     expect(indicator.fill).toEqual("none");
   });
@@ -47,7 +46,7 @@ describe("<SpreadOverlapHelper/>", () => {
     // Center distance: 240mm (inactive plant at x=100, y=100)
     // Overlap: 10mm (default spread = radius * 10 = 250mm)
     // Percentage overlap of inactive plant: 4%
-    const wrapper = shallow(<SpreadOverlapHelper {...p } />);
+    const wrapper = shallow(<SpreadOverlapHelper {...p} />);
     const indicator = wrapper.find(".overlap-circle").props();
     expect(indicator.fill).toEqual("rgba(41, 141, 0, 0.04)"); // "green"
   });
@@ -58,7 +57,7 @@ describe("<SpreadOverlapHelper/>", () => {
     // Center distance: 200mm (inactive plant at x=100, y=100)
     // Overlap: 50mm (default spread = radius * 10 = 250mm)
     // Percentage overlap of inactive plant: 20%
-    const wrapper = shallow(<SpreadOverlapHelper {...p } />);
+    const wrapper = shallow(<SpreadOverlapHelper {...p} />);
     const indicator = wrapper.find(".overlap-circle").props();
     expect(indicator.fill).toEqual("rgba(204, 255, 0, 0.2)"); // "yellow"
   });
@@ -69,7 +68,7 @@ describe("<SpreadOverlapHelper/>", () => {
     // Center distance: 150mm (inactive plant at x=100, y=100)
     // Overlap: 100mm (default spread = radius * 10 = 250mm)
     // Percentage overlap of inactive plant: 40%
-    const wrapper = shallow(<SpreadOverlapHelper {...p } />);
+    const wrapper = shallow(<SpreadOverlapHelper {...p} />);
     const indicator = wrapper.find(".overlap-circle").props();
     expect(indicator.fill).toEqual("rgba(255, 102, 0, 0.3)"); // "orange"
   });
@@ -80,7 +79,7 @@ describe("<SpreadOverlapHelper/>", () => {
     // Center distance: 125mm (inactive plant at x=100, y=100)
     // Overlap: 125mm (default spread = radius * 10 = 250mm)
     // Percentage overlap of inactive plant: 50%
-    const wrapper = shallow(<SpreadOverlapHelper {...p } />);
+    const wrapper = shallow(<SpreadOverlapHelper {...p} />);
     const indicator = wrapper.find(".overlap-circle").props();
     expect(indicator.fill).toEqual("rgba(255, 20, 0, 0.3)"); // "red"
   });
@@ -91,7 +90,7 @@ describe("<SpreadOverlapHelper/>", () => {
     // Center distance: 50mm (inactive plant at x=100, y=100)
     // Overlap: 200mm (default spread = radius * 10 = 250mm)
     // Percentage overlap of inactive plant: 80%
-    const wrapper = shallow(<SpreadOverlapHelper {...p } />);
+    const wrapper = shallow(<SpreadOverlapHelper {...p} />);
     const indicator = wrapper.find(".overlap-circle").props();
     expect(indicator.fill).toEqual("rgba(255, 0, 0, 0.3)"); // "red"
   });
@@ -102,7 +101,7 @@ describe("<SpreadOverlapHelper/>", () => {
     // Center distance: 0mm (inactive plant at x=100, y=100)
     // Overlap: 250mm (default spread = radius * 10 = 250mm)
     // Percentage overlap of inactive plant: 100%
-    const wrapper = shallow(<SpreadOverlapHelper {...p } />);
+    const wrapper = shallow(<SpreadOverlapHelper {...p} />);
     const indicator = wrapper.find(".overlap-circle").props();
     expect(indicator.fill).toEqual("rgba(255, 0, 0, 0.3)"); // "red"
   });

--- a/webpack/farm_designer/map/__tests__/target_coordinate_test.tsx
+++ b/webpack/farm_designer/map/__tests__/target_coordinate_test.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { TargetCoordinate, TargetCoordinateProps } from "../target_coordinate";
 import { shallow } from "enzyme";
+import { fakeMapTransformProps } from "../../../__test_support__/map_transform_props";
 
 describe("<TargetCoordinate/>", () => {
   function fakeProps(): TargetCoordinateProps {
@@ -10,14 +11,12 @@ describe("<TargetCoordinate/>", () => {
         y: 200,
         z: 0
       },
-      mapTransformProps: {
-        quadrant: 2, gridSize: { x: 3000, y: 1500 }
-      }
+      mapTransformProps: fakeMapTransformProps(),
     };
   }
 
   it("renders target", () => {
-    const wrapper = shallow(<TargetCoordinate {...fakeProps() } />);
+    const wrapper = shallow(<TargetCoordinate {...fakeProps()} />);
     const boxProps = wrapper.find("rect").props();
     expect(boxProps.x).toEqual(90);
     expect(boxProps.y).toEqual(198);

--- a/webpack/farm_designer/map/__tests__/tool_graphics_test.tsx
+++ b/webpack/farm_designer/map/__tests__/tool_graphics_test.tsx
@@ -13,31 +13,49 @@ describe("<ToolbaySlot />", () => {
       x: 10,
       y: 20,
       pulloutDirection: 0,
-      quadrant: 2
+      quadrant: 2,
+      xySwap: false,
     };
   };
 
   const checkSlotDirection =
-    (direction: number, quadrant: BotOriginQuadrant, expected: string) => {
-      it(`renders slot, pullout: ${direction} quad: ${quadrant}`, () => {
-        const p = fakeProps();
-        p.pulloutDirection = direction;
-        p.quadrant = quadrant;
-        const wrapper = mount(<ToolbaySlot {...p } />);
-        expect(wrapper.find("use").props().transform).toEqual(expected);
-      });
+    (direction: number,
+      quadrant: BotOriginQuadrant,
+      xySwap: boolean,
+      expected: string) => {
+      it(`renders slot, pullout: ${direction} quad: ${quadrant} yx: ${xySwap}`,
+        () => {
+          const p = fakeProps();
+          p.pulloutDirection = direction;
+          p.quadrant = quadrant;
+          p.xySwap = xySwap;
+          const wrapper = mount(<ToolbaySlot {...p} />);
+          expect(wrapper.find("use").props().transform).toEqual(expected);
+        });
     };
-  checkSlotDirection(0, 2, "rotate(0, 10, 20)");
-  checkSlotDirection(1, 1, "rotate(180, 10, 20)");
-  checkSlotDirection(1, 2, "rotate(0, 10, 20)");
-  checkSlotDirection(1, 3, "rotate(0, 10, 20)");
-  checkSlotDirection(1, 4, "rotate(180, 10, 20)");
-  checkSlotDirection(2, 3, "rotate(180, 10, 20)");
-  checkSlotDirection(3, 1, "rotate(90, 10, 20)");
-  checkSlotDirection(3, 2, "rotate(90, 10, 20)");
-  checkSlotDirection(3, 3, "rotate(270, 10, 20)");
-  checkSlotDirection(3, 4, "rotate(270, 10, 20)");
-  checkSlotDirection(4, 3, "rotate(90, 10, 20)");
+  checkSlotDirection(0, 2, false, "rotate(0, 10, 20)");
+  checkSlotDirection(1, 1, false, "rotate(180, 10, 20)");
+  checkSlotDirection(1, 2, false, "rotate(0, 10, 20)");
+  checkSlotDirection(1, 3, false, "rotate(0, 10, 20)");
+  checkSlotDirection(1, 4, false, "rotate(180, 10, 20)");
+  checkSlotDirection(2, 3, false, "rotate(180, 10, 20)");
+  checkSlotDirection(3, 1, false, "rotate(90, 10, 20)");
+  checkSlotDirection(3, 2, false, "rotate(90, 10, 20)");
+  checkSlotDirection(3, 3, false, "rotate(270, 10, 20)");
+  checkSlotDirection(3, 4, false, "rotate(270, 10, 20)");
+  checkSlotDirection(4, 3, false, "rotate(90, 10, 20)");
+
+  checkSlotDirection(0, 2, true, "rotate(180, 10, 20)");
+  checkSlotDirection(1, 1, true, "rotate(90, 10, 20)");
+  checkSlotDirection(1, 2, true, "rotate(90, 10, 20)");
+  checkSlotDirection(1, 3, true, "rotate(270, 10, 20)");
+  checkSlotDirection(1, 4, true, "rotate(270, 10, 20)");
+  checkSlotDirection(2, 3, true, "rotate(90, 10, 20)");
+  checkSlotDirection(3, 1, true, "rotate(180, 10, 20)");
+  checkSlotDirection(3, 2, true, "rotate(0, 10, 20)");
+  checkSlotDirection(3, 3, true, "rotate(0, 10, 20)");
+  checkSlotDirection(3, 4, true, "rotate(180, 10, 20)");
+  checkSlotDirection(4, 3, true, "rotate(180, 10, 20)");
 });
 
 describe("<Tool/>", () => {
@@ -58,7 +76,7 @@ describe("<Tool/>", () => {
   };
 
   it("renders standard tool styling", () => {
-    const wrapper = mount(<Tool {...fakeProps() } />);
+    const wrapper = mount(<Tool {...fakeProps()} />);
     const props = wrapper.find("circle").last().props();
     expect(props.r).toEqual(35);
     expect(props.cx).toEqual(10);
@@ -69,7 +87,7 @@ describe("<Tool/>", () => {
   it("tool hover", () => {
     const p = fakeProps();
     p.toolProps.hovered = true;
-    const wrapper = mount(<Tool {...p } />);
+    const wrapper = mount(<Tool {...p} />);
     const props = wrapper.find("circle").last().props();
     expect(props.fill).toEqual(Color.darkGray);
   });
@@ -77,7 +95,7 @@ describe("<Tool/>", () => {
   it("renders special tool styling: bin", () => {
     const p = fakeProps();
     p.tool = "seedBin";
-    const wrapper = mount(<Tool {...p } />);
+    const wrapper = mount(<Tool {...p} />);
     const elements = wrapper.find("#seed-bin").find("circle");
     expect(elements.length).toEqual(2);
     expect(elements.last().props().fill).toEqual("url(#SeedBinGradient)");
@@ -87,7 +105,7 @@ describe("<Tool/>", () => {
     const p = fakeProps();
     p.tool = "seedBin";
     p.toolProps.hovered = true;
-    const wrapper = mount(<Tool {...p } />);
+    const wrapper = mount(<Tool {...p} />);
     p.toolProps.hovered = true;
     expect(wrapper.find("#seed-bin").find("circle").length).toEqual(3);
   });
@@ -95,7 +113,7 @@ describe("<Tool/>", () => {
   it("renders special tool styling: tray", () => {
     const p = fakeProps();
     p.tool = "seedTray";
-    const wrapper = mount(<Tool {...p } />);
+    const wrapper = mount(<Tool {...p} />);
     const elements = wrapper.find("#seed-tray");
     expect(elements.find("circle").length).toEqual(2);
     expect(elements.find("rect").length).toEqual(1);
@@ -106,7 +124,7 @@ describe("<Tool/>", () => {
     const p = fakeProps();
     p.tool = "seedTray";
     p.toolProps.hovered = true;
-    const wrapper = mount(<Tool {...p } />);
+    const wrapper = mount(<Tool {...p} />);
     p.toolProps.hovered = true;
     expect(wrapper.find("#seed-tray").find("circle").length).toEqual(3);
   });

--- a/webpack/farm_designer/map/__tests__/tool_label_test.ts
+++ b/webpack/farm_designer/map/__tests__/tool_label_test.ts
@@ -7,30 +7,46 @@ describe("textAnchorPosition()", () => {
   const MIDDLE_BOTTOM = { anchor: "middle", x: 0, y: -40 };
 
   it("returns correct label position: positive x", () => {
-    expect(textAnchorPosition(1, 1)).toEqual(END);
-    expect(textAnchorPosition(1, 2)).toEqual(START);
-    expect(textAnchorPosition(1, 3)).toEqual(START);
-    expect(textAnchorPosition(1, 4)).toEqual(END);
+    expect(textAnchorPosition(1, 1, false)).toEqual(END);
+    expect(textAnchorPosition(1, 2, false)).toEqual(START);
+    expect(textAnchorPosition(1, 3, false)).toEqual(START);
+    expect(textAnchorPosition(1, 4, false)).toEqual(END);
+    expect(textAnchorPosition(1, 1, true)).toEqual(MIDDLE_TOP);
+    expect(textAnchorPosition(1, 2, true)).toEqual(MIDDLE_TOP);
+    expect(textAnchorPosition(1, 3, true)).toEqual(MIDDLE_BOTTOM);
+    expect(textAnchorPosition(1, 4, true)).toEqual(MIDDLE_BOTTOM);
   });
 
   it("returns correct label position: negative x", () => {
-    expect(textAnchorPosition(2, 1)).toEqual(START);
-    expect(textAnchorPosition(2, 2)).toEqual(END);
-    expect(textAnchorPosition(2, 3)).toEqual(END);
-    expect(textAnchorPosition(2, 4)).toEqual(START);
+    expect(textAnchorPosition(2, 1, false)).toEqual(START);
+    expect(textAnchorPosition(2, 2, false)).toEqual(END);
+    expect(textAnchorPosition(2, 3, false)).toEqual(END);
+    expect(textAnchorPosition(2, 4, false)).toEqual(START);
+    expect(textAnchorPosition(2, 1, true)).toEqual(MIDDLE_BOTTOM);
+    expect(textAnchorPosition(2, 2, true)).toEqual(MIDDLE_BOTTOM);
+    expect(textAnchorPosition(2, 3, true)).toEqual(MIDDLE_TOP);
+    expect(textAnchorPosition(2, 4, true)).toEqual(MIDDLE_TOP);
   });
 
   it("returns correct label position: positive y", () => {
-    expect(textAnchorPosition(3, 1)).toEqual(MIDDLE_TOP);
-    expect(textAnchorPosition(3, 2)).toEqual(MIDDLE_TOP);
-    expect(textAnchorPosition(3, 3)).toEqual(MIDDLE_BOTTOM);
-    expect(textAnchorPosition(3, 4)).toEqual(MIDDLE_BOTTOM);
+    expect(textAnchorPosition(3, 1, false)).toEqual(MIDDLE_TOP);
+    expect(textAnchorPosition(3, 2, false)).toEqual(MIDDLE_TOP);
+    expect(textAnchorPosition(3, 3, false)).toEqual(MIDDLE_BOTTOM);
+    expect(textAnchorPosition(3, 4, false)).toEqual(MIDDLE_BOTTOM);
+    expect(textAnchorPosition(3, 1, true)).toEqual(END);
+    expect(textAnchorPosition(3, 2, true)).toEqual(START);
+    expect(textAnchorPosition(3, 3, true)).toEqual(START);
+    expect(textAnchorPosition(3, 4, true)).toEqual(END);
   });
 
   it("returns correct label position: negative y", () => {
-    expect(textAnchorPosition(4, 1)).toEqual(MIDDLE_BOTTOM);
-    expect(textAnchorPosition(4, 2)).toEqual(MIDDLE_BOTTOM);
-    expect(textAnchorPosition(4, 3)).toEqual(MIDDLE_TOP);
-    expect(textAnchorPosition(4, 4)).toEqual(MIDDLE_TOP);
+    expect(textAnchorPosition(4, 1, false)).toEqual(MIDDLE_BOTTOM);
+    expect(textAnchorPosition(4, 2, false)).toEqual(MIDDLE_BOTTOM);
+    expect(textAnchorPosition(4, 3, false)).toEqual(MIDDLE_TOP);
+    expect(textAnchorPosition(4, 4, false)).toEqual(MIDDLE_TOP);
+    expect(textAnchorPosition(4, 1, true)).toEqual(START);
+    expect(textAnchorPosition(4, 2, true)).toEqual(END);
+    expect(textAnchorPosition(4, 3, true)).toEqual(END);
+    expect(textAnchorPosition(4, 4, true)).toEqual(START);
   });
 });

--- a/webpack/farm_designer/map/__tests__/tool_slot_point_test.tsx
+++ b/webpack/farm_designer/map/__tests__/tool_slot_point_test.tsx
@@ -2,13 +2,12 @@ import * as React from "react";
 import { ToolSlotPoint, TSPProps } from "../tool_slot_point";
 import { mount } from "enzyme";
 import { fakeToolSlot, fakeTool } from "../../../__test_support__/fake_state/resources";
+import { fakeMapTransformProps } from "../../../__test_support__/map_transform_props";
 
 describe("<ToolSlotPoint/>", () => {
   function fakeProps(): TSPProps {
     return {
-      mapTransformProps: {
-        quadrant: 2, gridSize: { x: 3000, y: 1500 }
-      },
+      mapTransformProps: fakeMapTransformProps(),
       slot: { toolSlot: fakeToolSlot(), tool: fakeTool() }
     };
   }
@@ -42,28 +41,28 @@ describe("<ToolSlotPoint/>", () => {
   it("displays 'no tool'", () => {
     const p = fakeProps();
     p.slot.tool = undefined;
-    const wrapper = mount(<ToolSlotPoint {...p } />);
+    const wrapper = mount(<ToolSlotPoint {...p} />);
     wrapper.setState({ hovered: true });
     expect(wrapper.find("text").text()).toEqual("no tool");
     expect(wrapper.find("text").props().dx).toEqual(40);
   });
 
   it("doesn't display tool name", () => {
-    const wrapper = mount(<ToolSlotPoint {...fakeProps() } />);
+    const wrapper = mount(<ToolSlotPoint {...fakeProps()} />);
     expect(wrapper.find("text").props().visibility).toEqual("hidden");
   });
 
   it("renders bin", () => {
     const p = fakeProps();
     if (p.slot.tool) { p.slot.tool.body.name = "seed bin"; }
-    const wrapper = mount(<ToolSlotPoint {...p } />);
+    const wrapper = mount(<ToolSlotPoint {...p} />);
     expect(wrapper.find("#SeedBinGradient").length).toEqual(1);
   });
 
   it("renders tray", () => {
     const p = fakeProps();
     if (p.slot.tool) { p.slot.tool.body.name = "seed tray"; }
-    const wrapper = mount(<ToolSlotPoint {...p } />);
+    const wrapper = mount(<ToolSlotPoint {...p} />);
     expect(wrapper.find("#SeedTrayPattern").length).toEqual(1);
   });
 });

--- a/webpack/farm_designer/map/__tests__/util_test.ts
+++ b/webpack/farm_designer/map/__tests__/util_test.ts
@@ -18,29 +18,48 @@ describe("Utils", () => {
 });
 
 describe("translateScreenToGarden()", () => {
-  it("translates garden coords to screen coords: corner case", () => {
-    const cornerCase = translateScreenToGarden({
+  it("translates screen coords to garden coords: zoomLvl = 1", () => {
+    const result = translateScreenToGarden({
       mapTransformProps: { quadrant: 2, gridSize: { x: 3000, y: 1500 } },
       page: { x: 520, y: 212 },
-      scroll: { left: 0, top: 0 },
+      scroll: { left: 10, top: 20 },
       zoomLvl: 1,
-      gridOffset: { x: 0, y: 0 },
+      gridOffset: { x: 30, y: 40 },
     });
-    expect(cornerCase.x).toEqual(200);
-    expect(cornerCase.y).toEqual(100);
+    expect(result).toEqual({ x: 180, y: 80 });
   });
 
-  it("translates garden coords to screen coords: edge case", () => {
-    const edgeCase = translateScreenToGarden({
+  it("translates screen coords to garden coords: zoomLvl < 1", () => {
+    const result = translateScreenToGarden({
       mapTransformProps: { quadrant: 2, gridSize: { x: 3000, y: 1500 } },
       page: { x: 1132, y: 382 },
-      scroll: { left: 0, top: 0 },
-      zoomLvl: 0.3,
-      gridOffset: { x: 0, y: 0 },
+      scroll: { left: 10, top: 20 },
+      zoomLvl: 0.33,
+      gridOffset: { x: 30, y: 40 },
     });
+    expect(result).toEqual({ x: 2470, y: 840 });
+  });
 
-    expect(Math.round(edgeCase.x)).toEqual(2710);
-    expect(Math.round(edgeCase.y)).toEqual(910);
+  it("translates screen coords to garden coords: zoomLvl > 1", () => {
+    const result = translateScreenToGarden({
+      mapTransformProps: { quadrant: 2, gridSize: { x: 3000, y: 1500 } },
+      page: { x: 1132, y: 382 },
+      scroll: { left: 10, top: 20 },
+      zoomLvl: 1.5,
+      gridOffset: { x: 30, y: 40 },
+    });
+    expect(result).toEqual({ x: 520, y: 150 });
+  });
+
+  it("translates screen coords to garden coords: other case", () => {
+    const result = translateScreenToGarden({
+      mapTransformProps: { quadrant: 3, gridSize: { x: 300, y: 150 } },
+      page: { x: 332, y: 132 },
+      scroll: { left: 10, top: 20 },
+      zoomLvl: 0.75,
+      gridOffset: { x: 30, y: 40 },
+    });
+    expect(result).toEqual({ x: 0, y: 130 });
   });
 });
 

--- a/webpack/farm_designer/map/__tests__/util_test.ts
+++ b/webpack/farm_designer/map/__tests__/util_test.ts
@@ -9,6 +9,7 @@ import {
 import { McuParams } from "farmbot";
 import { AxisNumberProperty, BotSize, MapTransformProps } from "../interfaces";
 import { StepsPerMmXY } from "../../../devices/interfaces";
+import { fakeMapTransformProps } from "../../../__test_support__/map_transform_props";
 
 describe("Utils", () => {
   it("rounds a number", () => {
@@ -20,7 +21,7 @@ describe("Utils", () => {
 describe("translateScreenToGarden()", () => {
   it("translates screen coords to garden coords: zoomLvl = 1", () => {
     const result = translateScreenToGarden({
-      mapTransformProps: { quadrant: 2, gridSize: { x: 3000, y: 1500 } },
+      mapTransformProps: fakeMapTransformProps(),
       page: { x: 520, y: 212 },
       scroll: { left: 10, top: 20 },
       zoomLvl: 1,
@@ -31,7 +32,7 @@ describe("translateScreenToGarden()", () => {
 
   it("translates screen coords to garden coords: zoomLvl < 1", () => {
     const result = translateScreenToGarden({
-      mapTransformProps: { quadrant: 2, gridSize: { x: 3000, y: 1500 } },
+      mapTransformProps: fakeMapTransformProps(),
       page: { x: 1132, y: 382 },
       scroll: { left: 10, top: 20 },
       zoomLvl: 0.33,
@@ -42,7 +43,7 @@ describe("translateScreenToGarden()", () => {
 
   it("translates screen coords to garden coords: zoomLvl > 1", () => {
     const result = translateScreenToGarden({
-      mapTransformProps: { quadrant: 2, gridSize: { x: 3000, y: 1500 } },
+      mapTransformProps: fakeMapTransformProps(),
       page: { x: 1132, y: 382 },
       scroll: { left: 10, top: 20 },
       zoomLvl: 1.5,
@@ -52,8 +53,11 @@ describe("translateScreenToGarden()", () => {
   });
 
   it("translates screen coords to garden coords: other case", () => {
+    const fakeMTP = fakeMapTransformProps();
+    fakeMTP.quadrant = 3;
+    fakeMTP.gridSize = { x: 300, y: 150 };
     const result = translateScreenToGarden({
-      mapTransformProps: { quadrant: 3, gridSize: { x: 300, y: 150 } },
+      mapTransformProps: fakeMTP,
       page: { x: 332, y: 132 },
       scroll: { left: 10, top: 20 },
       zoomLvl: 0.75,
@@ -173,7 +177,8 @@ describe("getMapSize()", () => {
 });
 
 describe("transformXY", () => {
-  const gridSize = { x: 2000, y: 1000 };
+  const mapTransformProps = fakeMapTransformProps();
+  mapTransformProps.gridSize = { x: 2000, y: 1000 };
 
   type QXY = { qx: number, qy: number };
 
@@ -188,43 +193,50 @@ describe("transformXY", () => {
   it("calculates transformed coordinate: quadrant 2", () => {
     const original = { qx: 100, qy: 200 };
     const transformed = { qx: 100, qy: 200 };
-    const transformProps = { quadrant: 2, gridSize };
-    transformCheck(original, transformed, transformProps);
+    mapTransformProps.quadrant = 2;
+    transformCheck(original, transformed, mapTransformProps);
   });
 
   it("calculates transformed coordinate: quadrant 4", () => {
     const original = { qx: 100, qy: 200 };
     const transformed = { qx: 1900, qy: 800 };
-    const transformProps = { quadrant: 4, gridSize };
-    transformCheck(original, transformed, transformProps);
+    mapTransformProps.quadrant = 4;
+    transformCheck(original, transformed, mapTransformProps);
   });
 
   it("calculates transformed coordinate: quadrant 4 (outside of grid)", () => {
     const original = { qx: 2200, qy: 1100 };
     const transformed = { qx: -200, qy: -100 };
-    const transformProps = { quadrant: 4, gridSize };
-    transformCheck(original, transformed, transformProps);
+    mapTransformProps.quadrant = 4;
+    transformCheck(original, transformed, mapTransformProps);
   });
 });
 
 describe("transformForQuadrant()", () => {
+  const mapTransformProps = fakeMapTransformProps();
+  mapTransformProps.gridSize = { x: 200, y: 100 };
+
   it("calculates transform for quadrant 1", () => {
-    expect(transformForQuadrant({ quadrant: 1, gridSize: { x: 200, y: 100 } }))
+    mapTransformProps.quadrant = 1;
+    expect(transformForQuadrant(mapTransformProps))
       .toEqual("scale(-1, 1) translate(-200, 0)");
   });
 
   it("calculates transform for quadrant 2", () => {
-    expect(transformForQuadrant({ quadrant: 2, gridSize: { x: 200, y: 100 } }))
+    mapTransformProps.quadrant = 2;
+    expect(transformForQuadrant(mapTransformProps))
       .toEqual("scale(1, 1) translate(0, 0)");
   });
 
   it("calculates transform for quadrant 3", () => {
-    expect(transformForQuadrant({ quadrant: 3, gridSize: { x: 200, y: 100 } }))
+    mapTransformProps.quadrant = 3;
+    expect(transformForQuadrant(mapTransformProps))
       .toEqual("scale(1, -1) translate(0, -100)");
   });
 
   it("calculates transform for quadrant 4", () => {
-    expect(transformForQuadrant({ quadrant: 4, gridSize: { x: 200, y: 100 } }))
+    mapTransformProps.quadrant = 4;
+    expect(transformForQuadrant(mapTransformProps))
       .toEqual("scale(-1, -1) translate(-200, -100)");
   });
 });

--- a/webpack/farm_designer/map/__tests__/util_test.ts
+++ b/webpack/farm_designer/map/__tests__/util_test.ts
@@ -170,9 +170,18 @@ describe("getbotSize()", () => {
 describe("getMapSize()", () => {
   it("calculates map size", () => {
     const mapSize = getMapSize(
-      { x: 2000, y: 1000 },
+      fakeMapTransformProps(),
       { x: 100, y: 50 });
-    expect(mapSize).toEqual({ x: 2200, y: 1100 });
+    expect(mapSize).toEqual({ h: 1600, w: 3200 });
+  });
+
+  it("calculates map size: X&Y Swapped", () => {
+    const fakeMPT = fakeMapTransformProps();
+    fakeMPT.xySwap = true;
+    const mapSize = getMapSize(
+      fakeMPT,
+      { x: 100, y: 50 });
+    expect(mapSize).toEqual({ h: 3200, w: 1600 });
   });
 });
 
@@ -184,10 +193,17 @@ describe("transformXY", () => {
 
   const transformCheck =
     (original: QXY, transformed: QXY, transformProps: MapTransformProps) => {
+      transformProps.xySwap = false;
       expect(transformXY(original.qx, original.qy, transformProps))
         .toEqual(transformed);
       expect(transformXY(transformed.qx, transformed.qy, transformProps))
         .toEqual(original);
+      transformProps.xySwap = true;
+      const transformedYX = { qx: transformed.qy, qy: transformed.qx };
+      expect(transformXY(original.qx, original.qy, transformProps))
+        .toEqual(transformedYX);
+      expect(transformXY(transformed.qx, transformed.qy, transformProps))
+        .toEqual({ qx: original.qy, qy: original.qx });
     };
 
   it("calculates transformed coordinate: quadrant 2", () => {

--- a/webpack/farm_designer/map/bot_extents.tsx
+++ b/webpack/farm_designer/map/bot_extents.tsx
@@ -4,6 +4,7 @@ import { BotExtentsProps } from "./interfaces";
 
 export function BotExtents(props: BotExtentsProps) {
   const { stopAtHome, botSize, mapTransformProps } = props;
+  const { xySwap } = mapTransformProps;
   const homeLength = transformXY(
     botSize.x.value, botSize.y.value, mapTransformProps);
   const homeZero = transformXY(2, 2, mapTransformProps);
@@ -27,12 +28,12 @@ export function BotExtents(props: BotExtentsProps) {
       }
     </g>
     <g id="max-lines">
-      {!botSize.x.isDefault &&
+      {(xySwap ? !botSize.y.isDefault : !botSize.x.isDefault) &&
         <line
           x1={homeLength.qx} y1={homeZero.qy}
           x2={homeLength.qx} y2={homeLength.qy} />
       }
-      {!botSize.y.isDefault &&
+      {(xySwap ? !botSize.x.isDefault : !botSize.y.isDefault) &&
         <line
           x1={homeZero.qx} y1={homeLength.qy}
           x2={homeLength.qx} y2={homeLength.qy} />

--- a/webpack/farm_designer/map/drag_helpers.tsx
+++ b/webpack/farm_designer/map/drag_helpers.tsx
@@ -55,7 +55,7 @@ export function DragHelpers(props: DragHelpersProps) {
   const {
     dragging, plant, zoomLvl, activeDragXY, mapTransformProps, plantAreaOffset
   } = props;
-  const mapSize = getMapSize(mapTransformProps.gridSize, plantAreaOffset);
+  const mapSize = getMapSize(mapTransformProps, plantAreaOffset);
   const { radius, x, y } = plant.body;
 
   const scale = 1 + Math.round(15 * (1.8 - zoomLvl)) / 10; // scale factor
@@ -71,8 +71,8 @@ export function DragHelpers(props: DragHelpersProps) {
       </text>}
     {dragging && // Active plant
       <g id="long-crosshair">
-        <rect x={qx - 0.5} y={-plantAreaOffset.y} width={1} height={mapSize.y} />
-        <rect x={-plantAreaOffset.x} y={qy - 0.5} width={mapSize.x} height={1} />
+        <rect x={qx - 0.5} y={-plantAreaOffset.y} width={1} height={mapSize.h} />
+        <rect x={-plantAreaOffset.x} y={qy - 0.5} width={mapSize.w} height={1} />
       </g>}
     {dragging && // Active plant
       <g id="short-crosshair">

--- a/webpack/farm_designer/map/easter_eggs/__tests__/bugs_test.tsx
+++ b/webpack/farm_designer/map/easter_eggs/__tests__/bugs_test.tsx
@@ -3,15 +3,14 @@ import { shallow, mount } from "enzyme";
 import { Bugs, BugsProps, showBugResetButton, showBugs, resetBugs } from "../bugs";
 import { EggKeys, setEggStatus, getEggStatus } from "../status";
 import { range } from "lodash";
+import { fakeMapTransformProps } from "../../../../__test_support__/map_transform_props";
 
 const expectAlive = (value: string) =>
   expect(getEggStatus(EggKeys.BUGS_ARE_STILL_ALIVE)).toEqual(value);
 
 describe("<Bugs />", () => {
   const fakeProps = (): BugsProps => ({
-    mapTransformProps: {
-      quadrant: 2, gridSize: { x: 3000, y: 1500 }
-    },
+    mapTransformProps: fakeMapTransformProps(),
     botSize: {
       x: { value: 3000, isDefault: true },
       y: { value: 1500, isDefault: true }

--- a/webpack/farm_designer/map/garden_map.tsx
+++ b/webpack/farm_designer/map/garden_map.tsx
@@ -263,16 +263,19 @@ export class GardenMap extends
         const plant = this.getPlant();
         const map = document.querySelector(".farm-designer-map");
         const { gridSize } = this.props;
+        const { quadrant, xySwap } = this.mapTransformProps;
         if (this.state.isDragging && plant && map) {
           const zoomLvl = parseFloat(window.getComputedStyle(map).zoom || "1");
           const { qx, qy } = transformXY(e.pageX, e.pageY, this.mapTransformProps);
           const deltaX = Math.round((qx - (this.state.pageX || qx)) / zoomLvl);
           const deltaY = Math.round((qy - (this.state.pageY || qy)) / zoomLvl);
+          const dX = xySwap && (quadrant % 2 === 1) ? -deltaX : deltaX;
+          const dY = xySwap && (quadrant % 2 === 1) ? -deltaY : deltaY;
           this.setState({
             pageX: qx, pageY: qy,
-            activeDragXY: { x: plant.body.x + deltaX, y: plant.body.y + deltaY, z: 0 }
+            activeDragXY: { x: plant.body.x + dX, y: plant.body.y + dY, z: 0 }
           });
-          this.props.dispatch(movePlant({ deltaX, deltaY, plant, gridSize }));
+          this.props.dispatch(movePlant({ deltaX: dX, deltaY: dY, plant, gridSize }));
         }
         break;
       case Mode.boxSelect:
@@ -312,13 +315,14 @@ export class GardenMap extends
 
   render() {
     const { gridSize } = this.props;
-    const mapSize = getMapSize(gridSize, this.props.gridOffset);
+    const mapSize = getMapSize(this.mapTransformProps, this.props.gridOffset);
     const mapTransformProps = this.mapTransformProps;
+    const { xySwap } = mapTransformProps;
     return <div
       className="drop-area"
       style={{
-        height: mapSize.y + "px", maxHeight: mapSize.y + "px",
-        width: mapSize.x + "px", maxWidth: mapSize.x + "px"
+        height: mapSize.h + "px", maxHeight: mapSize.h + "px",
+        width: mapSize.w + "px", maxWidth: mapSize.w + "px"
       }}
       onDrop={this.handleDrop}
       onDragEnter={this.handleDragEnter}
@@ -334,7 +338,8 @@ export class GardenMap extends
         <svg
           id="drop-area-svg"
           x={this.props.gridOffset.x} y={this.props.gridOffset.y}
-          width={gridSize.x} height={gridSize.y}
+          width={xySwap ? gridSize.y : gridSize.x}
+          height={xySwap ? gridSize.x : gridSize.y}
           onMouseUp={this.endDrag}
           onMouseDown={this.startDrag}
           onMouseMove={this.drag}

--- a/webpack/farm_designer/map/garden_map.tsx
+++ b/webpack/farm_designer/map/garden_map.tsx
@@ -37,9 +37,6 @@ import { TargetCoordinate } from "./target_coordinate";
 import { DrawnPoint } from "./drawn_point";
 import { Bugs, showBugs } from "./easter_eggs/bugs";
 
-const DRAG_ERROR = `ERROR - Couldn't get zoom level of garden map, check the
-  handleDrop() or drag() method in garden_map.tsx`;
-
 export enum Mode {
   none = "none",
   boxSelect = "boxSelect",
@@ -113,7 +110,7 @@ export class GardenMap extends
     const map = document.querySelector(".farm-designer-map");
     const page = document.querySelector(".farm-designer");
     if (el && map && page) {
-      const zoomLvl = parseFloat(window.getComputedStyle(map).zoom || DRAG_ERROR);
+      const zoomLvl = parseFloat(window.getComputedStyle(map).zoom || "1");
       const params: ScreenToGardenParams = {
         page: { x: e.pageX, y: e.pageY },
         scroll: { left: page.scrollLeft, top: map.scrollTop * zoomLvl },
@@ -265,7 +262,7 @@ export class GardenMap extends
         const map = document.querySelector(".farm-designer-map");
         const { gridSize } = this.props;
         if (this.state.isDragging && plant && map) {
-          const zoomLvl = parseFloat(window.getComputedStyle(map).zoom || DRAG_ERROR);
+          const zoomLvl = parseFloat(window.getComputedStyle(map).zoom || "1");
           const { qx, qy } = transformXY(e.pageX, e.pageY, this.mapTransformProps);
           const deltaX = Math.round((qx - (this.state.pageX || qx)) / zoomLvl);
           const deltaY = Math.round((qy - (this.state.pageY || qy)) / zoomLvl);

--- a/webpack/farm_designer/map/garden_map.tsx
+++ b/webpack/farm_designer/map/garden_map.tsx
@@ -36,6 +36,7 @@ import { isNumber } from "lodash";
 import { TargetCoordinate } from "./target_coordinate";
 import { DrawnPoint } from "./drawn_point";
 import { Bugs, showBugs } from "./easter_eggs/bugs";
+import { BooleanSetting } from "../../session_keys";
 
 export enum Mode {
   none = "none",
@@ -70,7 +71,8 @@ export class GardenMap extends
   get mapTransformProps(): MapTransformProps {
     return {
       quadrant: this.props.botOriginQuadrant,
-      gridSize: this.props.gridSize
+      gridSize: this.props.gridSize,
+      xySwap: !!this.props.getConfigValue(BooleanSetting.xy_swap),
     };
   }
 

--- a/webpack/farm_designer/map/grid.tsx
+++ b/webpack/farm_designer/map/grid.tsx
@@ -6,7 +6,9 @@ import { Color } from "../../ui/index";
 
 export function Grid(props: GridProps) {
   const { mapTransformProps } = props;
-  const { gridSize } = mapTransformProps;
+  const { gridSize, xySwap } = mapTransformProps;
+  const gridSizeW = xySwap ? gridSize.y : gridSize.x;
+  const gridSizeH = xySwap ? gridSize.x : gridSize.y;
   const origin = transformXY(0, 0, mapTransformProps);
   const arrowEnd = transformXY(25, 25, mapTransformProps);
   const xLabel = transformXY(15, -10, mapTransformProps);
@@ -34,10 +36,10 @@ export function Grid(props: GridProps) {
 
     <g id="grid">
       <rect id="minor-grid"
-        width={gridSize.x} height={gridSize.y} fill="url(#minor_grid)" />
+        width={gridSizeW} height={gridSizeH} fill="url(#minor_grid)" />
       <rect id="major-grid" transform={transformForQuadrant(mapTransformProps)}
-        width={gridSize.x} height={gridSize.y} fill="url(#major_grid)" />
-      <rect id="border" width={gridSize.x} height={gridSize.y} fill="none"
+        width={gridSizeW} height={gridSizeH} fill="url(#major_grid)" />
+      <rect id="border" width={gridSizeW} height={gridSizeH} fill="none"
         stroke="rgba(0,0,0,0.3)" strokeWidth={2} />
     </g>
 

--- a/webpack/farm_designer/map/interfaces.ts
+++ b/webpack/farm_designer/map/interfaces.ts
@@ -45,6 +45,7 @@ export interface GardenMapLegendProps {
 export type MapTransformProps = {
   quadrant: BotOriginQuadrant,
   gridSize: AxisNumberProperty
+  xySwap: boolean;
 };
 
 export interface GardenPlantProps {

--- a/webpack/farm_designer/map/layers/__tests__/drag_helper_layer_test.tsx
+++ b/webpack/farm_designer/map/layers/__tests__/drag_helper_layer_test.tsx
@@ -2,15 +2,14 @@ import * as React from "react";
 import { DragHelperLayer, DragHelperLayerProps } from "../drag_helper_layer";
 import { shallow } from "enzyme";
 import { fakePlant } from "../../../../__test_support__/fake_state/resources";
+import { fakeMapTransformProps } from "../../../../__test_support__/map_transform_props";
 
 describe("<DragHelperLayer/>", () => {
   function fakeProps(): DragHelperLayerProps {
     return {
       currentPlant: fakePlant(),
       editing: true,
-      mapTransformProps: {
-        quadrant: 2, gridSize: { x: 3000, y: 1500 }
-      },
+      mapTransformProps: fakeMapTransformProps(),
       dragging: true,
       zoomLvl: 1.8,
       activeDragXY: { x: undefined, y: undefined, z: undefined },
@@ -20,7 +19,7 @@ describe("<DragHelperLayer/>", () => {
 
   it("shows drag helpers", () => {
     const p = fakeProps();
-    const wrapper = shallow(<DragHelperLayer {...p } />);
+    const wrapper = shallow(<DragHelperLayer {...p} />);
     ["drag-helpers",
       "coordinates-tooltip",
       "long-crosshair",
@@ -31,7 +30,7 @@ describe("<DragHelperLayer/>", () => {
   it("doesn't show drag helpers", () => {
     const p = fakeProps();
     p.editing = false;
-    const wrapper = shallow(<DragHelperLayer {...p } />);
+    const wrapper = shallow(<DragHelperLayer {...p} />);
     expect(wrapper.html()).toEqual("<g id=\"drag-helper-layer\"></g>");
   });
 });

--- a/webpack/farm_designer/map/layers/__tests__/farmbot_layer_test.tsx
+++ b/webpack/farm_designer/map/layers/__tests__/farmbot_layer_test.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { FarmBotLayer } from "../farmbot_layer";
 import { shallow } from "enzyme";
 import { FarmBotLayerProps } from "../../interfaces";
+import { fakeMapTransformProps } from "../../../../__test_support__/map_transform_props";
 
 describe("<FarmBotLayer/>", () => {
   function fakeProps(): FarmBotLayerProps {
@@ -12,9 +13,7 @@ describe("<FarmBotLayer/>", () => {
         scaled_encoders: { x: undefined, y: undefined, z: undefined },
         raw_encoders: { x: undefined, y: undefined, z: undefined },
       },
-      mapTransformProps: {
-        quadrant: 1, gridSize: { x: 3000, y: 1500 }
-      },
+      mapTransformProps: fakeMapTransformProps(),
       stopAtHome: { x: true, y: true },
       botSize: {
         x: { value: 3000, isDefault: true },
@@ -28,7 +27,7 @@ describe("<FarmBotLayer/>", () => {
 
   it("shows layer elements", () => {
     const p = fakeProps();
-    const result = shallow(<FarmBotLayer {...p } />);
+    const result = shallow(<FarmBotLayer {...p} />);
     const layer = result.find("#farmbot-layer");
     expect(layer.find("#virtual-farmbot")).toBeTruthy();
     expect(layer.find("#extents")).toBeTruthy();
@@ -37,7 +36,7 @@ describe("<FarmBotLayer/>", () => {
   it("toggles visibility off", () => {
     const p = fakeProps();
     p.visible = false;
-    const result = shallow(<FarmBotLayer {...p } />);
+    const result = shallow(<FarmBotLayer {...p} />);
     expect(result.html()).toEqual("<g id=\"farmbot-layer\"></g>");
   });
 });

--- a/webpack/farm_designer/map/layers/__tests__/hovered_plant_layer_test.tsx
+++ b/webpack/farm_designer/map/layers/__tests__/hovered_plant_layer_test.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { HoveredPlantLayer, HoveredPlantLayerProps } from "../hovered_plant_layer";
 import { shallow } from "enzyme";
 import { fakePlant } from "../../../../__test_support__/fake_state/resources";
+import { fakeMapTransformProps } from "../../../../__test_support__/map_transform_props";
 
 describe("<HoveredPlantLayer/>", () => {
   function fakeProps(): HoveredPlantLayerProps {
@@ -23,16 +24,14 @@ describe("<HoveredPlantLayer/>", () => {
       },
       hoveredPlant: fakePlant(),
       isEditing: false,
-      mapTransformProps: {
-        quadrant: 2, gridSize: { x: 3000, y: 1500 }
-      }
+      mapTransformProps: fakeMapTransformProps(),
     };
   }
 
   it("shows hovered plant icon", () => {
     const p = fakeProps();
     p.designer.hoveredPlant.icon = "fake icon";
-    const wrapper = shallow(<HoveredPlantLayer {...p } />);
+    const wrapper = shallow(<HoveredPlantLayer {...p} />);
     const icon = wrapper.find("image").props();
     expect(icon.visibility).toBeTruthy();
     expect(icon.opacity).toEqual(1);
@@ -44,7 +43,7 @@ describe("<HoveredPlantLayer/>", () => {
     const p = fakeProps();
     p.designer.hoveredPlant.icon = "fake icon";
     p.currentPlant = fakePlant();
-    const wrapper = shallow(<HoveredPlantLayer {...p } />);
+    const wrapper = shallow(<HoveredPlantLayer {...p} />);
     expect(wrapper.find("#selected-plant-indicators").length).toEqual(1);
     expect(wrapper.find("Circle").length).toEqual(1);
     expect(wrapper.find("Circle").props().selected).toBeTruthy();
@@ -55,7 +54,7 @@ describe("<HoveredPlantLayer/>", () => {
 
   it("doesn't show hovered plant icon", () => {
     const p = fakeProps();
-    const wrapper = shallow(<HoveredPlantLayer {...p } />);
+    const wrapper = shallow(<HoveredPlantLayer {...p} />);
     expect(wrapper.html()).toEqual("<g id=\"hovered-plant-layer\"></g>");
   });
 });

--- a/webpack/farm_designer/map/layers/__tests__/images_layer_test.tsx
+++ b/webpack/farm_designer/map/layers/__tests__/images_layer_test.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { ImageLayer, ImageLayerProps } from "../image_layer";
 import { shallow } from "enzyme";
 import { fakeImage, fakeWebAppConfig } from "../../../../__test_support__/fake_state/resources";
+import { fakeMapTransformProps } from "../../../../__test_support__/map_transform_props";
 
 const mockConfig = fakeWebAppConfig();
 jest.mock("../../../../resources/selectors", () => {
@@ -19,9 +20,7 @@ describe("<ImageLayer/>", () => {
     return {
       visible: true,
       images: [image],
-      mapTransformProps: {
-        quadrant: 2, gridSize: { x: 3000, y: 1500 }
-      },
+      mapTransformProps: fakeMapTransformProps(),
       cameraCalibrationData: {
         offset: { x: "0", y: "0" },
         origin: "TOP_LEFT",

--- a/webpack/farm_designer/map/layers/__tests__/plant_layer_test.tsx
+++ b/webpack/farm_designer/map/layers/__tests__/plant_layer_test.tsx
@@ -16,15 +16,14 @@ import { PlantLayer } from "../plant_layer";
 import { shallow } from "enzyme";
 import { fakePlant } from "../../../../__test_support__/fake_state/resources";
 import { PlantLayerProps } from "../../interfaces";
+import { fakeMapTransformProps } from "../../../../__test_support__/map_transform_props";
 
 describe("<PlantLayer/>", () => {
   function fakeProps(): PlantLayerProps {
     return {
       visible: true,
       plants: [fakePlant()],
-      mapTransformProps: {
-        quadrant: 2, gridSize: { x: 3000, y: 1500 }
-      },
+      mapTransformProps: fakeMapTransformProps(),
       currentPlant: undefined,
       dragging: false,
       editing: false,
@@ -38,7 +37,7 @@ describe("<PlantLayer/>", () => {
 
   it("shows plants", () => {
     const p = fakeProps();
-    const wrapper = shallow(<PlantLayer {...p } />);
+    const wrapper = shallow(<PlantLayer {...p} />);
     const layer = wrapper.find("#plant-layer");
     expect(layer.find(".plant-link-wrapper").length).toEqual(1);
     ["soil-cloud",
@@ -55,21 +54,21 @@ describe("<PlantLayer/>", () => {
   it("toggles visibility off", () => {
     const p = fakeProps();
     p.visible = false;
-    const wrapper = shallow(<PlantLayer {...p } />);
+    const wrapper = shallow(<PlantLayer {...p} />);
     expect(wrapper.html()).toEqual("<g id=\"plant-layer\"></g>");
   });
 
   it("is in clickable mode", () => {
     mockPath = "/app/designer/plants";
     const p = fakeProps();
-    const wrapper = shallow(<PlantLayer {...p } />);
+    const wrapper = shallow(<PlantLayer {...p} />);
     expect(wrapper.find("Link").props().style).toEqual({});
   });
 
   it("is in non-clickable mode", () => {
     mockPath = "/app/designer/plants/select";
     const p = fakeProps();
-    const wrapper = shallow(<PlantLayer {...p } />);
+    const wrapper = shallow(<PlantLayer {...p} />);
     expect(wrapper.find("Link").props().style)
       .toEqual({ pointerEvents: "none" });
   });

--- a/webpack/farm_designer/map/layers/__tests__/point_layer_test.tsx
+++ b/webpack/farm_designer/map/layers/__tests__/point_layer_test.tsx
@@ -2,21 +2,20 @@ import * as React from "react";
 import { PointLayer, PointLayerProps } from "../point_layer";
 import { shallow } from "enzyme";
 import { fakePoint } from "../../../../__test_support__/fake_state/resources";
+import { fakeMapTransformProps } from "../../../../__test_support__/map_transform_props";
 
 describe("<PointLayer/>", () => {
   function fakeProps(): PointLayerProps {
     return {
       visible: true,
       points: [fakePoint()],
-      mapTransformProps: {
-        quadrant: 2, gridSize: { x: 3000, y: 1500 }
-      }
+      mapTransformProps: fakeMapTransformProps(),
     };
   }
 
   it("shows points", () => {
     const p = fakeProps();
-    const wrapper = shallow(<PointLayer {...p } />);
+    const wrapper = shallow(<PointLayer {...p} />);
     const layer = wrapper.find("#point-layer");
     expect(layer.find("GardenPoint").html()).toContain("r=\"100\"");
   });
@@ -24,7 +23,7 @@ describe("<PointLayer/>", () => {
   it("toggles visibility off", () => {
     const p = fakeProps();
     p.visible = false;
-    const wrapper = shallow(<PointLayer {...p } />);
+    const wrapper = shallow(<PointLayer {...p} />);
     const layer = wrapper.find("#point-layer");
     expect(layer.find("GardenPoint").length).toEqual(0);
   });

--- a/webpack/farm_designer/map/layers/__tests__/spread_layer_test.tsx
+++ b/webpack/farm_designer/map/layers/__tests__/spread_layer_test.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { SpreadLayer, SpreadLayerProps } from "../spread_layer";
 import { shallow } from "enzyme";
 import { fakePlant } from "../../../../__test_support__/fake_state/resources";
+import { fakeMapTransformProps } from "../../../../__test_support__/map_transform_props";
 
 describe("<SpreadLayer/>", () => {
   function fakeProps(): SpreadLayerProps {
@@ -9,9 +10,7 @@ describe("<SpreadLayer/>", () => {
       visible: true,
       plants: [fakePlant()],
       currentPlant: undefined,
-      mapTransformProps: {
-        quadrant: 2, gridSize: { x: 3000, y: 1500 }
-      },
+      mapTransformProps: fakeMapTransformProps(),
       dragging: false,
       zoomLvl: 1.8,
       activeDragXY: { x: undefined, y: undefined, z: undefined },
@@ -22,7 +21,7 @@ describe("<SpreadLayer/>", () => {
 
   it("shows spread", () => {
     const p = fakeProps();
-    const wrapper = shallow(<SpreadLayer {...p } />);
+    const wrapper = shallow(<SpreadLayer {...p} />);
     const layer = wrapper.find("#spread-layer");
     expect(layer.find("SpreadCircle").html()).toContain("r=\"125\"");
   });
@@ -30,7 +29,7 @@ describe("<SpreadLayer/>", () => {
   it("toggles visibility off", () => {
     const p = fakeProps();
     p.visible = false;
-    const wrapper = shallow(<SpreadLayer {...p } />);
+    const wrapper = shallow(<SpreadLayer {...p} />);
     const layer = wrapper.find("#spread-layer");
     expect(layer.find("SpreadCircle").length).toEqual(0);
   });

--- a/webpack/farm_designer/map/layers/__tests__/tool_slot_layer_test.tsx
+++ b/webpack/farm_designer/map/layers/__tests__/tool_slot_layer_test.tsx
@@ -9,6 +9,7 @@ jest.mock("../../../../history", () => ({
 
 import * as React from "react";
 import { ToolSlotLayer, ToolSlotLayerProps } from "../tool_slot_layer";
+import { fakeMapTransformProps } from "../../../../__test_support__/map_transform_props";
 import { fakeResource } from "../../../../__test_support__/fake_resource";
 import { ToolSlotPointer } from "../../../../interfaces";
 import { shallow } from "enzyme";
@@ -34,28 +35,26 @@ describe("<ToolSlotLayer/>", () => {
     return {
       visible: false,
       slots: [{ toolSlot, tool: undefined }],
-      mapTransformProps: {
-        quadrant: 1, gridSize: { x: 3000, y: 1500 }
-      },
+      mapTransformProps: fakeMapTransformProps(),
       dispatch: jest.fn()
     };
   }
   it("toggles visibility off", () => {
-    const result = shallow(<ToolSlotLayer {...fakeProps() } />);
+    const result = shallow(<ToolSlotLayer {...fakeProps()} />);
     expect(result.find("ToolSlotPoint").length).toEqual(0);
   });
 
   it("toggles visibility on", () => {
     const p = fakeProps();
     p.visible = true;
-    const result = shallow(<ToolSlotLayer {...p } />);
+    const result = shallow(<ToolSlotLayer {...p} />);
     expect(result.find("ToolSlotPoint").length).toEqual(1);
   });
 
   it("navigates to tools page", async () => {
     mockPath = "/app/designer/plants";
     const p = fakeProps();
-    const wrapper = shallow(<ToolSlotLayer {...p } />);
+    const wrapper = shallow(<ToolSlotLayer {...p} />);
     const tools = wrapper.find("g").first();
     await tools.simulate("click");
     expect(mockHistory).toHaveBeenCalledWith("/app/tools");
@@ -64,7 +63,7 @@ describe("<ToolSlotLayer/>", () => {
   it("doesn't navigate to tools page", async () => {
     mockPath = "/app/designer/plants/1";
     const p = fakeProps();
-    const wrapper = shallow(<ToolSlotLayer {...p } />);
+    const wrapper = shallow(<ToolSlotLayer {...p} />);
     const tools = wrapper.find("g").first();
     await tools.simulate("click");
     expect(mockHistory).not.toHaveBeenCalled();
@@ -74,7 +73,7 @@ describe("<ToolSlotLayer/>", () => {
   it("is in non-clickable mode", () => {
     mockPath = "/app/designer/plants/select";
     const p = fakeProps();
-    const wrapper = shallow(<ToolSlotLayer {...p } />);
+    const wrapper = shallow(<ToolSlotLayer {...p} />);
     expect(wrapper.find("g").props().style)
       .toEqual({ pointerEvents: "none" });
   });

--- a/webpack/farm_designer/map/map_background.tsx
+++ b/webpack/farm_designer/map/map_background.tsx
@@ -1,13 +1,15 @@
 import * as React from "react";
 import { MapBackgroundProps } from "./interfaces";
 import { Color } from "../../ui/index";
+import { getMapSize } from "./util";
 
 export function MapBackground(props: MapBackgroundProps) {
   const { mapTransformProps, plantAreaOffset } = props;
-  const { gridSize } = mapTransformProps;
+  const { gridSize, xySwap } = mapTransformProps;
+  const gridSizeW = xySwap ? gridSize.y : gridSize.x;
+  const gridSizeH = xySwap ? gridSize.x : gridSize.y;
   const boardWidth = 20;
-  const mapWidth = gridSize.x + plantAreaOffset.x * 2;
-  const mapHeight = gridSize.y + plantAreaOffset.y * 2;
+  const mapSize = getMapSize(mapTransformProps, plantAreaOffset);
   return <g id="map-background">
     <defs>
       <pattern id="diagonalHatch"
@@ -18,16 +20,16 @@ export function MapBackground(props: MapBackgroundProps) {
     </defs>
 
     <rect id="bed-border"
-      x={0} y={0} width={mapWidth} height={mapHeight}
+      x={0} y={0} width={mapSize.w} height={mapSize.h}
       fill={Color.soilBackground} />
     <rect id="bed-interior" x={boardWidth / 2} y={boardWidth / 2}
-      width={mapWidth - boardWidth} height={mapHeight - boardWidth}
+      width={mapSize.w - boardWidth} height={mapSize.h - boardWidth}
       stroke="rgba(120,63,4,0.25)" strokeWidth={boardWidth}
       fill={Color.soilBackground} />
     <rect id="no-access-perimeter" x={boardWidth} y={boardWidth}
-      width={mapWidth - boardWidth * 2} height={mapHeight - boardWidth * 2}
+      width={mapSize.w - boardWidth * 2} height={mapSize.h - boardWidth * 2}
       fill="url(#diagonalHatch)" />
     <rect id="grid-fill" x={plantAreaOffset.x} y={plantAreaOffset.y}
-      width={gridSize.x} height={gridSize.y} fill={Color.gridSoil} />
+      width={gridSizeW} height={gridSizeH} fill={Color.gridSoil} />
   </g>;
 }

--- a/webpack/farm_designer/map/tool_graphics.tsx
+++ b/webpack/farm_designer/map/tool_graphics.tsx
@@ -22,13 +22,16 @@ export interface ToolSlotGraphicProps {
   y: number;
   pulloutDirection: ToolPulloutDirection;
   quadrant: BotOriginQuadrant;
+  xySwap: boolean;
 }
 
 const toolbaySlotAngle = (
   pulloutDirection: ToolPulloutDirection,
-  quadrant: BotOriginQuadrant) => {
+  quadrant: BotOriginQuadrant,
+  xySwap: boolean) => {
   const rawAngle = () => {
-    switch (pulloutDirection) {
+    const direction = pulloutDirection + (xySwap ? 2 : 0);
+    switch (direction > 4 ? direction % 4 : direction) {
       case ToolPulloutDirection.POSITIVE_X: return 0;
       case ToolPulloutDirection.NEGATIVE_X: return 180;
       case ToolPulloutDirection.NEGATIVE_Y: return 90;
@@ -56,8 +59,8 @@ export enum ToolNames {
 }
 
 export const ToolbaySlot = (props: ToolSlotGraphicProps) => {
-  const { id, x, y, pulloutDirection, quadrant } = props;
-  const angle = toolbaySlotAngle(pulloutDirection, quadrant);
+  const { id, x, y, pulloutDirection, quadrant, xySwap } = props;
+  const angle = toolbaySlotAngle(pulloutDirection, quadrant, xySwap);
   return <g id={"toolbay-slot"}>
     <defs>
       <g id={"toolbay-slot-" + id}

--- a/webpack/farm_designer/map/tool_label.tsx
+++ b/webpack/farm_designer/map/tool_label.tsx
@@ -12,9 +12,11 @@ enum Anchor {
 
 export const textAnchorPosition = (
   pulloutDirection: ToolPulloutDirection,
-  quadrant: BotOriginQuadrant): { x: number, y: number, anchor: string } => {
+  quadrant: BotOriginQuadrant,
+  xySwap: boolean): { x: number, y: number, anchor: string } => {
   const rawAnchor = () => {
-    switch (pulloutDirection) {
+    const direction = pulloutDirection + (xySwap ? 2 : 0);
+    switch (direction > 4 ? direction % 4 : direction) {
       case ToolPulloutDirection.POSITIVE_X: return Anchor.start;
       case ToolPulloutDirection.NEGATIVE_X: return Anchor.end;
       case ToolPulloutDirection.NEGATIVE_Y: return Anchor.middleTop;
@@ -48,11 +50,12 @@ interface ToolLabelProps {
   y: number;
   pulloutDirection: ToolPulloutDirection;
   quadrant: BotOriginQuadrant;
+  xySwap: boolean;
 }
 
 export const ToolLabel = (props: ToolLabelProps) => {
-  const { toolName, hovered, x, y, pulloutDirection, quadrant } = props;
-  const labelAnchor = textAnchorPosition(pulloutDirection, quadrant);
+  const { toolName, hovered, x, y, pulloutDirection, quadrant, xySwap } = props;
+  const labelAnchor = textAnchorPosition(pulloutDirection, quadrant, xySwap);
 
   return <text textAnchor={labelAnchor.anchor}
     visibility={hovered ? "visible" : "hidden"}

--- a/webpack/farm_designer/map/tool_slot_point.tsx
+++ b/webpack/farm_designer/map/tool_slot_point.tsx
@@ -36,7 +36,7 @@ export class ToolSlotPoint extends
   render() {
     const { id, x, y, pullout_direction } = this.slot.toolSlot.body;
     const { mapTransformProps } = this.props;
-    const { quadrant } = mapTransformProps;
+    const { quadrant, xySwap } = mapTransformProps;
     const { qx, qy } = transformXY(x, y, this.props.mapTransformProps);
     const toolName = this.slot.tool ? this.slot.tool.body.name : "no tool";
     const toolProps = {
@@ -52,7 +52,8 @@ export class ToolSlotPoint extends
           x={qx}
           y={qy}
           pulloutDirection={pullout_direction}
-          quadrant={quadrant} />}
+          quadrant={quadrant}
+          xySwap={xySwap} />}
 
       {(this.slot.tool || !pullout_direction) &&
         <Tool
@@ -65,7 +66,8 @@ export class ToolSlotPoint extends
         x={qx}
         y={qy}
         pulloutDirection={pullout_direction}
-        quadrant={quadrant} />
+        quadrant={quadrant}
+        xySwap={xySwap} />
     </g>;
   }
 }

--- a/webpack/farm_designer/map/util.ts
+++ b/webpack/farm_designer/map/util.ts
@@ -72,7 +72,7 @@ export function translateScreenToGarden(
   const screenXY = page;
   const mapXY = ["x", "y"].reduce<XYCoordinate>(
     (result: XYCoordinate, axis: "x" | "y") => {
-      const unscrolled = screenXY[axis] - scroll[leftOrTop[axis]];
+      const unscrolled = screenXY[axis] + scroll[leftOrTop[axis]];
       const map = unscrolled - mapPadding[leftOrTop[axis]];
       const grid = map - gridOffset[axis] * zoomLvl;
       const unscaled = round(grid / zoomLvl);

--- a/webpack/farm_designer/map/virtual_farmbot/__tests__/bot_figure_test.tsx
+++ b/webpack/farm_designer/map/virtual_farmbot/__tests__/bot_figure_test.tsx
@@ -3,15 +3,14 @@ import { shallow } from "enzyme";
 import { BotOriginQuadrant } from "../../../interfaces";
 import { BotFigure, BotFigureProps } from "../bot_figure";
 import { Color } from "../../../../ui/index";
+import { fakeMapTransformProps } from "../../../../__test_support__/map_transform_props";
 
 describe("<BotFigure/>", () => {
   function fakeProps(): BotFigureProps {
     return {
       name: "",
       position: { x: 0, y: 0, z: 0 },
-      mapTransformProps: {
-        quadrant: 1, gridSize: { x: 3000, y: 1500 }
-      },
+      mapTransformProps: fakeMapTransformProps(),
       plantAreaOffset: { x: 100, y: 100 }
     };
   }

--- a/webpack/farm_designer/map/virtual_farmbot/__tests__/bot_figure_test.tsx
+++ b/webpack/farm_designer/map/virtual_farmbot/__tests__/bot_figure_test.tsx
@@ -17,21 +17,23 @@ describe("<BotFigure/>", () => {
 
   function checkPositionForQuadrant(
     quadrant: BotOriginQuadrant,
+    xySwap: boolean,
     expected: { x: number, y: number },
     name: string,
     opacity: number) {
     it(`shows ${name} in correct location for quadrant ${quadrant}`, () => {
       const p = fakeProps();
       p.mapTransformProps.quadrant = quadrant;
+      p.mapTransformProps.xySwap = xySwap;
       p.name = name;
       const result = shallow(<BotFigure {...p} />);
 
       const expectedGantryProps = expect.objectContaining({
         id: "gantry",
-        x: expected.x - 10,
-        y: -100,
-        width: 20,
-        height: 1700,
+        x: xySwap ? -100 : expected.x - 10,
+        y: xySwap ? expected.x - 10 : -100,
+        width: xySwap ? 1700 : 20,
+        height: xySwap ? 20 : 1700,
         fill: Color.darkGray,
         fillOpacity: opacity
       });
@@ -40,8 +42,8 @@ describe("<BotFigure/>", () => {
 
       const expectedUTMProps = expect.objectContaining({
         id: "UTM",
-        cx: expected.x,
-        cy: expected.y,
+        cx: xySwap ? expected.y : expected.x,
+        cy: xySwap ? expected.x : expected.y,
         r: 35,
         fill: Color.darkGray,
         fillOpacity: opacity
@@ -51,11 +53,15 @@ describe("<BotFigure/>", () => {
     });
   }
 
-  checkPositionForQuadrant(1, { x: 3000, y: 0 }, "motors", 0.75);
-  checkPositionForQuadrant(2, { x: 0, y: 0 }, "motors", 0.75);
-  checkPositionForQuadrant(3, { x: 0, y: 1500 }, "motors", 0.75);
-  checkPositionForQuadrant(4, { x: 3000, y: 1500 }, "motors", 0.75);
-  checkPositionForQuadrant(2, { x: 0, y: 0 }, "encoders", 0.25);
+  checkPositionForQuadrant(1, false, { x: 3000, y: 0 }, "motors", 0.75);
+  checkPositionForQuadrant(2, false, { x: 0, y: 0 }, "motors", 0.75);
+  checkPositionForQuadrant(3, false, { x: 0, y: 1500 }, "motors", 0.75);
+  checkPositionForQuadrant(4, false, { x: 3000, y: 1500 }, "motors", 0.75);
+  checkPositionForQuadrant(1, true, { x: 0, y: 1500 }, "motors", 0.75);
+  checkPositionForQuadrant(2, true, { x: 0, y: 0 }, "motors", 0.75);
+  checkPositionForQuadrant(3, true, { x: 3000, y: 0 }, "motors", 0.75);
+  checkPositionForQuadrant(4, true, { x: 3000, y: 1500 }, "motors", 0.75);
+  checkPositionForQuadrant(2, false, { x: 0, y: 0 }, "encoders", 0.25);
 
   it("changes location", () => {
     const p = fakeProps();

--- a/webpack/farm_designer/map/virtual_farmbot/__tests__/bot_peripherals_test.tsx
+++ b/webpack/farm_designer/map/virtual_farmbot/__tests__/bot_peripherals_test.tsx
@@ -16,15 +16,14 @@ import * as React from "react";
 import { shallow } from "enzyme";
 import { BotPeripheralsProps, BotPeripherals } from "../bot_peripherals";
 import { BooleanSetting } from "../../../../session_keys";
+import { fakeMapTransformProps } from "../../../../__test_support__/map_transform_props";
 
 describe("<BotPeripherals/>", () => {
   function fakeProps(): BotPeripheralsProps {
     return {
       peripherals: [{ label: "", value: false }],
       position: { x: 0, y: 0, z: 0 },
-      mapTransformProps: {
-        quadrant: 2, gridSize: { x: 3000, y: 1500 }
-      },
+      mapTransformProps: fakeMapTransformProps(),
       plantAreaOffset: { x: 100, y: 100 }
     };
   }
@@ -34,7 +33,7 @@ describe("<BotPeripherals/>", () => {
       const p = fakeProps();
       p.peripherals[0].label = name;
       p.peripherals[0].value = false;
-      const wrapper = shallow(<BotPeripherals {...p } />);
+      const wrapper = shallow(<BotPeripherals {...p} />);
       expect(wrapper.find(`#${name}`).length).toEqual(0);
     });
   }
@@ -42,11 +41,11 @@ describe("<BotPeripherals/>", () => {
   function animationToggle(
     props: BotPeripheralsProps, enabled: number, disabled: number) {
     mockStorj[BooleanSetting.disable_animations] = false;
-    const wrapperEnabled = shallow(<BotPeripherals {...props } />);
+    const wrapperEnabled = shallow(<BotPeripherals {...props} />);
     expect(wrapperEnabled.find("use").length).toEqual(enabled);
 
     mockStorj[BooleanSetting.disable_animations] = true;
-    const wrapperDisabled = shallow(<BotPeripherals {...props } />);
+    const wrapperDisabled = shallow(<BotPeripherals {...props} />);
     expect(wrapperDisabled.find("use").length).toEqual(disabled);
   }
 
@@ -54,7 +53,7 @@ describe("<BotPeripherals/>", () => {
     const p = fakeProps();
     p.peripherals[0].label = "lights";
     p.peripherals[0].value = true;
-    const wrapper = shallow(<BotPeripherals {...p } />);
+    const wrapper = shallow(<BotPeripherals {...p} />);
     expect(wrapper.find("#lights").length).toEqual(1);
     expect(wrapper.find("rect").last().props()).toEqual({
       fill: "url(#LightingGradient)",
@@ -66,7 +65,7 @@ describe("<BotPeripherals/>", () => {
     const p = fakeProps();
     p.peripherals[0].label = "water valve";
     p.peripherals[0].value = true;
-    const wrapper = shallow(<BotPeripherals {...p } />);
+    const wrapper = shallow(<BotPeripherals {...p} />);
     expect(wrapper.find("#water").length).toEqual(1);
     expect(wrapper.find("circle").last().props()).toEqual({
       cx: 0, cy: 0, fill: "rgb(11, 83, 148)", fillOpacity: 0.2, r: 55
@@ -78,7 +77,7 @@ describe("<BotPeripherals/>", () => {
     const p = fakeProps();
     p.peripherals[0].label = "vacuum pump";
     p.peripherals[0].value = true;
-    const wrapper = shallow(<BotPeripherals {...p } />);
+    const wrapper = shallow(<BotPeripherals {...p} />);
     expect(wrapper.find("#vacuum").length).toEqual(1);
     expect(wrapper.find("circle").last().props()).toEqual({
       fill: "url(#WaveGradient)", cx: 0, cy: 0, r: 100

--- a/webpack/farm_designer/map/virtual_farmbot/__tests__/bot_peripherals_test.tsx
+++ b/webpack/farm_designer/map/virtual_farmbot/__tests__/bot_peripherals_test.tsx
@@ -59,6 +59,35 @@ describe("<BotPeripherals/>", () => {
       fill: "url(#LightingGradient)",
       height: 1700, width: 400, x: 0, y: -100
     });
+    expect(wrapper.find("use").first().props()).toEqual({
+      xlinkHref: "#light-half",
+      transform: "rotate(0, 0, 750)"
+    });
+    expect(wrapper.find("use").last().props()).toEqual({
+      xlinkHref: "#light-half",
+      transform: "rotate(180, 0, 750)"
+    });
+  });
+
+  it("displays light: X&Y swapped", () => {
+    const p = fakeProps();
+    p.peripherals[0].label = "lights";
+    p.peripherals[0].value = true;
+    p.mapTransformProps.xySwap = true;
+    const wrapper = shallow(<BotPeripherals {...p} />);
+    expect(wrapper.find("#lights").length).toEqual(1);
+    expect(wrapper.find("rect").last().props()).toEqual({
+      fill: "url(#LightingGradient)",
+      height: 1700, width: 400, x: -100, y: 0
+    });
+    expect(wrapper.find("use").first().props()).toEqual({
+      xlinkHref: "#light-half",
+      transform: "rotate(90, 750, 850)"
+    });
+    expect(wrapper.find("use").last().props()).toEqual({
+      xlinkHref: "#light-half",
+      transform: "rotate(270, -100, 0)"
+    });
   });
 
   it("displays water", () => {

--- a/webpack/farm_designer/map/virtual_farmbot/__tests__/bot_trail_test.tsx
+++ b/webpack/farm_designer/map/virtual_farmbot/__tests__/bot_trail_test.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { shallow } from "enzyme";
 import { BotTrail, BotTrailProps, VirtualTrail } from "../bot_trail";
+import { fakeMapTransformProps } from "../../../../__test_support__/map_transform_props";
 
 describe("<BotTrail/>", () => {
   function fakeProps(): BotTrailProps {
@@ -12,9 +13,7 @@ describe("<BotTrail/>", () => {
       { coord: { x: 4, y: 4 }, water: 20 }]);
     return {
       position: { x: 0, y: 0, z: 0 },
-      mapTransformProps: {
-        quadrant: 2, gridSize: { x: 3000, y: 1500 }
-      },
+      mapTransformProps: fakeMapTransformProps(),
       peripherals: []
     };
   }

--- a/webpack/farm_designer/map/virtual_farmbot/__tests__/index_test.tsx
+++ b/webpack/farm_designer/map/virtual_farmbot/__tests__/index_test.tsx
@@ -16,6 +16,7 @@ import { VirtualFarmBot } from "../index";
 import { shallow } from "enzyme";
 import { VirtualFarmBotProps } from "../../interfaces";
 import { Dictionary } from "farmbot";
+import { fakeMapTransformProps } from "../../../../__test_support__/map_transform_props";
 
 describe("<VirtualFarmBot/>", () => {
   function fakeProps(): VirtualFarmBotProps {
@@ -25,9 +26,7 @@ describe("<VirtualFarmBot/>", () => {
         scaled_encoders: { x: undefined, y: undefined, z: undefined },
         raw_encoders: { x: undefined, y: undefined, z: undefined },
       },
-      mapTransformProps: {
-        quadrant: 1, gridSize: { x: 3000, y: 1500 }
-      },
+      mapTransformProps: fakeMapTransformProps(),
       plantAreaOffset: { x: 100, y: 100 },
       peripherals: [],
       eStopStatus: false
@@ -35,7 +34,7 @@ describe("<VirtualFarmBot/>", () => {
   }
 
   it("shows bot position", () => {
-    const wrapper = shallow(<VirtualFarmBot {...fakeProps() } />);
+    const wrapper = shallow(<VirtualFarmBot {...fakeProps()} />);
     const figures = wrapper.find("BotFigure");
     expect(figures.length).toEqual(1);
     expect(figures.last().props().name).toEqual("motor-position");
@@ -43,13 +42,13 @@ describe("<VirtualFarmBot/>", () => {
 
   it("shows trail", () => {
     mockStorj["display_trail"] = true;
-    const wrapper = shallow(<VirtualFarmBot {...fakeProps() } />);
+    const wrapper = shallow(<VirtualFarmBot {...fakeProps()} />);
     expect(wrapper.find("BotTrail").length).toEqual(1);
   });
 
   it("shows encoder position", () => {
     mockStorj["encoder_figure"] = true;
-    const wrapper = shallow(<VirtualFarmBot {...fakeProps() } />);
+    const wrapper = shallow(<VirtualFarmBot {...fakeProps()} />);
     const figures = wrapper.find("BotFigure");
     expect(figures.length).toEqual(2);
     expect(figures.last().props().name).toEqual("encoder-position");

--- a/webpack/farm_designer/map/virtual_farmbot/__tests__/negative_position_labels_test.tsx
+++ b/webpack/farm_designer/map/virtual_farmbot/__tests__/negative_position_labels_test.tsx
@@ -3,14 +3,13 @@ import { shallow } from "enzyme";
 import {
   NegativePositionLabel, NegativePositionLabelProps
 } from "../negative_position_labels";
+import { fakeMapTransformProps } from "../../../../__test_support__/map_transform_props";
 
 describe("<NegativePositionLabel />", () => {
   const fakeProps = (): NegativePositionLabelProps => {
     return {
       position: { x: 1234, y: undefined, z: undefined },
-      mapTransformProps: {
-        quadrant: 1, gridSize: { x: 3000, y: 1500 }
-      },
+      mapTransformProps: fakeMapTransformProps(),
       plantAreaOffset: { x: 100, y: 100 }
     };
   };

--- a/webpack/farm_designer/map/virtual_farmbot/bot_figure.tsx
+++ b/webpack/farm_designer/map/virtual_farmbot/bot_figure.tsx
@@ -26,18 +26,18 @@ export class BotFigure extends
   render() {
     const { name, position, plantAreaOffset, eStopStatus, mapTransformProps
     } = this.props;
-    const mapSize = getMapSize(mapTransformProps.gridSize, plantAreaOffset);
+    const { xySwap } = mapTransformProps;
+    const mapSize = getMapSize(mapTransformProps, plantAreaOffset);
     const positionQ = transformXY(
       (position.x || 0), (position.y || 0), mapTransformProps);
     const color = eStopStatus ? Color.virtualRed : Color.darkGray;
     const opacity = name.includes("encoder") ? 0.25 : 0.75;
     return <g id={name}>
       <rect id="gantry"
-        x={positionQ.qx - 10}
-        y={-plantAreaOffset.y
-        }
-        width={20}
-        height={mapSize.y}
+        x={xySwap ? -plantAreaOffset.x : positionQ.qx - 10}
+        y={xySwap ? positionQ.qy - 10 : -plantAreaOffset.y}
+        width={xySwap ? mapSize.w : 20}
+        height={xySwap ? 20 : mapSize.h}
         fillOpacity={opacity}
         fill={color} />
       <circle id="UTM"

--- a/webpack/session_keys.ts
+++ b/webpack/session_keys.ts
@@ -12,6 +12,7 @@ export const BooleanSetting: Record<BooleanConfigKey, BooleanConfigKey> = {
   show_spread: "show_spread",
   show_farmbot: "show_farmbot",
   show_images: "show_images",
+  xy_swap: "xy_swap",
 
   /** "Labs" feature names. (App preferences) */
   stub_config: "stub_config",

--- a/webpack/ui/fallback_img.tsx
+++ b/webpack/ui/fallback_img.tsx
@@ -24,9 +24,9 @@ export class FallbackImg extends React.Component<Props, State> {
   fallback = () => {
     return <div className="webcam-stream-unavailable">
       <img src={this.props.fallback} style={{ maxWidth: "100%" }} />
-      <text>
+      <p>
         {t("Unable to load webcam feed.")}
-      </text>
+      </p>
     </div>;
   }
 


### PR DESCRIPTION
**Farm Designer:**
 * Fix garden map plant move and placement actions for some browsers.
 * Add option to swap garden map X and Y axes (in `Move` widget settings menu).

**Controls:**
 * Add option to `Move` widget settings menu to swap X and Y axis jog buttons.
 * Controls pop-up jog buttons now disable when FarmBot is busy (like the `Move` widget jog buttons).
