### PR TITLE
Tweak point deletion error verbiage

### DIFF
--- a/app/models/tool.rb
+++ b/app/models/tool.rb
@@ -8,4 +8,8 @@ class Tool < ApplicationRecord
   validates  :name,   uniqueness: { scope: :device }
 
   IN_USE = "Tool in use by the following sequences: %s"
+
+  def fancy_name
+    "tool #{name.inspect}"
+  end
 end

--- a/app/models/tool.rb
+++ b/app/models/tool.rb
@@ -8,8 +8,4 @@ class Tool < ApplicationRecord
   validates  :name,   uniqueness: { scope: :device }
 
   IN_USE = "Tool in use by the following sequences: %s"
-
-  def fancy_name
-    "tool #{name.inspect}"
-  end
 end

--- a/spec/mutations/points/destroy_edge_cases_spec.rb
+++ b/spec/mutations/points/destroy_edge_cases_spec.rb
@@ -4,7 +4,7 @@ describe "Point deletion edge cases" do
   let(:device) { FactoryBot.create(:device) }
 
   it "cant delete toolslots that have a tool that are in use by sequences" do
-    tool      = FactoryBot.create(:tool, device: device, name: "tool")
+    tool      = FactoryBot.create(:tool, device: device, name: "foo tool")
     tool_slot = FactoryBot.create(:tool_slot,
                                   device: device,
                                   tool_id: tool.id,
@@ -24,9 +24,10 @@ describe "Point deletion edge cases" do
             offset: { kind: "coordinate", args: { x: 0, y: 0, z: 0} }
           },
         }])
-    result = Points::Destroy.run(point_ids: [tool_slot.id], device: device)
-    errors = result.errors.message_list
-    expect(errors)
-      .to include(Points::Destroy::STILL_IN_USE % ["sequence", "tool"])
+    result   = Points::Destroy.run(point_ids: [tool_slot.id], device: device)
+    errors   = result.errors.message_list
+    expected = "Could not delete the following point(s): foo tool. They are" \
+               " in use by the following sequence(s): sequence"
+    expect(errors).to include(expected)
   end
 end

--- a/spec/mutations/points/destroy_spec.rb
+++ b/spec/mutations/points/destroy_spec.rb
@@ -134,10 +134,6 @@ describe Points::Destroy do
     expect(result[:point]).to eq(expected)
   end
 
-  it "has a nicely formatted deletion error messages" do
-
-  end
-
   it "performs a hard (real) delete" do
     points = FactoryBot.create_list(:generic_pointer, 3, device: device)
     ids    = points.pluck(:id)

--- a/spec/mutations/points/destroy_spec.rb
+++ b/spec/mutations/points/destroy_spec.rb
@@ -37,8 +37,9 @@ describe Points::Destroy do
     expect(Point.count).to eq(before)
     expect(result.errors.message_list.count).to eq(1)
     expect(result.errors.message_list.first).to include(params[:name])
-    expected =  "The sequence 'Test Case I' is still using the following "\
-                "points: point at"
+    coords = [:x,:y,:z].map{|c|points.first[c]}.join(", ")
+    expected =  "Could not delete the following point(s): point at (#{coords}" \
+                "). They are in use by the following sequence(s): Test Case I"
     expect(result.errors.message_list.first).to include(expected)
   end
 
@@ -47,8 +48,8 @@ describe Points::Destroy do
     point_ids = [s.tool_slot.id]
     result = Points::Destroy.run(point_ids: point_ids, device: s.device)
     expect(result.success?).to be(false)
-    expected = "The sequence 'Scenario Sequence' is still using the following "\
-                "points: Scenario Tool"
+    expected  = "Could not delete the following point(s): Scenario Tool. They "\
+                "are in use by the following sequence(s): Scenario Sequence"
     expect(result.errors.message_list).to include(expected)
   end
 
@@ -89,14 +90,54 @@ describe Points::Destroy do
                                           },
                                         ])
 
+                                        sequence_a  = Sequences::Create.run!(device: device,
+                                        name: "Sequence B",
+                                        body: [
+                                          {
+                                            kind: "move_absolute",
+                                            args: {
+                                              location: {
+                                                kind: "point",
+                                                args: {
+                                                  pointer_id:   plant.id,
+                                                  pointer_type: "Plant"
+                                                }
+                                              },
+                                              speed: 100,
+                                              offset: empty_point
+                                            }
+                                          },
+                                          {
+                                            kind: "move_absolute",
+                                            args: {
+                                              location: {
+                                                kind: "point",
+                                                args: {
+                                                  pointer_id:   plant.id,
+                                                  pointer_type: "GenericPointer"
+                                                }
+                                              },
+                                              speed: 100,
+                                              offset: empty_point
+                                            }
+                                          },
+                                        ])
+
     result = Points::Destroy
       .run(point_ids: [point.id, plant.id], device: device)
       .errors
       .message
-      expect(result[:point])
-        .to eq("The sequence 'Sequence A' is still using the following points:"\
-               " plant at (0.0, 1.0, 0.0)")
+
+    expected =  "Could not delete the following point(s): plant at (0.0, 1.0,"\
+                " 0.0). They are in use by the following sequence(s): Sequence"\
+                " A, Sequence B"
+    expect(result[:point]).to eq(expected)
   end
+
+  it "has a nicely formatted deletion error messages" do
+
+  end
+
   it "performs a hard (real) delete" do
     points = FactoryBot.create_list(:generic_pointer, 3, device: device)
     ids    = points.pluck(:id)


### PR DESCRIPTION

# Before

```
The sequence 'Sequence A' is still using the
following points: plant at (0.0, 1.0, 0.0). The 
sequence 'Sequence B' is still using the 
following points: plant at (0.0, 1.0, 0.0)
```

# After

```
"Could not delete the following point(s): plant 
at (0.0, 1.0, 0.0). They are in use by the 
following sequence(s): Sequence A,
Sequence B"
```
