### PR TITLE
Make Users::Update update emails when NO_EMAILS is set

### DIFF
--- a/app/mutations/users/update.rb
+++ b/app/mutations/users/update.rb
@@ -23,7 +23,7 @@ module Users
       set_unconfirmed_email if email.present?
       excludable = [:user]
       excludable.push(:email) unless skip_email_stuff
-      user.update_attributes!(inputs.except(:user, :email))
+      user.update_attributes!(inputs.except(*excludable))
       if inputs[:password]
         SendFactoryResetJob.perform_later(user.device)
         delete_all_tokens_except_this_one

--- a/spec/mutations/users/update_spec.rb
+++ b/spec/mutations/users/update_spec.rb
@@ -28,7 +28,13 @@ describe Users::Update do
     u = FactoryBot.create(:user)
     expect(u.unconfirmed_email?).to be false
     Users::Update.run!(user: u, email: "example@mailinator.com")
-    expect(u.unconfirmed_email?).to be true
-    expect(u.unconfirmed_email).to eq("example@mailinator.com")
+
+    if User::SKIP_EMAIL_VALIDATION
+      expect(u.unconfirmed_email?).to be false
+      expect(u.email).to eq("example@mailinator.com")
+    else
+      expect(u.unconfirmed_email?).to be true
+      expect(u.unconfirmed_email).to eq("example@mailinator.com")
+    end
   end
 end


### PR DESCRIPTION
With NO_EMAILS set (say in a dev environment), some pieces of the User update mutation are skipped. Running the tests for Users::Update on a fresh clone of master with NO_EMAILS set had a failing test:

```
Failures:

  1) Users::Update changes email addresses
     Failure/Error: expect(u.unconfirmed_email?).to be true

       expected true
            got false
     # ./spec/mutations/users/update_spec.rb:31:in `block (2 levels) in <top (required)>'
     # /Users/airhorns/.rbenv/versions/2.5.1/bin/rspec:23:in `load'
     # /Users/airhorns/.rbenv/versions/2.5.1/bin/rspec:23:in `<top (required)>'
     # /Users/airhorns/.rbenv/versions/2.5.1/bin/bundle:23:in `load'
     # /Users/airhorns/.rbenv/versions/2.5.1/bin/bundle:23:in `<main>'
```

This test failed because it was expecting against the `unconfirmed_email` attribute, which in the NO_EMAILS case, isn't used at all. So, the test now checks if email verification is on, and expects against `unconfirmed_email` if so, and the actual `email` attribute otherwise.

Turns out, that test failed too! The actual code in `Users::Update` figured out that direct email mutations should be allowed when NO_EMAILS is set, but didn't pass that down to the `#update_attributes` call. I think this was just a small mistake because the code builds a list of attribute exclusions conditional on NO_EMAILS already, and just never uses it. This code was added in 65b044d7a8124c0c7cb62a28968602198acb90ff which looks like it might not have been intended to hit master. No matter, easy fix!