### PR TITLE
Make db/seeds work again after pointer fixes

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -60,7 +60,6 @@ unless Rails.env == "production"
                    y:             rand(40...470),
                    radius:        rand(10...50),
                    name:          Faker::StarWars.call_sign,
-                   pointer_id:    0,
                    openfarm_slug: ["tomato", "carrot", "radish", "garlic"].sample)
     end
 
@@ -72,7 +71,6 @@ unless Rails.env == "production"
                             y: rand(40...470) + rand(40...470),
                             z: 5,
                             radius: (rand(1...150) + rand(1...150)) / 20,
-                            pointer_id: 0,
                             meta: {
                               created_by: "plant-detection",
                               color: (Sequence::COLORS + [nil]).sample


### PR DESCRIPTION
Bootstrapping a new clone broke because there were still a couple references to this column which now doesn't exist and shouldn't be referenced after f56aa55843a9962cdbc7a71299c36463a86f4250. :fire:

Error was:

```
ActiveModel::UnknownAttributeError: unknown attribute 'pointer_id' for Plant.
/Users/airhorns/Code/Farmbot-Web-App/db/seeds.rb:58:in `block in <top (required)>'
/Users/airhorns/Code/Farmbot-Web-App/db/seeds.rb:57:in `times'
/Users/airhorns/Code/Farmbot-Web-App/db/seeds.rb:57:in `<top (required)>'
/Users/airhorns/.rbenv/versions/2.5.1/bin/bundle:23:in `load'
/Users/airhorns/.rbenv/versions/2.5.1/bin/bundle:23:in `<main>'
```