### PR TITLE
Add a CI test suite for a self hosted setup 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,23 @@ cache:
   directories:
    - /home/travis/.rvm/
    - /home/travis/bundle
+env:
+ # Production like setup
+ - SECRET_TOKEN=e815982094c62436066bafc9151f2d33c4a351a776654cb7487476de260a4592
+   MQTT_HOST=example.com
+   OS_UPDATE_SERVER=http://example.com
+   FW_UPDATE_SERVER=http://example.com
+   DB=postgresql
+   COVERALLS_REPO_TOKEN=lEX6nkql7y2YFCcIXVq5ORvdvMtYzfZdG
+ # Self hosted like setup
+ - SECRET_TOKEN=e815982094c62436066bafc9151f2d33c4a351a776654cb7487476de260a4592
+   MQTT_HOST=127.0.0.1
+   OS_UPDATE_SERVER=http://example.com
+   FW_UPDATE_SERVER=http://example.com
+   DB=postgresql
+   COVERALLS_REPO_TOKEN=lEX6nkql7y2YFCcIXVq5ORvdvMtYzfZdG
+   API_HOST=127.0.0.1
+   NO_EMAILS=TRUE
 before_install:
   - rvm install 2.5.1
   - rvm use 2.5.1
@@ -16,12 +33,6 @@ before_script:
 - cp config/database.travis.yml config/database.yml
 - bundle exec rake db:create db:migrate
 script:
-- export SECRET_TOKEN=e815982094c62436066bafc9151f2d33c4a351a776654cb7487476de260a4592
-- export MQTT_HOST=example.com
-- export OS_UPDATE_SERVER=http://example.com
-- export FW_UPDATE_SERVER=http://example.com
-- export DB=postgresql
-- export COVERALLS_REPO_TOKEN=lEX6nkql7y2YFCcIXVq5ORvdvMtYzfZdG
 - bundle exec rspec --fail-fast=3
 - npm run typecheck
 - npm run test-slow

--- a/spec/controllers/api/devices/devices_controller_dump_spec.rb
+++ b/spec/controllers/api/devices/devices_controller_dump_spec.rb
@@ -4,14 +4,21 @@ describe Api::DevicesController do
   include Devise::Test::ControllerHelpers
   let(:user) { FactoryBot.create(:user) }
 
+  around(:each) do |example|
+    b4 = Api::DevicesController.send_emails
+    example.run
+    Api::DevicesController.send_emails = b4
+  end
+
   describe '#dump' do
-    it 'queues the creation of an account backup' do
+    it 'queues the creation of an account backup to email when an email server is available' do
+      Api::DevicesController.send_emails = true
       sign_in user
       empty_mail_bag
       run_jobs_now do
         post :dump, params: {}, session: { format: :json }
       end
-      expect(response.status).to eq(ENV["NO_EMAILS"] ? 200 : 202)
+      expect(response.status).to eq(202)
       mail = ActionMailer::Base.deliveries.last
       expect(mail).to be_kind_of(Mail::Message)
       expect(mail.to).to include(user.email)
@@ -22,14 +29,12 @@ describe Api::DevicesController do
     end
 
     it 'stores to disk when no email server is available' do
-      b4 = Api::DevicesController.send_emails
       Api::DevicesController.send_emails = false
       sign_in user
       post :dump, params: {}, session: { format: :json }
       expect(response.status).to eq(200)
       # Just a spot check. Handle in depth usage at the mutation spec level. -RC
       expect(json[:tools]).to be_kind_of(Array)
-      Api::DevicesController.send_emails = b4
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,13 +5,18 @@ describe User do
     end
   end
 
+  around(:each) do |example|
+    original = User::SKIP_EMAIL_VALIDATION
+    example.run
+    const_reassign(User, :SKIP_EMAIL_VALIDATION, original)
+  end
+
   describe 'SKIP_EMAIL_VALIDATION' do
     let (:user) { FactoryBot.create(:user, confirmed_at: nil) }
 
     it 'considers al users verified when set to `true`' do
       const_reassign(User, :SKIP_EMAIL_VALIDATION, true)
       expect(user.verified?).to be(true)
-      const_reassign(User, :SKIP_EMAIL_VALIDATION, false)
     end
 
     it 'does not skip when false' do


### PR DESCRIPTION
Rick and I observed that it's hard to make sure the self hosted style of running the app stays working, since most development is focused on the main deploy platform and run with settings that look like it. So, lets run a CI suite against the other settings that will catch accidental breakages of the self-hosted case! This uses Travis' Build Matrix feature documented here: https://docs.travis-ci.com/user/customizing-the-build/#Build-Matrix to run multiple sub-builds per build. All tests (and coverage helpers) will run twice, once in each of the listed environments like so: https://travis-ci.com/airhorns/Farmbot-Web-App/builds/72483422 . In the future, we could add more environments too like a new ruby or node version, or a dockerized version or what have you. 

I am not exactly sure which coverage tool is testing what and how they will respond to multiple coverage reports coming from different build instances, so I'm opening this to test. @RickCarlino maybe you could take a look at the coverage reports when they are in to see if they look like what you'd expect. 