### PR TITLE
Make `body` and `args` mandatory for `Sequences#update`

### DIFF
--- a/app/controllers/api/images_controller.rb
+++ b/app/controllers/api/images_controller.rb
@@ -34,9 +34,9 @@ module Api
 
     def policy_class
       if ImagesController.store_locally
-        Images::GeneratePolicy
-      else
         Images::StubPolicy
+      else
+        Images::GeneratePolicy
       end
     end
 

--- a/app/mutations/sequences/update.rb
+++ b/app/mutations/sequences/update.rb
@@ -11,8 +11,8 @@ module Sequences
       string :name
       # HISTORICAL NOTE ========================================================
       # Originally, `args` and `body` were optional. We stored them in a
-      args # serialized column and it was very inexpensive to retreive them
-      body # from the database. Serialized columns led to an enoromous amunt of
+      args # serialized column and it was very inexpensive to retrieve them
+      body # from the database. Serialized columns led to an enormous amount of
       # issues in other parts of the app, however. One of the tradeoffs that we
       # now face is that we can no longer call `sequence.args` and
       # `sequence.body` as quickly as in the old days. It also means these

--- a/app/mutations/sequences/update.rb
+++ b/app/mutations/sequences/update.rb
@@ -8,13 +8,26 @@ module Sequences
     required do
       model :device, class: Device
       model :sequence, class: Sequence
+      string :name
+      # HISTORICAL NOTE ========================================================
+      # Originally, `args` and `body` were optional. We stored them in a
+      args # serialized column and it was very inexpensive to retreive them
+      body # from the database. Serialized columns led to an enoromous amunt of
+      # issues in other parts of the app, however. One of the tradeoffs that we
+      # now face is that we can no longer call `sequence.args` and
+      # `sequence.body` as quickly as in the old days. It also means these
+      # fields are now mandatory for sequence updates.
+      #
+      # In the long term, the app benefits from the new storage mechanism
+      # because it is easier to track sequence dependencies, migrate deprecated
+      # sequences, and also to query for data inside of a sequence (nearly
+      # impossible under the old database schema.
+      #
+      # END HISTORICAL NOTE ================================================== ^
     end
 
     optional do
-      string :name
       color
-      args
-      body
     end
 
     def validate
@@ -26,11 +39,12 @@ module Sequences
       ActiveRecord::Base.transaction do
         sequence.migrated_nodes = true
         sequence.update_attributes!(inputs.except(*BLACKLIST))
-        params = {sequence: sequence, args: args || {}, body: body || []}
-        CeleryScript::StoreCelery.run!(params)
+        CeleryScript::StoreCelery
+          .run!(sequence: sequence, args: args, body: body)
       end
       sequence.manually_sync! # We must manually sync this resource.
-      CeleryScript::FetchCelery.run!(sequence: sequence)
+      CeleryScript::FetchCelery
+        .run!(sequence: sequence, args: args, body: body)
     end
   end
 end

--- a/spec/controllers/api/images/images_spec.rb
+++ b/spec/controllers/api/images/images_spec.rb
@@ -5,7 +5,10 @@ describe Api::ImagesController do
   let(:user) { FactoryBot.create(:user) }
   it "Creates a policy object" do
     sign_in user
+    b4 = Api::ImagesController.store_locally
+    Api::ImagesController.store_locally = false
     get :storage_auth
+    Api::ImagesController.store_locally = b4
 
     expect(response.status).to eq(200)
     expect(json).to be_kind_of(Hash)
@@ -19,7 +22,7 @@ describe Api::ImagesController do
   it "Creates a (stub) policy object" do
     sign_in user
     b4 = Api::ImagesController.store_locally
-    Api::ImagesController.store_locally = false
+    Api::ImagesController.store_locally = true
     get :storage_auth
     Api::ImagesController.store_locally = b4
     expect(response.status).to eq(200)

--- a/spec/controllers/api/sequences/sequences_update_spec.rb
+++ b/spec/controllers/api/sequences/sequences_update_spec.rb
@@ -24,7 +24,7 @@ describe Api::SequencesController do
     it 'updates existing sequences' do
       sign_in user
       sequence = FakeSequence.create( device: user.device)
-      input = { sequence: { name: "Scare Birds" } }
+      input = { sequence: { name: "Scare Birds", args: {}, body: [] } }
       params = { id: sequence.id }
       patch :update,
         params: params,

--- a/webpack/farm_designer/farm_events/__tests__/add_farm_event_test.tsx
+++ b/webpack/farm_designer/farm_events/__tests__/add_farm_event_test.tsx
@@ -9,7 +9,7 @@ jest.mock("../../../history", () => ({
 }));
 
 import * as React from "react";
-import { mount } from "enzyme";
+import { mount, shallow } from "enzyme";
 import { AddFarmEvent } from "../add_farm_event";
 import { AddEditFarmEventProps } from "../../interfaces";
 import { fakeFarmEvent, fakeSequence } from "../../../__test_support__/fake_state/resources";
@@ -51,6 +51,14 @@ describe("<AddFarmEvent />", () => {
   it("redirects", () => {
     const wrapper = mount(<AddFarmEvent {...fakeProps()} />);
     expect(wrapper.text()).toContain("Loading");
+  });
+
+  it("renders `none`", () => {
+    const props: Partial<AddEditFarmEventProps> = {};
+    const comp = new AddFarmEvent(props as AddEditFarmEventProps);
+    const results = shallow(<div>{comp.none()}</div>);
+    expect(results.text())
+      .toContain("You haven't made any regimens or sequences yet.");
   });
 
   it("cleans up when unmounting", () => {

--- a/webpack/farmware/farmware_panel.tsx
+++ b/webpack/farmware/farmware_panel.tsx
@@ -82,9 +82,10 @@ export class FarmwarePanel extends React.Component<FWProps, Partial<FWState>> {
 
   run = () => {
     this
-      .ifFarmwareSelected(label => getDevice()
-        .execScript(label)
-        .then(() => this.setState({ selectedFarmware: label })));
+      .ifFarmwareSelected(label => {
+        const ok = () => this.setState({ selectedFarmware: label });
+        getDevice().execScript(label).then(ok, ok);
+      });
   }
 
   install = () => {

--- a/webpack/farmware/farmware_panel.tsx
+++ b/webpack/farmware/farmware_panel.tsx
@@ -84,7 +84,8 @@ export class FarmwarePanel extends React.Component<FWProps, Partial<FWState>> {
     this
       .ifFarmwareSelected(label => {
         const ok = () => this.setState({ selectedFarmware: label });
-        getDevice().execScript(label).then(ok, ok);
+        const no = commandErr("Farmware execution");
+        getDevice().execScript(label).then(ok, no);
       });
   }
 


### PR DESCRIPTION
# Why?

Originally, `args` and `body` were optional. We stored them in a
serialized column and it was very inexpensive to retrieve them
from the database. Serialized columns led to an enormous amount of
issues in other parts of the app, however. One of the tradeoffs that we
now face is that we can no longer call `sequence.args` and
`sequence.body` as quickly as in the old days. It also means these
fields are now mandatory for sequence updates.

In the long term, the app benefits from the new storage mechanism
because it is easier to track sequence dependencies, migrate deprecated
sequences, and also to query for data inside of a sequence (nearly
impossible under the old database schema).

Unfortunately, **sequence updating is the slowest part of the API** so it is
not currently feasible to allow for optional `body` and `args` because it would
further degrade endpoint performance.
