### PR TITLE
Farm Designer additions

### DIFF
--- a/webpack/constants.ts
+++ b/webpack/constants.ts
@@ -488,6 +488,10 @@ export namespace Content {
     trim(`No Regimen selected. Click one in the Regimens panel to edit, or
     click "+" in the Regimens panel to create a new one.`);
 
+  // Farm Designer
+  export const OUTSIDE_PLANTING_AREA =
+    trim(`Outside of planting area. Plants must be placed within the grid.`);
+
   // Farm Events
   export const REGIMEN_TODAY_SKIPPED_ITEM_RISK =
     trim(`You are scheduling a regimen to run today. Be aware that

--- a/webpack/farm_designer/index.tsx
+++ b/webpack/farm_designer/index.tsx
@@ -10,7 +10,7 @@ import { Session, safeBooleanSettting } from "../session";
 import { NumericSetting, BooleanSetting } from "../session_keys";
 import { isUndefined, last } from "lodash";
 import { AxisNumberProperty, BotSize } from "./map/interfaces";
-import { getBotSize } from "./map/util";
+import { getBotSize, round } from "./map/util";
 import { calcZoomLevel, getZoomLevelIndex, saveZoomLevelIndex } from "./map/zoom";
 import * as moment from "moment";
 import { DesignerNavTabs } from "./panel_header";
@@ -26,7 +26,7 @@ export const getDefaultAxisLength = (): AxisNumberProperty => {
 export const getGridSize = (botSize: BotSize) => {
   if (Session.deprecatedGetBool(BooleanSetting.dynamic_map)) {
     // Render the map size according to device axis length.
-    return { x: botSize.x.value, y: botSize.y.value };
+    return { x: round(botSize.x.value), y: round(botSize.y.value) };
   }
   // Use a default map size.
   return getDefaultAxisLength();

--- a/webpack/farm_designer/interfaces.ts
+++ b/webpack/farm_designer/interfaces.ts
@@ -245,6 +245,7 @@ export interface CropInfoProps {
   dispatch: Function;
   cropSearchResults: CropLiveSearchResult[];
   OFSearch: (query: string) => (dispatch: Function) => void;
+  botPosition: BotPosition;
 }
 
 export interface CameraCalibrationData {

--- a/webpack/farm_designer/map/__tests__/grid_test.tsx
+++ b/webpack/farm_designer/map/__tests__/grid_test.tsx
@@ -12,7 +12,6 @@ describe("<Grid/>", () => {
   function fakeProps(): GridProps {
     return {
       mapTransformProps: fakeMapTransformProps(),
-      dispatch: jest.fn(),
       onClick: jest.fn()
     };
   }

--- a/webpack/farm_designer/map/interfaces.ts
+++ b/webpack/farm_designer/map/interfaces.ts
@@ -71,13 +71,21 @@ export interface GardenPointProps {
   point: TaggedGenericPointer;
 }
 
-export interface DragHelpersProps {
+export interface DragHelpersBaseProps {
   dragging: boolean;
-  plant: Readonly<TaggedPlantPointer>;
   mapTransformProps: MapTransformProps;
   zoomLvl: number;
   activeDragXY: BotPosition | undefined;
   plantAreaOffset: AxisNumberProperty;
+}
+
+export interface DragHelperLayerProps extends DragHelpersBaseProps {
+  currentPlant: TaggedPlantPointer | undefined;
+  editing: boolean;
+}
+
+export interface DragHelpersProps extends DragHelpersBaseProps {
+  plant: Readonly<TaggedPlantPointer>;
 }
 
 export type AxisNumberProperty = Record<"x" | "y", number>;
@@ -97,7 +105,6 @@ export interface MapBackgroundProps {
 
 export interface GridProps {
   mapTransformProps: MapTransformProps;
-  dispatch: Function;
   onClick(): void;
 }
 

--- a/webpack/farm_designer/map/layers/__tests__/drag_helper_layer_test.tsx
+++ b/webpack/farm_designer/map/layers/__tests__/drag_helper_layer_test.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
-import { DragHelperLayer, DragHelperLayerProps } from "../drag_helper_layer";
+import { DragHelperLayer } from "../drag_helper_layer";
 import { shallow } from "enzyme";
 import { fakePlant } from "../../../../__test_support__/fake_state/resources";
 import { fakeMapTransformProps } from "../../../../__test_support__/map_transform_props";
+import { DragHelperLayerProps } from "../../interfaces";
 
 describe("<DragHelperLayer/>", () => {
   function fakeProps(): DragHelperLayerProps {

--- a/webpack/farm_designer/map/layers/__tests__/tool_slot_layer_test.tsx
+++ b/webpack/farm_designer/map/layers/__tests__/tool_slot_layer_test.tsx
@@ -36,7 +36,6 @@ describe("<ToolSlotLayer/>", () => {
       visible: false,
       slots: [{ toolSlot, tool: undefined }],
       mapTransformProps: fakeMapTransformProps(),
-      dispatch: jest.fn()
     };
   }
   it("toggles visibility off", () => {
@@ -67,7 +66,6 @@ describe("<ToolSlotLayer/>", () => {
     const tools = wrapper.find("g").first();
     await tools.simulate("click");
     expect(mockHistory).not.toHaveBeenCalled();
-    expect(p.dispatch).not.toHaveBeenCalled();
   });
 
   it("is in non-clickable mode", () => {

--- a/webpack/farm_designer/map/layers/drag_helper_layer.tsx
+++ b/webpack/farm_designer/map/layers/drag_helper_layer.tsx
@@ -1,23 +1,11 @@
 import * as React from "react";
-import { TaggedPlantPointer } from "../../../resources/tagged_resources";
-import { MapTransformProps, AxisNumberProperty } from "../interfaces";
+import { DragHelperLayerProps } from "../interfaces";
 import { DragHelpers } from "../drag_helpers";
-import { BotPosition } from "../../../devices/interfaces";
 
 /**
  * For showing drag helpers for the selected plant.
  * This layer must be rendered after the hovered plant layer.
  */
-
-export interface DragHelperLayerProps {
-  currentPlant: TaggedPlantPointer | undefined;
-  mapTransformProps: MapTransformProps;
-  dragging: boolean;
-  editing: boolean;
-  zoomLvl: number;
-  activeDragXY: BotPosition | undefined;
-  plantAreaOffset: AxisNumberProperty;
-}
 
 export class DragHelperLayer extends
   React.Component<DragHelperLayerProps, {}> {

--- a/webpack/farm_designer/map/layers/farmbot_layer.tsx
+++ b/webpack/farm_designer/map/layers/farmbot_layer.tsx
@@ -6,12 +6,12 @@ import { FarmBotLayerProps } from "../interfaces";
 export function FarmBotLayer(props: FarmBotLayerProps) {
   const {
     visible, stopAtHome, botSize, plantAreaOffset, mapTransformProps,
-    peripherals, eStopStatus
-   } = props;
+    peripherals, eStopStatus, botLocationData
+  } = props;
   return visible ? <g id="farmbot-layer">
     <VirtualFarmBot
       mapTransformProps={mapTransformProps}
-      botLocationData={props.botLocationData}
+      botLocationData={botLocationData}
       plantAreaOffset={plantAreaOffset}
       peripherals={peripherals}
       eStopStatus={eStopStatus} />

--- a/webpack/farm_designer/map/layers/hovered_plant_layer.tsx
+++ b/webpack/farm_designer/map/layers/hovered_plant_layer.tsx
@@ -39,17 +39,19 @@ export class HoveredPlantLayer extends
   }
 
   render() {
-    const { icon } = this.props.designer.hoveredPlant;
-    const { currentPlant, mapTransformProps, dragging, isEditing } = this.props;
+    const {
+      currentPlant, mapTransformProps, dragging, isEditing, visible, designer
+    } = this.props;
+    const { icon } = designer.hoveredPlant;
+    const hovered = !!icon;
     const { id, x, y, radius } = this.plantInfo;
     const { qx, qy } = transformXY(round(x), round(y), mapTransformProps);
-    const hovered = !!this.props.designer.hoveredPlant.icon;
     const scaledRadius = currentPlant ? radius : radius * 1.2;
     const alpha = dragging ? 0.4 : 1.0;
     const animate = !Session.deprecatedGetBool(BooleanSetting.disable_animations);
 
     return <g id="hovered-plant-layer">
-      {this.props.visible && hovered &&
+      {visible && hovered &&
         <g id={"hovered-plant-" + id}>
           {currentPlant &&
             <g id="selected-plant-indicators">

--- a/webpack/farm_designer/map/layers/plant_layer.tsx
+++ b/webpack/farm_designer/map/layers/plant_layer.tsx
@@ -10,15 +10,17 @@ const cropSpreadDict: CropSpreadDict = {};
 
 export function PlantLayer(props: PlantLayerProps) {
   const {
-    crops,
-    plants,
+    mapTransformProps,
     dispatch,
     visible,
+    plants,
+    crops,
     currentPlant,
     dragging,
     editing,
     selectedForDel,
-    mapTransformProps
+    zoomLvl,
+    activeDragXY,
   } = props;
 
   crops
@@ -30,9 +32,6 @@ export function PlantLayer(props: PlantLayerProps) {
       plants
         .filter(x => !!x.body.id)
         .map(p => defensiveClone(p))
-        .map(p => {
-          return p;
-        })
         .map(p => {
           return {
             selected: !!(currentPlant && (p.uuid === currentPlant.uuid)),
@@ -57,8 +56,8 @@ export function PlantLayer(props: PlantLayerProps) {
               grayscale={p.grayscale}
               dragging={p.selected && dragging && editing}
               dispatch={dispatch}
-              zoomLvl={props.zoomLvl}
-              activeDragXY={props.activeDragXY} />
+              zoomLvl={zoomLvl}
+              activeDragXY={activeDragXY} />
           </Link>;
         })}
   </g>;

--- a/webpack/farm_designer/map/layers/spread_layer.tsx
+++ b/webpack/farm_designer/map/layers/spread_layer.tsx
@@ -36,7 +36,7 @@ export function SpreadLayer(props: SpreadLayerProps) {
       </radialGradient>
     </defs>
 
-    {plants.map((p) => {
+    {plants.map(p => {
       const selected = !!(currentPlant && (p.uuid === currentPlant.uuid));
       return <g id={"spread-components-" + p.body.id} key={p.uuid}>
         {visible &&
@@ -54,8 +54,7 @@ export function SpreadLayer(props: SpreadLayerProps) {
           activeDragXY={activeDragXY}
           activeDragSpread={activeDragSpread} />
       </g>;
-    })
-    }
+    })}
   </g>;
 }
 

--- a/webpack/farm_designer/map/layers/tool_slot_layer.tsx
+++ b/webpack/farm_designer/map/layers/tool_slot_layer.tsx
@@ -9,7 +9,6 @@ export interface ToolSlotLayerProps {
   visible: boolean;
   slots: SlotWithTool[];
   mapTransformProps: MapTransformProps;
-  dispatch: Function;
 }
 
 export function ToolSlotLayer(props: ToolSlotLayerProps) {

--- a/webpack/farm_designer/plants/__tests__/edit_plant_info_test.tsx
+++ b/webpack/farm_designer/plants/__tests__/edit_plant_info_test.tsx
@@ -42,9 +42,9 @@ describe("<EditPlantInfo />", () => {
     const p = fakeProps();
     p.dispatch = jest.fn(() => { return Promise.resolve(); });
     const wrapper = mount(<EditPlantInfo {...p} />);
-    const deleteButton = wrapper.find("button").at(1);
-    expect(deleteButton.props().hidden).toBeFalsy();
+    const deleteButton = wrapper.find("button").at(2);
     expect(deleteButton.text()).toEqual("Delete");
+    expect(deleteButton.props().hidden).toBeFalsy();
     deleteButton.simulate("click");
     expect(p.dispatch).toHaveBeenCalled();
   });

--- a/webpack/farm_designer/plants/__tests__/move_to_test.tsx
+++ b/webpack/farm_designer/plants/__tests__/move_to_test.tsx
@@ -17,7 +17,7 @@ jest.mock("../../../history", () => ({
 
 import * as React from "react";
 import { mount } from "enzyme";
-import { MoveTo, MoveToProps } from "../move_to";
+import { MoveTo, MoveToProps, MoveToForm, MoveToFormProps } from "../move_to";
 
 describe("<MoveTo />", () => {
   beforeEach(function () {
@@ -34,16 +34,24 @@ describe("<MoveTo />", () => {
   }
 
   it("moves to location: bot's current z value", () => {
-    const wrapper = mount(<MoveTo {...fakeProps() } />);
+    const wrapper = mount(<MoveTo {...fakeProps()} />);
     wrapper.find("button").simulate("click");
     expect(mockDevice.moveAbsolute).toHaveBeenCalledWith({ x: 1, y: 2, z: 30 });
   });
+});
+
+describe("<MoveToForm />", () => {
+  function fakeProps(): MoveToFormProps {
+    return {
+      chosenLocation: { x: 1, y: 2, z: 3 },
+      currentBotLocation: { x: 10, y: 20, z: 30 },
+    };
+  }
 
   it("moves to location: custom z value", () => {
-    const wrapper = mount(<MoveTo {...fakeProps() } />);
+    const wrapper = mount(<MoveToForm {...fakeProps()} />);
     wrapper.setState({ z: 50 });
     wrapper.find("button").simulate("click");
     expect(mockDevice.moveAbsolute).toHaveBeenCalledWith({ x: 1, y: 2, z: 50 });
   });
-
 });

--- a/webpack/farm_designer/plants/__tests__/plant_panel_test.tsx
+++ b/webpack/farm_designer/plants/__tests__/plant_panel_test.tsx
@@ -9,6 +9,7 @@ import * as React from "react";
 import { PlantPanel, PlantPanelProps, EditPlantStatus, EditPlantStatusProps } from "../plant_panel";
 import { shallow } from "enzyme";
 import { FormattedPlantInfo } from "../map_state_to_props";
+import { Actions } from "../../../constants";
 
 describe("<PlantPanel/>", () => {
   beforeEach(function () {
@@ -32,6 +33,7 @@ describe("<PlantPanel/>", () => {
       info,
       onDestroy: jest.fn(),
       updatePlant: jest.fn(),
+      dispatch: jest.fn(),
     };
   };
 
@@ -46,23 +48,38 @@ describe("<PlantPanel/>", () => {
   it("calls destroy", () => {
     const p = fakeProps();
     const wrapper = shallow(<PlantPanel {...p} />);
-    wrapper.find("button").first().simulate("click");
+    const btn = wrapper.find("button").at(1);
+    expect(btn.text()).toEqual("Delete");
+    btn.simulate("click");
     expect(p.onDestroy).toHaveBeenCalledWith("Plant.0.0");
   });
 
   it("renders", () => {
-    const wrapper = shallow(<PlantPanel info={info} />);
+    const wrapper = shallow(<PlantPanel info={info} dispatch={jest.fn()} />);
     const txt = wrapper.text().toLowerCase();
     expect(txt).toContain("1 days old");
     expect(txt).toContain("(12, 34)");
   });
 
   it("enters select mode", () => {
-    const wrapper = shallow(<PlantPanel info={info} />);
+    const wrapper = shallow(<PlantPanel info={info} dispatch={jest.fn()} />);
     const btn = wrapper.find("button").last();
     btn.simulate("click");
     expect(btn.text()).toEqual("Delete multiple");
     expect(mockHistory).toHaveBeenCalledWith("/app/designer/plants/select");
+  });
+
+  it("navigates to 'move to' mode", () => {
+    const dispatch = jest.fn();
+    const wrapper = shallow(<PlantPanel info={info} dispatch={dispatch} />);
+    const btn = wrapper.find("button").first();
+    btn.simulate("click");
+    expect(btn.text()).toEqual("Move FarmBot to this plant");
+    expect(mockHistory).toHaveBeenCalledWith("/app/designer/plants/move_to");
+    expect(dispatch).toHaveBeenCalledWith({
+      payload: { "x": 12, "y": 34, "z": undefined },
+      type: Actions.CHOOSE_LOCATION
+    });
   });
 });
 

--- a/webpack/farm_designer/plants/crop_info.tsx
+++ b/webpack/farm_designer/plants/crop_info.tsx
@@ -10,6 +10,8 @@ import { Everything } from "../../interfaces";
 import { OpenFarm } from "../openfarm";
 import { OFSearch } from "../util";
 import { unselectPlant, setDragIcon } from "../actions";
+import { validBotLocationData } from "../../util";
+import { createPlant } from "../map/garden_map";
 
 interface InforFieldProps {
   title: string;
@@ -28,6 +30,73 @@ function InfoField(props: InforFieldProps) {
   </li>;
 }
 
+const CropInfoList = (crop: OpenFarm.OFCrop) => {
+  return <div className="object-list">
+    <ul>
+      {_(crop)
+        .omit([
+          "slug",
+          "processing_pictures",
+          "description",
+          "main_image_path",
+          "tags_array",
+          "guides_count"
+        ])
+        .toPairs()
+        .map((pair: string, i: number) => {
+          const field = pair[0];
+          const value = pair[1];
+          switch (field) {
+            case "svg_icon":
+              /**
+              * If there's a value, give it an img element to render the
+              * actual graphic. If no value, return "Not Set".
+              */
+              return <InfoField key={i} title={field}>
+                {value
+                  ? <div>
+                    <img
+                      src={svgToUrl(value)}
+                      width={100}
+                      height={100}
+                      onDragStart={setDragIcon(value)} />
+                  </div>
+                  : <span>
+                    {t("Not Set")}
+                  </span>
+                }
+              </InfoField>;
+            /**
+             * Need to convert the `cm` provided by OpenFarm to `mm`
+             * to match the Farm Designer units.
+             */
+            case "spread":
+            case "row_spacing":
+            case "height":
+              return <InfoField key={i} title={field}>
+                {!isNaN(parseInt(value))
+                  ? (parseInt(value) * 10) + t("mm")
+                  : undefined || t("Not Set")}
+              </InfoField>;
+            case "common_names":
+              return <InfoField key={i} title={field}>
+                {_.isArray(value)
+                  ? value.join(", ")
+                  : value || t("Not Set")}
+              </InfoField>;
+            /**
+             * Default behavior for all other properties.
+             */
+            default:
+              return <InfoField key={i} title={field}>
+                {value || t("Not Set")}
+              </InfoField>;
+          }
+        }).value()}
+    </ul>
+  </div>;
+};
+
 export function mapStateToProps(props: Everything): CropInfoProps {
   return {
     OFSearch,
@@ -36,7 +105,8 @@ export function mapStateToProps(props: Everything): CropInfoProps {
       .resources
       .consumers
       .farm_designer
-      .cropSearchResults || []
+      .cropSearchResults || [],
+    botPosition: validBotLocationData(props.bot.hardware.location_data).position
   };
 }
 
@@ -47,6 +117,15 @@ export class CropInfo extends React.Component<CropInfoProps, {}> {
     const crop = getPathArray()[5];
     OFSearch(crop)(this.props.dispatch);
     unselectPlant(this.props.dispatch)();
+  }
+
+  get botXY(): Record<"x" | "y", number> | undefined {
+    const { x, y } = this.props.botPosition;
+    return _.isNumber(x) && _.isNumber(y) ? { x, y } : undefined;
+  }
+
+  get botXYLabel(): string {
+    return this.botXY ? `(${this.botXY.x}, ${this.botXY.y})` : "(unknown)";
   }
 
   render() {
@@ -93,73 +172,17 @@ export class CropInfo extends React.Component<CropInfoProps, {}> {
           target="_blank">
           OpenFarm
         </a>
-        <div className="object-list">
-          <ul>
-            {
-              _(result.crop)
-                .omit([
-                  "slug",
-                  "processing_pictures",
-                  "description",
-                  "main_image_path",
-                  "tags_array",
-                  "guides_count"
-                ])
-                .toPairs()
-                .map((pair: string, i: number) => {
-                  const field = pair[0];
-                  const value = pair[1];
-                  switch (field) {
-                    case "svg_icon":
-                      /**
-                      * If there's a value, give it an img element to render the
-                      * actual graphic. If no value, return "Not Set".
-                      */
-                      return <InfoField key={i} title={field}>
-                        {value ?
-                          <div>
-                            <img
-                              src={svgToUrl(value)}
-                              width={100}
-                              height={100}
-                              onDragStart={setDragIcon(value)} />
-                          </div>
-                          :
-                          <span>
-                            {t("Not Set")}
-                          </span>
-                        }
-                      </InfoField>;
-                    /**
-                     * Need to convert the `cm` provided by OpenFarm to `mm`
-                     * to match the Farm Designer units.
-                     */
-                    case "spread":
-                    case "row_spacing":
-                    case "height":
-                      return <InfoField key={i} title={field}>
-                        {!isNaN(parseInt(value))
-                          ? (parseInt(value) * 10) + t("mm")
-                          : undefined || t("Not Set")}
-                      </InfoField>;
-                    case "common_names":
-                      return <InfoField key={i} title={field}>
-                        {_.isArray(value)
-                          ? value.join(", ")
-                          : value || t("Not Set")}
-                      </InfoField>;
-                    /**
-                     * Default behavior for all other properties.
-                     */
-                    default:
-                      return <InfoField key={i} title={field}>
-                        {value || t("Not Set")}
-                      </InfoField>;
-                  }
-                }).value()
+        <CropInfoList {...result.crop} />
+        <button className="fb-button gray" disabled={!this.botXY}
+          onClick={() => {
+            if (this.botXY) {
+              createPlant(result.crop.name, result.crop.slug,
+                this.botXY, undefined, this.props.dispatch);
             }
-          </ul>
-        </div>
+          }}>
+          {t("Add plant at current FarmBot location {{coordinate}}",
+            { coordinate: this.botXYLabel })}
+        </button>
       </div>
     </div>;
   }

--- a/webpack/farm_designer/plants/edit_plant_info.tsx
+++ b/webpack/farm_designer/plants/edit_plant_info.tsx
@@ -24,7 +24,8 @@ export class EditPlantInfo extends PlantInfoBase {
       <PlantPanel
         info={info}
         onDestroy={this.destroy}
-        updatePlant={this.updatePlant} />
+        updatePlant={this.updatePlant}
+        dispatch={this.props.dispatch} />
     </div>;
   }
 

--- a/webpack/farm_designer/plants/move_to.tsx
+++ b/webpack/farm_designer/plants/move_to.tsx
@@ -20,29 +20,21 @@ export function mapStateToProps(props: Everything) {
   };
 }
 
-export interface MoveToProps {
+export interface MoveToFormProps {
   chosenLocation: BotPosition;
   currentBotLocation: BotPosition;
+}
+
+export interface MoveToProps extends MoveToFormProps {
   dispatch: Function;
 }
 
-interface MoveToState {
+interface MoveToFormState {
   z: number | undefined;
 }
 
-@connect(mapStateToProps)
-export class MoveTo extends React.Component<MoveToProps, MoveToState> {
-  constructor(props: MoveToProps) {
-    super(props);
-    this.state = { z: undefined };
-  }
-
-  componentWillUnmount() {
-    this.props.dispatch({
-      type: Actions.CHOOSE_LOCATION,
-      payload: { x: undefined, y: undefined, z: undefined }
-    });
-  }
+export class MoveToForm extends React.Component<MoveToFormProps, MoveToFormState> {
+  state = { z: undefined };
 
   get vector(): { x: number, y: number, z: number } {
     const { chosenLocation } = this.props;
@@ -59,6 +51,53 @@ export class MoveTo extends React.Component<MoveToProps, MoveToState> {
 
   render() {
     const { x, y } = this.props.chosenLocation;
+    return <div>
+      <Row>
+        <Col xs={4}>
+          <label>{t("X AXIS")}</label>
+        </Col>
+        <Col xs={4}>
+          <label>{t("Y AXIS")}</label>
+        </Col>
+        <Col xs={4}>
+          <label>{t("Z AXIS")}</label>
+        </Col>
+      </Row>
+      <Row>
+        <Col xs={4}>
+          <input disabled value={isNumber(x) ? x : "---"} />
+        </Col>
+        <Col xs={4}>
+          <input disabled value={isNumber(y) ? y : "---"} />
+        </Col>
+        <AxisInputBox
+          onChange={(_, val: number) => this.setState({ z: val })}
+          axis={"z"}
+          value={this.state.z} />
+        <Row>
+          <button
+            onClick={() => moveAbs(this.vector)}
+            disabled={false}
+            className="fb-button gray" >
+            {t("Move to this coordinate")}
+          </button>
+        </Row>
+      </Row>
+    </div>;
+  }
+}
+
+@connect(mapStateToProps)
+export class MoveTo extends React.Component<MoveToProps, {}> {
+
+  componentWillUnmount() {
+    this.props.dispatch({
+      type: Actions.CHOOSE_LOCATION,
+      payload: { x: undefined, y: undefined, z: undefined }
+    });
+  }
+
+  render() {
     return <div
       className="panel-container green-panel move-to-panel">
       <div className="panel-header green-panel">
@@ -73,41 +112,12 @@ export class MoveTo extends React.Component<MoveToProps, MoveToState> {
             "Once selected, press button to move FarmBot to this postion. " +
             "Press the back arrow to exit.")}
         </div>
-
       </div>
 
       <div className="panel-content move-to-panel-content">
-        <Row>
-          <Col xs={4}>
-            <label>{t("X AXIS")}</label>
-          </Col>
-          <Col xs={4}>
-            <label>{t("Y AXIS")}</label>
-          </Col>
-          <Col xs={4}>
-            <label>{t("Z AXIS")}</label>
-          </Col>
-        </Row>
-        <Row>
-          <Col xs={4}>
-            <input disabled value={isNumber(x) ? x : "---"} />
-          </Col>
-          <Col xs={4}>
-            <input disabled value={isNumber(y) ? y : "---"} />
-          </Col>
-          <AxisInputBox
-            onChange={(_, val: number) => this.setState({ z: val })}
-            axis={"z"}
-            value={this.state.z} />
-          <Row>
-            <button
-              onClick={() => moveAbs(this.vector)}
-              disabled={false}
-              className="fb-button gray" >
-              {t("Move to this coordinate")}
-            </button>
-          </Row>
-        </Row>
+        <MoveToForm
+          chosenLocation={this.props.chosenLocation}
+          currentBotLocation={this.props.currentBotLocation} />
       </div>
     </div>;
   }

--- a/webpack/farm_designer/plants/plant_info.tsx
+++ b/webpack/farm_designer/plants/plant_info.tsx
@@ -36,7 +36,7 @@ export class PlantInfo extends PlantInfoBase {
           </Link>
         </p>
       </div>
-      <PlantPanel info={info} />
+      <PlantPanel info={info} dispatch={this.props.dispatch} />
     </div>;
   }
 

--- a/webpack/farm_designer/plants/plant_info.tsx
+++ b/webpack/farm_designer/plants/plant_info.tsx
@@ -11,6 +11,10 @@ import { unselectPlant } from "../actions";
 @connect(mapStateToProps)
 export class PlantInfo extends PlantInfoBase {
 
+  componentWillUnmount() {
+    unselectPlant(this.props.dispatch)();
+  }
+
   default = (plant_info: TaggedPlantPointer) => {
     const info = formatPlantInfo(plant_info);
     const { name, id } = info;

--- a/webpack/farm_designer/plants/plant_panel.tsx
+++ b/webpack/farm_designer/plants/plant_panel.tsx
@@ -9,11 +9,13 @@ import { FBSelect, DropDownItem } from "../../ui";
 import { PlantOptions } from "../interfaces";
 import { PlantStage } from "farmbot";
 import * as moment from "moment";
+import { Actions } from "../../constants";
 
 export interface PlantPanelProps {
   info: FormattedPlantInfo;
   onDestroy?(uuid: string): void;
   updatePlant?(uuid: string, update: PlantOptions): void;
+  dispatch: Function;
 }
 
 export const PLANT_STAGES: DropDownItem[] = [
@@ -62,7 +64,8 @@ export function EditPlantStatus(props: EditPlantStatusProps) {
     }} />;
 }
 
-export function PlantPanel({ info, onDestroy, updatePlant }: PlantPanelProps) {
+export function PlantPanel(props: PlantPanelProps) {
+  const { info, onDestroy, updatePlant, dispatch } = props;
   const { name, slug, plantedAt, daysOld, uuid, plantStatus } = info;
   let { x, y } = info;
   if (onDestroy) { x = round(x); y = round(y); }
@@ -129,6 +132,17 @@ export function PlantPanel({ info, onDestroy, updatePlant }: PlantPanelProps) {
         </span>
       </li>
     </ul>
+    <button className="fb-button gray"
+      hidden={true}
+      onClick={() => {
+        dispatch({
+          type: Actions.CHOOSE_LOCATION,
+          payload: { x, y, z: undefined }
+        });
+        history.push("/app/designer/plants/move_to");
+      }}>
+      {t("Move FarmBot to this plant")}
+    </button>
     <div>
       <label hidden={!onDestroy}>
         {t("Delete this plant")}
@@ -137,7 +151,7 @@ export function PlantPanel({ info, onDestroy, updatePlant }: PlantPanelProps) {
     <button
       className="fb-button red"
       hidden={!onDestroy}
-      onClick={destroy} >
+      onClick={destroy}>
       {t("Delete")}
     </button>
     <button

--- a/webpack/sequences/step_tiles/tile_execute_script.tsx
+++ b/webpack/sequences/step_tiles/tile_execute_script.tsx
@@ -29,7 +29,7 @@ export function TileExecuteScript({
 
     /** dispatch editStep for current ExecuteScript step */
     const updateStep = (executor: (stepCopy: ExecuteScript) => void) => {
-      return dispatch(editStep({
+      dispatch(editStep({
         sequence: currentSequence,
         step: currentStep,
         index: index,

--- a/webpack/sequences/step_tiles/tile_execute_script_support.tsx
+++ b/webpack/sequences/step_tiles/tile_execute_script_support.tsx
@@ -120,7 +120,7 @@ export function FarmwareInputs(props: FarmwareInputsProps) {
 
   /** Add a Farmware input pair. */
   const addStepPair = (inputPair: Pair) => () => {
-    updateStep(addOrUpdatePair(inputPair, currentStep, updateStep));
+    addOrUpdatePair(inputPair, currentStep, updateStep);
   };
 
   /** Remove a Farmware input pair. */


### PR DESCRIPTION
**Farm Designer:**
 * Add a button to the crop info panel to create a plant in the garden map at FarmBot's current position.

---

_+ refactoring, bug fixes, cleanup, comments_