### PR TITLE
Search by type

### DIFF
--- a/app/mutations/points/query.rb
+++ b/app/mutations/points/query.rb
@@ -15,6 +15,7 @@ module Points
         float    :z
         hstore   :meta
         string   :name
+        string   :pointer_type, in: Point::POINTER_KINDS
       end
 
       def execute

--- a/spec/controllers/api/points/search_spec.rb
+++ b/spec/controllers/api/points/search_spec.rb
@@ -62,5 +62,20 @@ describe Api::PointsController do
       expect(json).to be_kind_of(Array)
       expect(json.length).to eq(0)
     end
+
+    it 'filters by point_type' do
+      sign_in user
+      d = user.device
+      tool_slot       = FactoryBot.create(:tool_slot,       device: d)
+      plant           = FactoryBot.create(:plant,           device: d)
+      generic_pointer = FactoryBot.create(:generic_pointer, device: d)
+      post :search,
+            body: { pointer_type: "Plant" }.to_json,
+            params: {format: :json }
+      expect(response.status).to eq(200)
+      expect(json).to be_kind_of(Array)
+      expect(json.length).to eq(1)
+      expect(json.first[:pointer_type]).to eq("Plant")
+    end
   end
 end


### PR DESCRIPTION
# What's New?

 * Point search endpoint does not allow filtering by `pointer_type`. Now it does.