### PR TITLE
Self-Hosted Documentation Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,45 +27,15 @@ For a list of example API requests and responses, see our [reference documentati
 
 ## Prerequisites
 
-You will need the following:
+Installation requires an x86 desktop machine running a fresh installation of Ubuntu 18.
 
- 1. A Linux or Mac based machine. We do not support windows at this time.
- 0. [Docker 17.06.0-ce or greater](https://docs.docker.com/engine/installation/)
- 0. [Ruby 2..5.0](http://rvm.io/rvm/install)
- 0. [ImageMagick](https://www.imagemagick.org/script/index.php) (`brew install imagemagick` (Mac) or `sudo apt-get install imagemagick` (Ubuntu))
- 0. [Node JS >= v8.9.0](https://nodejs.org/en/download/)
- 0. [`libpq-dev` and `postgresql`](http://stackoverflow.com/questions/6040583/cant-find-the-libpq-fe-h-header-when-trying-to-install-pg-gem/6040822#6040822) and `postgresql-contrib`
- 0. `gem install bundler`
+We **do not recomend running the server on a Raspberry Pi** due to issues with ARM compilation and memory usage. **Windows is not supported** at this time.
 
-### Setup
+## Setup
 
-**NOTE:** A step-by-step setup guide for Ubuntu 17 users can be found [here](https://github.com/FarmBot/Farmbot-Web-App/blob/master/ubuntu_example.sh)
+A step-by-step setup guide for Ubuntu 18 can be found [here](https://github.com/FarmBot/Farmbot-Web-App/blob/master/ubuntu_example.sh). Installation on distributions other than Ubuntu is possible, but we do not provide installation support.
 
-Setup for non-Ubuntu users after installing the dependencies listed above:
-
- 1. `git clone https://github.com/FarmBot/Farmbot-Web-App --branch=master --depth=10`
- 0. `cd Farmbot-Web-App`
- 0. `bundle install`
- 0. `yarn install`
- 0. Database config: Copy `config/database.example.yml` to `config/database.yml` via `cp config/database.example.yml config/database.yml`
- 0. App config: **MOST IMPORTANT STEP**. Copy `config/application.example.yml` to `config/application.yml` via `mv config/application.example.yml config/application.yml`. **Please read the instructions inside the file. Replace the example values provided with real world values.**
- 0. Give permission to create a database*
- 0. `rake db:create:all db:migrate db:seed`
- 0. (optional) Verify installation with `RAILS_ENV=test rake db:create db:migrate && rspec spec` (API) and `npm run test` (Frontend).
- 0. Start server with `rails api:start`. Make sure you set an `MQTT_HOST` entry in `application.yml` pointing to the IP address or domain of  MQTT server. If you are not running the MQTT server on a separate machine, `MQTT_HOST` and `API_HOST` will point to the same server.
- 0. Start MQTT with `rails mqtt:start`. **Important note:** You may be required to enter a `sudo` password because [docker requires root access](https://docs.docker.com/engine/security/security/#docker-daemon-attack-surface).
- 0. Open [localhost:3000](http://localhost:3000).
- 0. [Raise an issue](https://github.com/FarmBot/Farmbot-Web-App/issues/new?title=Installation%20Failure) if you hit problems with any of these steps. *We can't fix issues we don't know about.*
-
-\*Give permission to `user` to create database:
-```
-sudo -u postgres psql
-CREATE USER "user" WITH SUPERUSER;
-```
-
-# Q: Is Dokku / Docker supported?
-
-Dokku (a Docker management system) is partially supported. Pull requests welcome. Please see `deployment.md` for more information.
+Installation was last tested against Ubuntu 18.04 in June of 2018. Please [Raise an issue](https://github.com/FarmBot/Farmbot-Web-App/issues/new?title=Installation%20Failure) if you hit problems with any of these steps. *We can't fix issues we don't know about.*
 
 # Config Settings (important)
 
@@ -76,8 +46,6 @@ You can accomplish this by setting the ENV variables directly from your shell / 
 See `config/application.example.yml` for a list of all the variables that must be set.
 
 **Encryption keys**: Encryption keys will be auto-generated if not present. They can be reset using `rake keys:generate`. If `ENV['RSA_KEY']` is set, it will be used in place of the `*.pem` files. Useful for environments like Heroku, where file system access is not allowed.
-
-**We can't fix issues we don't know about.** Please submit an issue if you are having trouble installing on your local machine.
 
 # Q: How can I Generate an API token?
 

--- a/ubuntu_example.sh
+++ b/ubuntu_example.sh
@@ -51,14 +51,22 @@ cp config/application.example.yml config/application.yml
 # Open `config/application.yml` in a text editor and change all the values.
 #
 # == Nothing will work if you skip this step!!! ==
-# Don't know which editor to use?
+# Don't know which text editor to use?
 # Use micro! `snap install micro --classic`
-# READ THE FILE AND CHANGE THE VALUES ^
+#
+# BE SURE TO READ `application.yml` AND CHANGE THE VALUES
 
 # Next, we need to set some things up in PostgreSQL
-# Run this command...
-  sudo -u postgres psql
-#  Now that you are in the PSQL command prompt, enter these commands:
+# Before proceeding, it is important to know your username on the machine.
+# Type the following command to determine your system username:
+whoami
+
+# ...then Run this command...
+sudo -u postgres psql
+
+#  Now that you are in the PSQL command prompt,
+#  enter the commands below. Replace your_system_username_here with the results
+#  of the `whoami` command:
 #
 #    CREATE USER "your_system_username_here" WITH SUPERUSER;
 #    \q
@@ -85,10 +93,13 @@ npm run test
 # Runs the web server in new tab, but use SAME DIRECTORY AS BEFORE. Don't worry
 # about the "MQTT server is unreachable" messages yet- we still need to start
 # MQTT (next).
-bundle exec rails api:start
+rails api:start
 
 # Run MQTT (new tab or window, SAME DIRECTORY)
-bundle exec rails mqtt:start
+rails mqtt:start
+
+# That's it! You can now visit the webserver on http://0.0.0.0:3000
+# (replace 0.0.0.0 with the IP address of your machine)
 
 # RUNNING ON PORT 80 =======================================================+
 # NEXT STEP IS OPTIONAL. DO THIS IF YOU WANT TO USE PORT 80 INSTEAD OF 3000.|


### PR DESCRIPTION
# What's New?

 * Remove Dokku support.
 * Use `ubuntu_setup.sh` as the standard/only setup procedure.
 * Minor verbiage changes.