### PR TITLE
Message Broker Updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem "tzinfo" # For validation of user selected timezone names
 gem "valid_url"
 gem "webpack-rails"
 # Still working out the bugs. - RC 5 Jul 18
-# gem "rabbitmq_http_api_client"
+gem "rabbitmq_http_api_client"
 
 group :development, :test do
   gem "thin"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,7 @@ GEM
     discard (1.0.0)
       activerecord (>= 4.2, < 6)
     docile (1.3.1)
+    effin_utf8 (1.0)
     erubi (1.7.1)
     eventmachine (1.2.7)
     excon (0.62.0)
@@ -110,8 +111,10 @@ GEM
       railties (>= 3.0.0)
     faker (1.8.7)
       i18n (>= 0.7)
-    faraday (0.15.2)
+    faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.12.2)
+      faraday (>= 0.7.4, < 1.0)
     ffi (1.9.25)
     figaro (1.1.1)
       thor (~> 0.14)
@@ -154,6 +157,7 @@ GEM
       os (~> 0.9)
       signet (~> 0.7)
     hashdiff (0.3.7)
+    hashie (3.5.7)
     httpclient (2.8.3)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
@@ -215,6 +219,12 @@ GEM
     pry-rails (0.3.6)
       pry (>= 0.10.4)
     public_suffix (3.0.2)
+    rabbitmq_http_api_client (1.9.1)
+      effin_utf8 (~> 1.0.0)
+      faraday (~> 0.13.0)
+      faraday_middleware (~> 0.12.0)
+      hashie (~> 3.5)
+      multi_json (~> 1.12)
     rack (2.0.5)
     rack-attack (5.4.0)
       rack (>= 1.0, < 3)
@@ -374,6 +384,7 @@ DEPENDENCIES
   polymorphic_constraints
   pry
   pry-rails
+  rabbitmq_http_api_client
   rack-attack
   rack-cors
   rails

--- a/app/controllers/api/rmq_utils_controller.rb
+++ b/app/controllers/api/rmq_utils_controller.rb
@@ -62,15 +62,15 @@ module Api
     def authenticate_admin
       correct_pw = password == ENV.fetch("ADMIN_PASSWORD")
       ok         = is_admin && correct_pw
-      ok         ? allow : deny
+      ok         ? allow("management", "administrator") : deny
     end
 
     def deny
       render json: "deny", status: 403
     end
 
-    def allow
-      render json: "allow"
+    def allow(*tags)
+      render json: (["allow"] + tags).join(" ")
     end
 
     def username

--- a/app/models/token_issuance.rb
+++ b/app/models/token_issuance.rb
@@ -2,8 +2,27 @@
 # expiration date).
 class TokenIssuance < ApplicationRecord
   belongs_to :device
+  after_destroy :maybe_evict_clients
 
   def broadcast?
     false
+  end
+
+  # PROBLEM:
+  #     A token issuance was destroyed, but people are still on the broker using
+  #     a revoked token.
+  #
+  # COMPLICATED SOLUTION:
+  #     Track the JTI of all users and selectively boot only the users that have
+  #     an expired JTI. This requires external caching and session storage.
+  #
+  # SIMPLE SOLUTION:
+  #     Kick _everyone_ off the broker. The clients with the revoked token will
+  #     not be able to reconnect.
+  #
+  # TODO:
+  #     Move this into a background worker.
+  def maybe_evict_clients
+    Transport::Mgmt.try(:close_connections_for_username, "device_#{device_id}")
   end
 end

--- a/app/models/token_issuance.rb
+++ b/app/models/token_issuance.rb
@@ -25,6 +25,6 @@ class TokenIssuance < ApplicationRecord
   def maybe_evict_clients
     Transport::Mgmt.try(:close_connections_for_username, "device_#{device_id}")
   rescue Faraday::ConnectionFailed
-    nil
+    Rollbar.error("Failed to evict clients on token revocation")
   end
 end

--- a/app/models/token_issuance.rb
+++ b/app/models/token_issuance.rb
@@ -24,5 +24,7 @@ class TokenIssuance < ApplicationRecord
   #     Move this into a background worker.
   def maybe_evict_clients
     Transport::Mgmt.try(:close_connections_for_username, "device_#{device_id}")
+  rescue Faraday::ConnectionFailed
+    nil
   end
 end

--- a/app/models/transport.rb
+++ b/app/models/transport.rb
@@ -65,10 +65,6 @@ class Transport
   module Mgmt
     require "rabbitmq/http/client"
 
-    def self.endpoint
-      @endpoint ||= "http://#{ENV.fetch("MQTT_HOST")}:15672"
-    end
-
     def self.username
       @username ||= URI(Transport.amqp_url).user || "admin"
     end
@@ -93,11 +89,16 @@ class Transport
                                              password: self.password)
     end
 
+    def self.connections
+      client.list_connections
+    end
+
     def self.find_connection_by_name(name)
-      client
-        .list_connections
+      connections
         .select { |x| x.fetch("user").include?(name) }
         .pluck("name")
+        .compact
+        .uniq
     end
 
     def self.close_connections_for_username(name)

--- a/app/models/transport.rb
+++ b/app/models/transport.rb
@@ -82,13 +82,15 @@ class Transport
       uri.scheme = ENV["FORCE_SSL"] ? "https" : "http"
       uri.user   = nil
       uri.port   = 15672
-      puts "=== " + uri.to_s
       uri.to_s
     end
 
     def self.client
-      @client ||= RabbitMQ::HTTP::Client.new(api_url, username: self.username,
-                                                      password: self.password)
+      url = ENV["RABBIT_MGMT_URL"] || api_url
+      puts "=== " + url
+      @client ||= RabbitMQ::HTTP::Client.new(url,
+                                             username: self.username,
+                                             password: self.password)
     end
 
     def self.find_connection_by_name(name)

--- a/app/models/transport.rb
+++ b/app/models/transport.rb
@@ -69,6 +69,14 @@ class Transport
       @endpoint ||= "http://#{ENV.fetch("MQTT_HOST")}:15672"
     end
 
+    def self.username
+      @username ||= URI(Transport.amqp_url).user || "admin"
+    end
+
+    def self.password
+      @password ||= URI(Transport.amqp_url).password
+    end
+
     def self.api_url
       uri        = URI(Transport.amqp_url)
       uri.scheme = ENV["FORCE_SSL"] ? "https" : "http"
@@ -79,9 +87,8 @@ class Transport
     end
 
     def self.client
-      @client   ||= RabbitMQ::HTTP::Client.new(api_url,
-                                            username: "admin",
-                                            password: ENV.fetch("ADMIN_PASSWORD"))
+      @client ||= RabbitMQ::HTTP::Client.new(api_url, username: self.username,
+                                                      password: self.password)
     end
 
     def self.find_connection_by_name(name)

--- a/config/application.example.yml
+++ b/config/application.example.yml
@@ -91,3 +91,8 @@ RAILS_ENV: "production"
 # Every server has a superuser.
 # Set this to something SECURE.
 ADMIN_PASSWORD: ""
+# Some hosts (Eg: FarmBot, Inc.) run the RabbitMQ management API on a
+# non-standard host.
+# Include the protocol! (http vs. https)
+# DELETE THIS LINE if you are a self-hosted user.
+RABBIT_MGMT_URL: "http://delete_this_line.com"

--- a/mqtt/rabbitmq.conf.erb
+++ b/mqtt/rabbitmq.conf.erb
@@ -1,4 +1,4 @@
-auth_backends.1           = http
+auth_backends.1           = cache
 
 auth_cache.cached_backend = http
 auth_cache.cache_ttl      = 600000

--- a/spec/lib/transport_mgmt_spec.rb
+++ b/spec/lib/transport_mgmt_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+describe Transport::Mgmt do
+  it "generates a URL" do
+    expect(Transport::Mgmt.api_url).to eq("http://blooper.io:15672")
+  end
+
+  it "finds connections by name" do
+    fake_connections = [{ "name" => "A", "user" => "1" },
+                        { "name" => "B", "user" => "2" },
+                        { "name" => "C", "user" => "3" }]
+    allow(Transport::Mgmt).to receive(:connections).and_return(fake_connections)
+    expect(Transport::Mgmt.find_connection_by_name("1")).to eq(["A"])
+  end
+end


### PR DESCRIPTION
# What's New?

 * Get off of old auth_jwt plugin
 * Use REST API for auth now.
 * Enable cache_backend and set cache interval to 10 minutes.