### PR TITLE
Token revocation bg

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,7 +141,7 @@ GEM
     formatador (0.2.5)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
-    google-api-client (0.23.1)
+    google-api-client (0.23.2)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.5, < 0.7.0)
       httpclient (>= 2.8.1, < 3.0)

--- a/app/controllers/api/tokens_controller.rb
+++ b/app/controllers/api/tokens_controller.rb
@@ -44,9 +44,7 @@ module Api
     # Every time a token is created, sweep the old TokenIssuances out of the
     # database.
     def clean_out_old_tokens
-      TokenIssuance
-        .where("exp < ?", Time.now.to_i)
-        .destroy_all
+      CleanOutOldDbItemsJob.perform_later if TokenIssuance.any_expired?
     end
 
     def if_properly_formatted

--- a/app/jobs/clean_out_old_db_items_job.rb
+++ b/app/jobs/clean_out_old_db_items_job.rb
@@ -1,0 +1,7 @@
+class CleanOutOldDbItemsJob < ApplicationJob
+  queue_as :default
+
+  def perform(*args)
+    TokenIssuance.clean_old_tokens
+  end
+end

--- a/app/models/token_issuance.rb
+++ b/app/models/token_issuance.rb
@@ -20,8 +20,12 @@ class TokenIssuance < ApplicationRecord
   #     Kick _everyone_ off the broker. The clients with the revoked token will
   #     not be able to reconnect.
   def maybe_evict_clients
-    Transport::Mgmt.try(:close_connections_for_username, "device_#{device_id}")
+    Timeout::timeout(2.5) do
+      id = "device_#{device_id}"
+      Transport::Mgmt.try(:close_connections_for_username, id)
+    end
   rescue Faraday::ConnectionFailed
+  rescue Timeout::Error
     Rollbar.error("Failed to evict clients on token revocation")
   end
 

--- a/app/models/transport.rb
+++ b/app/models/transport.rb
@@ -82,9 +82,7 @@ class Transport
     end
 
     def self.client
-      url = ENV["RABBIT_MGMT_URL"] || api_url
-      puts "=== " + url
-      @client ||= RabbitMQ::HTTP::Client.new(url,
+      @client ||= RabbitMQ::HTTP::Client.new(ENV["RABBIT_MGMT_URL"] || api_url,
                                              username: self.username,
                                              password: self.password)
     end

--- a/spec/jobs/clean_out_old_db_items_job_spec.rb
+++ b/spec/jobs/clean_out_old_db_items_job_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe CleanOutOldDbItemsJob, type: :job do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/lib/transport_mgmt_spec.rb
+++ b/spec/lib/transport_mgmt_spec.rb
@@ -9,7 +9,7 @@ describe Transport::Mgmt do
     fake_connections = [{ "name" => "A", "user" => "1" },
                         { "name" => "B", "user" => "2" },
                         { "name" => "C", "user" => "3" }]
-    allow(Transport::Mgmt).to receive(:connections).and_return(fake_connections)
-    expect(Transport::Mgmt.find_connection_by_name("1")).to eq(["A"])
+                        allow(Transport::Mgmt).to receive(:connections).and_return(fake_connections)
+                        expect(Transport::Mgmt.find_connection_by_name("1")).to eq(["A"])
   end
 end

--- a/spec/models/token_issuance_spec.rb
+++ b/spec/models/token_issuance_spec.rb
@@ -1,0 +1,10 @@
+require "spec_helper"
+
+describe TokenIssuance do
+  it "notifies admins about failed message queue evictions" do
+    allow(Transport::Mgmt)
+      .to receive(:connections).and_raise(Faraday::ConnectionFailed, "rspec")
+    allow(Rollbar).to receive(:error).and_return("OK")
+    TokenIssuance.new(device_id: 8).maybe_evict_clients
+  end
+end

--- a/spec/models/token_issuance_spec.rb
+++ b/spec/models/token_issuance_spec.rb
@@ -7,4 +7,14 @@ describe TokenIssuance do
     allow(Rollbar).to receive(:error).and_return("OK")
     TokenIssuance.new(device_id: 8).maybe_evict_clients
   end
+
+  it "clears out old stuff via #clean_old_tokens" do
+    TokenIssuance.delete_all
+    TokenIssuance.create(device_id: 8,
+                         exp: 1.year.ago.to_i,
+                         jti: "WOW")
+    expect(TokenIssuance.count).to eq(1)
+    TokenIssuance.clean_old_tokens
+    expect(TokenIssuance.count).to eq(0)
+  end
 end


### PR DESCRIPTION
# Problem

 * We need to call an external API (RabbitMQ) when revoking tokens, which is slow.

# Solution

 * Move token revocation work to a background process..

# What Else?

 * Upgrade some bundler deps.