### PR TITLE
Removal of `TaggedResource` from this repo (into FBJS)

### DIFF
--- a/app/controllers/api/device_configs_controller.rb
+++ b/app/controllers/api/device_configs_controller.rb
@@ -14,7 +14,7 @@ module Api
     end
 
     def update
-      mutate DeviceConfigs::Update.run(raw_json, config: device_config)
+      mutate DeviceConfigs::Update.run(raw_json, device_config: device_config)
     end
 
     def destroy

--- a/app/controllers/api/webcam_feeds_controller.rb
+++ b/app/controllers/api/webcam_feeds_controller.rb
@@ -15,7 +15,7 @@ module Api
     end
 
     def update
-      mutate WebcamFeeds::Update.run(params.as_json, feed: webcam)
+      mutate WebcamFeeds::Update.run(params.as_json, webcam_feed: webcam)
     end
 
     def destroy

--- a/app/mutations/device_configs/update.rb
+++ b/app/mutations/device_configs/update.rb
@@ -1,7 +1,7 @@
 module DeviceConfigs
   class Update < Mutations::Command
     required {
-      model :config, class: DeviceConfig
+      model :device_config, class: DeviceConfig
     }
 
     optional do
@@ -10,7 +10,7 @@ module DeviceConfigs
     end
 
     def execute
-      config.update_attributes!(inputs.except(:config)) && config
+      device_config.update_attributes!(inputs.except(:device_config)) && device_config
     end
   end
 end

--- a/app/mutations/webcam_feeds/update.rb
+++ b/app/mutations/webcam_feeds/update.rb
@@ -1,6 +1,6 @@
 module WebcamFeeds
   class Update < Mutations::Command
-    required { model :feed, class: WebcamFeed }
+    required { model :webcam_feed, class: WebcamFeed }
 
     optional do
       string :name
@@ -8,7 +8,7 @@ module WebcamFeeds
     end
 
     def execute
-      feed.update_attributes!(inputs.except(:feed)) && feed
+      webcam_feed.update_attributes!(inputs.except(:webcam_feed)) && webcam_feed
     end
   end
 end

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "css-loader": "1.0.0",
     "enzyme": "^3.1.0",
     "enzyme-adapter-react-16": "^1.1.0",
-    "farmbot": "https://github.com/RickCarlino/farmbot-js.git",
+    "farmbot": "6.4.2",
     "farmbot-toastr": "^1.0.3",
     "fastclick": "^1.0.6",
     "file-loader": "1.1.11",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "css-loader": "1.0.0",
     "enzyme": "^3.1.0",
     "enzyme-adapter-react-16": "^1.1.0",
-    "farmbot": "6.4.0",
+    "farmbot": "https://github.com/RickCarlino/farmbot-js.git",
     "farmbot-toastr": "^1.0.3",
     "fastclick": "^1.0.6",
     "file-loader": "1.1.11",

--- a/webpack/__test_support__/fake_resource.ts
+++ b/webpack/__test_support__/fake_resource.ts
@@ -1,10 +1,10 @@
 import {
   Resource as Res,
   ResourceName as Name,
-  TaggedResource,
   SpecialStatus
-} from "../resources/tagged_resources";
+} from "farmbot";
 import { generateUuid } from "../resources/util";
+import { TaggedResource } from "farmbot";
 
 let ID_COUNTER = 0;
 

--- a/webpack/__test_support__/fake_state/images.ts
+++ b/webpack/__test_support__/fake_state/images.ts
@@ -1,4 +1,4 @@
-import { TaggedImage, SpecialStatus } from "../../resources/tagged_resources";
+import { TaggedImage, SpecialStatus } from "farmbot";
 
 export let fakeImages: TaggedImage[] = [
   {

--- a/webpack/__test_support__/fake_state/resources.ts
+++ b/webpack/__test_support__/fake_state/resources.ts
@@ -1,17 +1,25 @@
 import { Everything } from "../../interfaces";
 import { buildResourceIndex } from "../resource_index_builder";
 import {
-  TaggedFarmEvent, TaggedSequence, TaggedRegimen, TaggedImage,
-  TaggedTool, TaggedUser, TaggedWebcamFeed,
-  TaggedPlantPointer, TaggedGenericPointer, TaggedPeripheral, TaggedFbosConfig,
-  TaggedWebAppConfig,
-  TaggedSensor,
-  TaggedFirmwareConfig,
-  TaggedPinBinding,
-  TaggedLog,
   TaggedDiagnosticDump,
-  TaggedSensorReading
-} from "../../resources/tagged_resources";
+  TaggedFarmEvent,
+  TaggedFbosConfig,
+  TaggedFirmwareConfig,
+  TaggedGenericPointer,
+  TaggedImage,
+  TaggedLog,
+  TaggedPeripheral,
+  TaggedPinBinding,
+  TaggedPlantPointer,
+  TaggedRegimen,
+  TaggedSensor,
+  TaggedSensorReading,
+  TaggedSequence,
+  TaggedTool,
+  TaggedUser,
+  TaggedWebAppConfig,
+  TaggedWebcamFeed,
+} from "farmbot";
 import { ExecutableType } from "../../farm_designer/interfaces";
 import { fakeResource } from "../fake_resource";
 import { emptyToolSlot } from "../../tools/components/empty_tool_slot";

--- a/webpack/__test_support__/resource_index_builder.ts
+++ b/webpack/__test_support__/resource_index_builder.ts
@@ -1,10 +1,12 @@
 import { resourceReducer, emptyState } from "../resources/reducer";
 import {
-  TaggedResource, TaggedDevice, TaggedPoint,
+  ResourceName,
   SpecialStatus,
+  TaggedDevice,
   TaggedLog,
-  ResourceName
-} from "../resources/tagged_resources";
+  TaggedPoint,
+  TaggedResource,
+} from "farmbot";
 import * as _ from "lodash";
 import { Actions } from "../constants";
 export function fakeDevice(): TaggedDevice {

--- a/webpack/__test_support__/user.ts
+++ b/webpack/__test_support__/user.ts
@@ -1,5 +1,5 @@
 import { User } from "../auth/interfaces";
-import { TaggedUser, SpecialStatus } from "../resources/tagged_resources";
+import { TaggedUser, SpecialStatus } from "farmbot";
 
 export let user: User = {
   created_at: "2016-10-05T03:02:58.000Z",

--- a/webpack/__tests__/resource_index_builder_test.ts
+++ b/webpack/__tests__/resource_index_builder_test.ts
@@ -2,7 +2,7 @@ import {
   buildResourceIndex,
   FAKE_RESOURCES
 } from "../__test_support__/resource_index_builder";
-import { TaggedFarmEvent, SpecialStatus } from "../resources/tagged_resources";
+import { TaggedFarmEvent, SpecialStatus } from "farmbot";
 
 const STUB_RESOURCE: TaggedFarmEvent = {
   "uuid": "FarmEvent.0.435",

--- a/webpack/account/__tests__/test_change_password.tsx
+++ b/webpack/account/__tests__/test_change_password.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { ChangePassword } from "../components/index";
 import { mount } from "enzyme";
-import { SpecialStatus } from "../../resources/tagged_resources";
+import { SpecialStatus } from "farmbot";
 import * as moxios from "moxios";
 import { API } from "../../api/api";
 import { error } from "farmbot-toastr";

--- a/webpack/account/components/change_password.tsx
+++ b/webpack/account/components/change_password.tsx
@@ -6,7 +6,7 @@ import {
   WidgetBody,
   SaveBtn
 } from "../../ui/index";
-import { SpecialStatus } from "../../resources/tagged_resources";
+import { SpecialStatus } from "farmbot";
 import Axios from "axios";
 import { API } from "../../api/index";
 import { prettyPrintApiErrors, equals, trim } from "../../util";

--- a/webpack/account/interfaces.ts
+++ b/webpack/account/interfaces.ts
@@ -1,5 +1,5 @@
 import { User } from "../auth/interfaces";
-import { TaggedUser } from "../resources/tagged_resources";
+import { TaggedUser } from "farmbot";
 
 export interface Props {
   user: TaggedUser;

--- a/webpack/api/__tests__/crud_data_tracking.ts
+++ b/webpack/api/__tests__/crud_data_tracking.ts
@@ -21,7 +21,7 @@ import { ReduxAction } from "../../redux/interfaces";
 import { maybeStartTracking } from "../maybe_start_tracking";
 import { API } from "../api";
 import { betterCompact } from "../../util";
-import { SpecialStatus } from "../../resources/tagged_resources";
+import { SpecialStatus } from "farmbot";
 import * as _ from "lodash";
 
 describe("AJAX data tracking", () => {

--- a/webpack/api/__tests__/crud_malformed_data_tests.ts
+++ b/webpack/api/__tests__/crud_malformed_data_tests.ts
@@ -14,7 +14,7 @@ jest.mock("axios", () => ({
 }));
 
 import { refresh, updateViaAjax } from "../crud";
-import { TaggedDevice, SpecialStatus } from "../../resources/tagged_resources";
+import { TaggedDevice, SpecialStatus } from "farmbot";
 import { API } from "../index";
 import { get } from "lodash";
 import { Actions } from "../../constants";

--- a/webpack/api/__tests__/crud_success_tests.ts
+++ b/webpack/api/__tests__/crud_success_tests.ts
@@ -12,7 +12,7 @@ jest.mock("axios", () => ({
 }));
 
 import { refresh } from "../crud";
-import { TaggedDevice, SpecialStatus } from "../../resources/tagged_resources";
+import { TaggedDevice, SpecialStatus } from "farmbot";
 import { API } from "../index";
 import { Actions } from "../../constants";
 import { get } from "lodash";

--- a/webpack/api/__tests__/crud_test.ts
+++ b/webpack/api/__tests__/crud_test.ts
@@ -1,6 +1,6 @@
 import { urlFor } from "../crud";
 import { API } from "../api";
-import { ResourceName } from "../../resources/tagged_resources";
+import { ResourceName } from "farmbot";
 
 describe("urlFor()", () => {
   API.setBaseUrl("");

--- a/webpack/api/__tests__/destroy_catch_tests.ts
+++ b/webpack/api/__tests__/destroy_catch_tests.ts
@@ -1,4 +1,4 @@
-import { SpecialStatus } from "../../resources/tagged_resources";
+import { SpecialStatus } from "farmbot";
 import { destroyNO } from "../../resources/actions";
 import { destroyCatch } from "../crud";
 

--- a/webpack/api/crud.ts
+++ b/webpack/api/crud.ts
@@ -1,10 +1,14 @@
 import {
-  TaggedResource,
-  ResourceName,
+  TaggedResource
+} from "farmbot";
+import {
   isTaggedResource,
-  TaggedSequence,
   SpecialStatus,
 } from "../resources/tagged_resources";
+import {
+  ResourceName,
+  TaggedSequence,
+} from "farmbot";
 import { GetState, ReduxAction } from "../redux/interfaces";
 import { API } from "./index";
 import axios from "axios";

--- a/webpack/api/crud.ts
+++ b/webpack/api/crud.ts
@@ -1,9 +1,8 @@
 import {
-  TaggedResource
+  TaggedResource, SpecialStatus
 } from "farmbot";
 import {
   isTaggedResource,
-  SpecialStatus,
 } from "../resources/tagged_resources";
 import {
   ResourceName,

--- a/webpack/api/interfaces.ts
+++ b/webpack/api/interfaces.ts
@@ -1,4 +1,4 @@
-import { SpecialStatus } from "../resources/tagged_resources";
+import { SpecialStatus } from "farmbot";
 
 export interface EditResourceParams {
   uuid: string;

--- a/webpack/api/maybe_start_tracking.ts
+++ b/webpack/api/maybe_start_tracking.ts
@@ -1,4 +1,4 @@
-import { ResourceName } from "../resources/tagged_resources";
+import { ResourceName } from "farmbot";
 import { startTracking } from "../connectivity/data_consistency";
 
 const BLACKLIST: ResourceName[] = [

--- a/webpack/app.tsx
+++ b/webpack/app.tsx
@@ -9,7 +9,7 @@ import { LoadingPlant } from "./loading_plant";
 import { BotState, Xyz } from "./devices/interfaces";
 import {
   ResourceName, TaggedUser, TaggedLog
-} from "./resources/tagged_resources";
+} from "farmbot";
 import {
   maybeFetchUser,
   maybeGetTimeOffset,

--- a/webpack/connectivity/__tests__/auto_sync_test.ts
+++ b/webpack/connectivity/__tests__/auto_sync_test.ts
@@ -6,7 +6,7 @@ import {
   handleUpdate,
   handleCreateOrUpdate
 } from "../auto_sync";
-import { SpecialStatus } from "../../resources/tagged_resources";
+import { SpecialStatus } from "farmbot";
 import { Actions } from "../../constants";
 import { fakeState } from "../../__test_support__/fake_state";
 import { GetState } from "../../redux/interfaces";

--- a/webpack/connectivity/auto_sync.ts
+++ b/webpack/connectivity/auto_sync.ts
@@ -1,8 +1,10 @@
 import { GetState } from "../redux/interfaces";
 import { maybeDetermineUuid } from "../resources/selectors";
 import {
-  ResourceName, TaggedResource, SpecialStatus
-} from "../resources/tagged_resources";
+  ResourceName,
+  TaggedResource,
+  SpecialStatus
+} from "farmbot";
 import { overwrite, init } from "../api/crud";
 import { handleInbound } from "./auto_sync_handle_inbound";
 import { SyncPayload, MqttDataResult, Reason, UpdateMqttData } from "./interfaces";

--- a/webpack/connectivity/batch_queue.ts
+++ b/webpack/connectivity/batch_queue.ts
@@ -1,4 +1,4 @@
-import { TaggedLog } from "../resources/tagged_resources";
+import { TaggedLog } from "farmbot";
 import { store } from "../redux/store";
 import { batchInitResources, bothUp } from "./connect_device";
 import { maybeGetDevice } from "../resources/selectors";

--- a/webpack/connectivity/connect_device.ts
+++ b/webpack/connectivity/connect_device.ts
@@ -17,7 +17,7 @@ import {
 } from "../devices/actions";
 import { init } from "../api/crud";
 import { AuthState } from "../auth/interfaces";
-import { TaggedResource, SpecialStatus } from "../resources/tagged_resources";
+import { TaggedResource, SpecialStatus } from "farmbot";
 import { autoSync } from "./auto_sync";
 import { startPinging } from "./ping_mqtt";
 import { talk } from "browser-speech";

--- a/webpack/connectivity/interfaces.ts
+++ b/webpack/connectivity/interfaces.ts
@@ -1,5 +1,5 @@
 import { DeviceAccountSettings } from "../devices/interfaces";
-import { ResourceName } from "../resources/tagged_resources";
+import { ResourceName } from "farmbot";
 
 export type NetworkState = "up" | "down";
 

--- a/webpack/controls/interfaces.ts
+++ b/webpack/controls/interfaces.ts
@@ -6,7 +6,7 @@ import {
   TaggedPeripheral,
   TaggedSensor,
   TaggedSensorReading
-} from "../resources/tagged_resources";
+} from "farmbot";
 import { NetworkState } from "../connectivity/interfaces";
 import { GetWebAppConfigValue } from "../config_storage/actions";
 

--- a/webpack/controls/move/interfaces.ts
+++ b/webpack/controls/move/interfaces.ts
@@ -1,6 +1,6 @@
 import { BotPosition, BotState } from "../../devices/interfaces";
 import { McuParams, Xyz } from "farmbot";
-import { TaggedUser } from "../../resources/tagged_resources";
+import { TaggedUser } from "farmbot";
 import { NetworkState } from "../../connectivity/interfaces";
 import { GetWebAppConfigValue } from "../../config_storage/actions";
 import {

--- a/webpack/controls/peripherals/__tests__/index_test.tsx
+++ b/webpack/controls/peripherals/__tests__/index_test.tsx
@@ -9,7 +9,7 @@ import { bot } from "../../../__test_support__/fake_state/bot";
 import { PeripheralsProps } from "../../../devices/interfaces";
 import { fakePeripheral } from "../../../__test_support__/fake_state/resources";
 import { clickButton } from "../../../__test_support__/helpers";
-import { SpecialStatus } from "../../../resources/tagged_resources";
+import { SpecialStatus } from "farmbot";
 import { error } from "farmbot-toastr";
 
 describe("<Peripherals />", () => {

--- a/webpack/controls/peripherals/__tests__/peripheral_form_test.tsx
+++ b/webpack/controls/peripherals/__tests__/peripheral_form_test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { mount } from "enzyme";
 import { PeripheralForm } from "../peripheral_form";
-import { TaggedPeripheral, SpecialStatus } from "../../../resources/tagged_resources";
+import { TaggedPeripheral, SpecialStatus } from "farmbot";
 
 describe("<PeripheralForm/>", function () {
   const dispatch = jest.fn();

--- a/webpack/controls/peripherals/__tests__/peripheral_list_test.tsx
+++ b/webpack/controls/peripherals/__tests__/peripheral_list_test.tsx
@@ -8,7 +8,10 @@ jest.mock("../../../device", () => ({
 import * as React from "react";
 import { mount } from "enzyme";
 import { PeripheralList } from "../peripheral_list";
-import { TaggedPeripheral, SpecialStatus } from "../../../resources/tagged_resources";
+import {
+  TaggedPeripheral,
+  SpecialStatus
+} from "farmbot";
 import { Pins } from "farmbot/dist";
 
 describe("<PeripheralList/>", function () {

--- a/webpack/controls/peripherals/index.tsx
+++ b/webpack/controls/peripherals/index.tsx
@@ -7,7 +7,11 @@ import { Widget, WidgetBody, WidgetHeader, SaveBtn } from "../../ui/index";
 import { PeripheralsProps } from "../../devices/interfaces";
 import { PeripheralState } from "./interfaces";
 import {
-  TaggedPeripheral, getArrayStatus, SpecialStatus
+  TaggedPeripheral,
+} from "farmbot";
+import {
+  getArrayStatus,
+  SpecialStatus
 } from "../../resources/tagged_resources";
 import { saveAll, init } from "../../api/crud";
 import { ToolTips } from "../../constants";

--- a/webpack/controls/peripherals/index.tsx
+++ b/webpack/controls/peripherals/index.tsx
@@ -7,11 +7,10 @@ import { Widget, WidgetBody, WidgetHeader, SaveBtn } from "../../ui/index";
 import { PeripheralsProps } from "../../devices/interfaces";
 import { PeripheralState } from "./interfaces";
 import {
-  TaggedPeripheral,
+  TaggedPeripheral, SpecialStatus,
 } from "farmbot";
 import {
   getArrayStatus,
-  SpecialStatus
 } from "../../resources/tagged_resources";
 import { saveAll, init } from "../../api/crud";
 import { ToolTips } from "../../constants";

--- a/webpack/controls/peripherals/interfaces.ts
+++ b/webpack/controls/peripherals/interfaces.ts
@@ -1,4 +1,4 @@
-import { TaggedPeripheral } from "../../resources/tagged_resources";
+import { TaggedPeripheral } from "farmbot";
 import { Pins } from "farmbot/dist";
 
 export interface PeripheralState {

--- a/webpack/controls/sensor_readings/filter_readings.ts
+++ b/webpack/controls/sensor_readings/filter_readings.ts
@@ -1,4 +1,4 @@
-import { TaggedSensorReading } from "../../resources/tagged_resources";
+import { TaggedSensorReading } from "farmbot";
 import { SensorReadingsState } from "./interfaces";
 import { every, isNumber } from "lodash";
 import { Xyz } from "../../devices/interfaces";

--- a/webpack/controls/sensor_readings/interfaces.ts
+++ b/webpack/controls/sensor_readings/interfaces.ts
@@ -1,4 +1,4 @@
-import { TaggedSensorReading, TaggedSensor } from "../../resources/tagged_resources";
+import { TaggedSensorReading, TaggedSensor } from "farmbot";
 import { AxisInputBoxGroupState } from "../interfaces";
 
 export interface SensorReadingsProps {

--- a/webpack/controls/sensor_readings/sensor_readings.tsx
+++ b/webpack/controls/sensor_readings/sensor_readings.tsx
@@ -10,7 +10,7 @@ import { LocationSelection, LocationDisplay } from "./location_selection";
 import { SensorSelection } from "./sensor_selection";
 import { ToolTips } from "../../constants";
 import { t } from "i18next";
-import { TaggedSensor } from "../../resources/tagged_resources";
+import { TaggedSensor } from "farmbot";
 import { AxisInputBoxGroupState } from "../interfaces";
 import { SensorReadingsPlot } from "./graph";
 

--- a/webpack/controls/sensor_readings/sensor_selection.tsx
+++ b/webpack/controls/sensor_readings/sensor_selection.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { FBSelect, DropDownItem } from "../../ui";
 import { t } from "i18next";
-import { TaggedSensor } from "../../resources/tagged_resources";
+import { TaggedSensor } from "farmbot";
 import { SensorSelectionProps } from "./interfaces";
 
 const ALL_CHOICE: DropDownItem = { label: t("All"), value: "" };

--- a/webpack/controls/sensor_readings/time_period_selection.tsx
+++ b/webpack/controls/sensor_readings/time_period_selection.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { FBSelect, Row, Col, BlurableInput } from "../../ui";
 import { t } from "i18next";
 import * as moment from "moment";
-import { TaggedSensorReading } from "../../resources/tagged_resources";
+import { TaggedSensorReading } from "farmbot";
 import { TimePeriodSelectionProps, DateDisplayProps } from "./interfaces";
 import { cloneDeep } from "lodash";
 

--- a/webpack/controls/sensors/__tests__/index_test.tsx
+++ b/webpack/controls/sensors/__tests__/index_test.tsx
@@ -10,7 +10,7 @@ import { SensorsProps } from "../../../devices/interfaces";
 import { fakeSensor } from "../../../__test_support__/fake_state/resources";
 import { error } from "farmbot-toastr";
 import { clickButton } from "../../../__test_support__/helpers";
-import { SpecialStatus } from "../../../resources/tagged_resources";
+import { SpecialStatus } from "farmbot";
 
 describe("<Sensors />", () => {
   function fakeProps(): SensorsProps {

--- a/webpack/controls/sensors/index.tsx
+++ b/webpack/controls/sensors/index.tsx
@@ -7,7 +7,11 @@ import { Widget, WidgetBody, WidgetHeader, SaveBtn } from "../../ui/index";
 import { SensorsProps } from "../../devices/interfaces";
 import { SensorState } from "./interfaces";
 import {
-  TaggedSensor, getArrayStatus, SpecialStatus
+  TaggedSensor,
+  SpecialStatus
+} from "farmbot";
+import {
+  getArrayStatus,
 } from "../../resources/tagged_resources";
 import { saveAll, init } from "../../api/crud";
 import { ToolTips } from "../../constants";

--- a/webpack/controls/sensors/interfaces.ts
+++ b/webpack/controls/sensors/interfaces.ts
@@ -1,4 +1,4 @@
-import { TaggedSensor } from "../../resources/tagged_resources";
+import { TaggedSensor } from "farmbot";
 import { Pins } from "farmbot/dist";
 
 export interface SensorState {

--- a/webpack/controls/webcam/__tests__/edit_test.tsx
+++ b/webpack/controls/webcam/__tests__/edit_test.tsx
@@ -3,7 +3,7 @@ import { fakeWebcamFeed } from "../../../__test_support__/fake_state/resources";
 import { mount } from "enzyme";
 import { props } from "../test_helpers";
 import { Edit } from "../edit";
-import { SpecialStatus } from "../../../resources/tagged_resources";
+import { SpecialStatus } from "farmbot";
 import { clickButton } from "../../../__test_support__/helpers";
 import { WebcamPanelProps } from "../interfaces";
 

--- a/webpack/controls/webcam/__tests__/index_test.tsx
+++ b/webpack/controls/webcam/__tests__/index_test.tsx
@@ -7,7 +7,7 @@ import { mount } from "enzyme";
 import { WebcamPanel, preToggleCleanup } from "../index";
 import { fakeWebcamFeed } from "../../../__test_support__/fake_state/resources";
 import { destroy, save } from "../../../api/crud";
-import { SpecialStatus } from "../../../resources/tagged_resources";
+import { SpecialStatus } from "farmbot";
 import { clickButton, allButtonText } from "../../../__test_support__/helpers";
 
 describe("<WebcamPanel/>", () => {

--- a/webpack/controls/webcam/edit.tsx
+++ b/webpack/controls/webcam/edit.tsx
@@ -4,7 +4,7 @@ import { t } from "i18next";
 import { ToolTips } from "../../constants";
 import { WebcamPanelProps } from "./interfaces";
 import { KeyValEditRow } from "../key_val_edit_row";
-import { SpecialStatus, TaggedWebcamFeed } from "../../resources/tagged_resources";
+import { SpecialStatus, TaggedWebcamFeed } from "farmbot";
 import * as _ from "lodash";
 
 export function sortedFeeds(feeds: TaggedWebcamFeed[]): TaggedWebcamFeed[] {

--- a/webpack/controls/webcam/index.tsx
+++ b/webpack/controls/webcam/index.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { Show } from "./show";
 import { Edit } from "./edit";
 import { WebcamPanelProps } from "./interfaces";
-import { TaggedWebcamFeed, SpecialStatus } from "../../resources/tagged_resources";
+import { TaggedWebcamFeed, SpecialStatus } from "farmbot";
 import { edit, save, destroy, init } from "../../api/crud";
 
 type S = { activeMenu: "edit" | "show" };

--- a/webpack/controls/webcam/interfaces.ts
+++ b/webpack/controls/webcam/interfaces.ts
@@ -1,4 +1,4 @@
-import { TaggedWebcamFeed } from "../../resources/tagged_resources";
+import { TaggedWebcamFeed } from "farmbot";
 
 export interface WebcamPanelProps {
   onToggle(): void;

--- a/webpack/controls/webcam/test_helpers.tsx
+++ b/webpack/controls/webcam/test_helpers.tsx
@@ -1,4 +1,4 @@
-import { TaggedWebcamFeed } from "../../resources/tagged_resources";
+import { TaggedWebcamFeed } from "farmbot";
 import { WebcamPanelProps } from "./interfaces";
 
 export const props = (feeds: TaggedWebcamFeed[]): WebcamPanelProps => {

--- a/webpack/devices/__tests__/actions_test.ts
+++ b/webpack/devices/__tests__/actions_test.ts
@@ -47,7 +47,7 @@ import { Actions } from "../../constants";
 import { buildResourceIndex } from "../../__test_support__/resource_index_builder";
 import { API } from "../../api/index";
 import axios from "axios";
-import { SpecialStatus } from "../../resources/tagged_resources";
+import { SpecialStatus } from "farmbot";
 import { McuParamName } from "farmbot";
 import { bot } from "../../__test_support__/fake_state/bot";
 import { success, error, warning, info } from "farmbot-toastr";

--- a/webpack/devices/__tests__/state_to_props_test.tsx
+++ b/webpack/devices/__tests__/state_to_props_test.tsx
@@ -11,7 +11,7 @@ jest.mock("../../resources/selectors_by_kind", () => ({
 
 import { mapStateToProps } from "../state_to_props";
 import { fakeState } from "../../__test_support__/fake_state";
-import { TaggedFbosConfig, TaggedImage } from "../../resources/tagged_resources";
+import { TaggedFbosConfig, TaggedImage } from "farmbot";
 
 describe("mapStateToProps()", () => {
   it("uses the API as the source of FBOS settings", () => {

--- a/webpack/devices/actions.ts
+++ b/webpack/devices/actions.ts
@@ -14,7 +14,7 @@ import { ControlPanelState } from "../devices/interfaces";
 import { API } from "../api/index";
 import { User } from "../auth/interfaces";
 import { getDeviceAccountSettings, getFirmwareConfig } from "../resources/selectors";
-import { TaggedDevice, TaggedFirmwareConfig } from "../resources/tagged_resources";
+import { TaggedDevice, TaggedFirmwareConfig } from "farmbot";
 import { oneOf, versionOK, trim } from "../util";
 import { Actions, Content } from "../constants";
 import { mcuParamValidator } from "./update_interceptor";

--- a/webpack/devices/components/__tests__/farmbot_os_settings_test.tsx
+++ b/webpack/devices/components/__tests__/farmbot_os_settings_test.tsx
@@ -13,7 +13,7 @@ import { fakeResource } from "../../../__test_support__/fake_resource";
 import { FarmbotOsProps } from "../../interfaces";
 import axios from "axios";
 import { Actions } from "../../../constants";
-import { SpecialStatus } from "../../../resources/tagged_resources";
+import { SpecialStatus } from "farmbot";
 
 describe("<FarmbotOsSettings/>", () => {
   beforeEach(() => {

--- a/webpack/devices/components/diagnostic_dump_row.tsx
+++ b/webpack/devices/components/diagnostic_dump_row.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { Row, Col } from "../../ui";
-import { TaggedDiagnosticDump } from "../../resources/tagged_resources";
+import { TaggedDiagnosticDump } from "farmbot";
 import { jsonDownload } from "../../account/request_account_export";
 import { destroy } from "../../api/crud";
 import { ago } from "../connectivity/status_checks";

--- a/webpack/devices/components/fbos_settings/__tests__/last_seen_row_test.tsx
+++ b/webpack/devices/components/fbos_settings/__tests__/last_seen_row_test.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { fakeResource } from "../../../../__test_support__/fake_resource";
 import { LastSeen, LastSeenProps } from "../last_seen_row";
 import { mount } from "enzyme";
-import { SpecialStatus } from "../../../../resources/tagged_resources";
+import { SpecialStatus } from "farmbot";
 
 describe("<LastSeen/>", () => {
   const resource = () => fakeResource("Device", {
@@ -28,7 +28,7 @@ describe("<LastSeen/>", () => {
   });
 
   it("tells you the device has never been seen", () => {
-    const wrapper = mount(<LastSeen {...props() } />);
+    const wrapper = mount(<LastSeen {...props()} />);
     expect(wrapper.text()).toContain("network connectivity issue");
   });
 

--- a/webpack/devices/components/fbos_settings/last_seen_row.tsx
+++ b/webpack/devices/components/fbos_settings/last_seen_row.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { Row, Col } from "../../../ui/index";
 import { t } from "i18next";
 import * as moment from "moment";
-import { TaggedDevice } from "../../../resources/tagged_resources";
+import { TaggedDevice } from "farmbot";
 import { ColWidth } from "../farmbot_os_settings";
 
 export interface LastSeenProps {

--- a/webpack/devices/components/hardware_settings.tsx
+++ b/webpack/devices/components/hardware_settings.tsx
@@ -13,7 +13,7 @@ import { SpacePanelHeader } from "./hardware_settings/space_panel_header";
 import {
   HomingAndCalibration
 } from "./hardware_settings/homing_and_calibration";
-import { SpecialStatus } from "../../resources/tagged_resources";
+import { SpecialStatus } from "farmbot";
 import { Popover, Position } from "@blueprintjs/core";
 import { FwParamExportMenu } from "./hardware_settings/export_menu";
 

--- a/webpack/devices/components/send_diagnostic_report.tsx
+++ b/webpack/devices/components/send_diagnostic_report.tsx
@@ -5,7 +5,7 @@ import { t } from "i18next";
 import { Collapse } from "@blueprintjs/core";
 import { Header } from "./hardware_settings/header";
 import { ShouldDisplay, Feature } from "../interfaces";
-import { TaggedDiagnosticDump } from "../../resources/tagged_resources";
+import { TaggedDiagnosticDump } from "farmbot";
 import { DiagnosticDumpRow } from "./diagnostic_dump_row";
 import { requestDiagnostic } from "../actions";
 import { Content } from "../../constants";

--- a/webpack/devices/connectivity/__tests__/index_test.tsx
+++ b/webpack/devices/connectivity/__tests__/index_test.tsx
@@ -3,7 +3,7 @@ import { render, mount } from "enzyme";
 import { ConnectivityPanel } from "../index";
 import { StatusRowProps } from "../connectivity_row";
 import * as _ from "lodash";
-import { SpecialStatus } from "../../../resources/tagged_resources";
+import { SpecialStatus } from "farmbot";
 import { bot } from "../../../__test_support__/fake_state/bot";
 
 describe("<ConnectivityPanel/>", () => {

--- a/webpack/devices/connectivity/__tests__/retry_btn_test.tsx
+++ b/webpack/devices/connectivity/__tests__/retry_btn_test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { shallow } from "enzyme";
 import { RetryBtn } from "../retry_btn";
-import { SpecialStatus } from "../../../resources/tagged_resources";
+import { SpecialStatus } from "farmbot";
 
 describe("<RetryBtn/>", () => {
   it("is green before saving", () => {

--- a/webpack/devices/connectivity/index.tsx
+++ b/webpack/devices/connectivity/index.tsx
@@ -3,7 +3,7 @@ import { Widget, WidgetHeader, WidgetBody, Row, Col } from "../../ui/index";
 import { t } from "i18next";
 import { ConnectivityRow, StatusRowProps } from "./connectivity_row";
 import { RetryBtn } from "./retry_btn";
-import { SpecialStatus } from "../../resources/tagged_resources";
+import { SpecialStatus } from "farmbot";
 import { ConnectivityDiagram } from "./diagram";
 import { ToolTips } from "../../constants";
 import {

--- a/webpack/devices/connectivity/retry_btn.tsx
+++ b/webpack/devices/connectivity/retry_btn.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { SpecialStatus } from "../../resources/tagged_resources";
+import { SpecialStatus } from "farmbot";
 import { t } from "i18next";
 
 interface RetryBtnProps {
@@ -16,5 +16,5 @@ export function RetryBtn(props: RetryBtnProps) {
     className={css + " fb-button"}
     onClick={props.onClick}>
     {t("Check Again")}
-</button>;
+  </button>;
 }

--- a/webpack/devices/interfaces.ts
+++ b/webpack/devices/interfaces.ts
@@ -6,10 +6,10 @@ import {
   TaggedPeripheral,
   TaggedDevice,
   TaggedSensor,
-  TaggedDiagnosticDump
-} from "../resources/tagged_resources";
+  TaggedDiagnosticDump,
+  TaggedUser
+} from "farmbot";
 import { ResourceIndex } from "../resources/interfaces";
-import { TaggedUser } from "../resources/tagged_resources";
 import { WD_ENV } from "../farmware/weed_detector/remote_env/interfaces";
 import { ConnectionStatus, ConnectionState, NetworkState } from "../connectivity/interfaces";
 import { IntegerSize } from "../util";

--- a/webpack/devices/pin_bindings/__tests__/pin_binding_input_group_test.tsx
+++ b/webpack/devices/pin_bindings/__tests__/pin_binding_input_group_test.tsx
@@ -15,7 +15,7 @@ import { mount, shallow } from "enzyme";
 import {
   buildResourceIndex
 } from "../../../__test_support__/resource_index_builder";
-import { TaggedSequence } from "../../../resources/tagged_resources";
+import { TaggedSequence } from "farmbot";
 import {
   fakeSequence
 } from "../../../__test_support__/fake_state/resources";

--- a/webpack/devices/pin_bindings/__tests__/pin_bindings_list_test.tsx
+++ b/webpack/devices/pin_bindings/__tests__/pin_bindings_list_test.tsx
@@ -27,7 +27,7 @@ import { mount } from "enzyme";
 import {
   buildResourceIndex
 } from "../../../__test_support__/resource_index_builder";
-import { TaggedSequence } from "../../../resources/tagged_resources";
+import { TaggedSequence } from "farmbot";
 import {
   fakeSequence, fakePinBinding
 } from "../../../__test_support__/fake_state/resources";

--- a/webpack/devices/pin_bindings/tagged_pin_binding_init.tsx
+++ b/webpack/devices/pin_bindings/tagged_pin_binding_init.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {
   PinBindingType, PinBindingSpecialAction, PinBinding, PinBindingListItems
 } from "./interfaces";
-import { TaggedPinBinding, SpecialStatus } from "../../resources/tagged_resources";
+import { TaggedPinBinding, SpecialStatus } from "farmbot";
 import { ShouldDisplay, Feature } from "../interfaces";
 import { stockPinBindings } from "./list_and_label_support";
 import { initSave } from "../../api/crud";

--- a/webpack/farm_designer/farm_events/__tests__/edit_fe_form_test.tsx
+++ b/webpack/farm_designer/farm_events/__tests__/edit_fe_form_test.tsx
@@ -21,7 +21,7 @@ import {
 } from "../edit_fe_form";
 import { isString } from "lodash";
 import { repeatOptions } from "../map_state_to_props_add_edit";
-import { SpecialStatus } from "../../../resources/tagged_resources";
+import { SpecialStatus } from "farmbot";
 import { success, error } from "farmbot-toastr";
 import * as moment from "moment";
 import { fakeState } from "../../../__test_support__/fake_state";

--- a/webpack/farm_designer/farm_events/add_farm_event.tsx
+++ b/webpack/farm_designer/farm_events/add_farm_event.tsx
@@ -14,7 +14,7 @@ import {
   ExecutableType
 } from "../interfaces";
 import { BackArrow } from "../../ui/index";
-import { SpecialStatus } from "../../resources/tagged_resources";
+import { SpecialStatus } from "farmbot";
 
 interface State {
   uuid: string;

--- a/webpack/farm_designer/farm_events/calendar/selectors.ts
+++ b/webpack/farm_designer/farm_events/calendar/selectors.ts
@@ -6,7 +6,7 @@ import {
   indexRegimenById
 } from "../../../resources/selectors";
 import { betterCompact } from "../../../util";
-import { TaggedFarmEvent } from "../../../resources/tagged_resources";
+import { TaggedFarmEvent } from "farmbot";
 
 export function joinFarmEventsToExecutable(input: ResourceIndex): FarmEventWithExecutable[] {
   const farmEvents: TaggedFarmEvent[] = selectAllFarmEvents(input);

--- a/webpack/farm_designer/farm_events/edit_farm_event.tsx
+++ b/webpack/farm_designer/farm_events/edit_farm_event.tsx
@@ -3,7 +3,7 @@ import { AddEditFarmEventProps } from "../interfaces";
 import { connect } from "react-redux";
 import { mapStateToPropsAddEdit } from "./map_state_to_props_add_edit";
 import { history } from "../../history";
-import { TaggedFarmEvent } from "../../resources/tagged_resources";
+import { TaggedFarmEvent } from "farmbot";
 import { EditFEForm } from "./edit_fe_form";
 import { t } from "i18next";
 

--- a/webpack/farm_designer/farm_events/edit_fe_form.tsx
+++ b/webpack/farm_designer/farm_events/edit_fe_form.tsx
@@ -4,7 +4,7 @@ import { t } from "i18next";
 import { success, error } from "farmbot-toastr";
 import {
   TaggedFarmEvent, SpecialStatus, TaggedSequence, TaggedRegimen
-} from "../../resources/tagged_resources";
+} from "farmbot";
 import {
   TimeUnit, ExecutableQuery, ExecutableType, FarmEvent
 } from "../interfaces";

--- a/webpack/farm_designer/farm_events/map_state_to_props_add_edit.ts
+++ b/webpack/farm_designer/farm_events/map_state_to_props_add_edit.ts
@@ -21,7 +21,7 @@ import {
   TaggedFarmEvent,
   TaggedSequence,
   TaggedRegimen
-} from "../../resources/tagged_resources";
+} from "farmbot";
 import { DropDownItem } from "../../ui/index";
 import {
   validFbosConfig, shouldDisplay, determineInstalledOsVersion

--- a/webpack/farm_designer/farm_events/util.ts
+++ b/webpack/farm_designer/farm_events/util.ts
@@ -1,4 +1,4 @@
-import { TaggedFarmEvent } from "../../resources/tagged_resources";
+import { TaggedFarmEvent } from "farmbot";
 import * as moment from "moment";
 
 /**

--- a/webpack/farm_designer/interfaces.ts
+++ b/webpack/farm_designer/interfaces.ts
@@ -8,7 +8,7 @@ import {
   TaggedGenericPointer,
   TaggedPlantPointer,
   TaggedImage,
-} from "../resources/tagged_resources";
+} from "farmbot";
 import { PlantPointer } from "../interfaces";
 import { SlotWithTool } from "../resources/interfaces";
 import { BotPosition, StepsPerMmXY, BotLocationData } from "../devices/interfaces";

--- a/webpack/farm_designer/interfaces.ts
+++ b/webpack/farm_designer/interfaces.ts
@@ -7,14 +7,13 @@ import {
   TaggedRegimen,
   TaggedGenericPointer,
   TaggedPlantPointer,
-  TaggedCrop,
   TaggedImage,
 } from "../resources/tagged_resources";
 import { PlantPointer } from "../interfaces";
 import { SlotWithTool } from "../resources/interfaces";
 import { BotPosition, StepsPerMmXY, BotLocationData } from "../devices/interfaces";
 import { isNumber } from "lodash";
-import { McuParams } from "farmbot/dist";
+import { McuParams, TaggedCrop } from "farmbot";
 import { AxisNumberProperty, BotSize } from "./map/interfaces";
 import { SelectionBoxData } from "./map/selection_box";
 import { BooleanConfigKey } from "../config_storage/web_app_configs";

--- a/webpack/farm_designer/map/__tests__/map_image_test.tsx
+++ b/webpack/farm_designer/map/__tests__/map_image_test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { mount } from "enzyme";
 import { MapImage, MapImageProps } from "../map_image";
-import { SpecialStatus } from "../../../resources/tagged_resources";
+import { SpecialStatus } from "farmbot";
 import { cloneDeep } from "lodash";
 import { trim } from "../../../util";
 import { fakeMapTransformProps } from "../../../__test_support__/map_transform_props";

--- a/webpack/farm_designer/map/garden_map.tsx
+++ b/webpack/farm_designer/map/garden_map.tsx
@@ -9,7 +9,7 @@ import { getPathArray } from "../../history";
 import { initSave, save, edit } from "../../api/crud";
 import {
   TaggedPlantPointer, SpecialStatus
-} from "../../resources/tagged_resources";
+} from "farmbot";
 import {
   translateScreenToGarden,
   round,

--- a/webpack/farm_designer/map/interfaces.ts
+++ b/webpack/farm_designer/map/interfaces.ts
@@ -1,8 +1,8 @@
 import {
   TaggedPlantPointer,
-  TaggedCrop,
   TaggedGenericPointer
 } from "../../resources/tagged_resources";
+import { TaggedCrop } from "farmbot";
 import { State, BotOriginQuadrant } from "../interfaces";
 import { BotPosition, BotLocationData } from "../../devices/interfaces";
 import { GetWebAppConfigValue } from "../../config_storage/actions";

--- a/webpack/farm_designer/map/interfaces.ts
+++ b/webpack/farm_designer/map/interfaces.ts
@@ -1,7 +1,7 @@
 import {
   TaggedPlantPointer,
   TaggedGenericPointer
-} from "../../resources/tagged_resources";
+} from "farmbot";
 import { TaggedCrop } from "farmbot";
 import { State, BotOriginQuadrant } from "../interfaces";
 import { BotPosition, BotLocationData } from "../../devices/interfaces";

--- a/webpack/farm_designer/map/layers/hovered_plant_layer.tsx
+++ b/webpack/farm_designer/map/layers/hovered_plant_layer.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { TaggedPlantPointer } from "../../../resources/tagged_resources";
+import { TaggedPlantPointer } from "farmbot";
 import { DesignerState } from "../../interfaces";
 import { transformXY, round } from "../util";
 import { MapTransformProps } from "../interfaces";

--- a/webpack/farm_designer/map/layers/image_layer.tsx
+++ b/webpack/farm_designer/map/layers/image_layer.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { MapTransformProps } from "../interfaces";
 import { CameraCalibrationData } from "../../interfaces";
-import { TaggedImage } from "../../../resources/tagged_resources";
+import { TaggedImage } from "farmbot";
 import { MapImage } from "../map_image";
 import { reverse, cloneDeep } from "lodash";
 import { GetWebAppConfigValue } from "../../../config_storage/actions";

--- a/webpack/farm_designer/map/layers/point_layer.tsx
+++ b/webpack/farm_designer/map/layers/point_layer.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { TaggedGenericPointer } from "../../../resources/tagged_resources";
+import { TaggedGenericPointer } from "farmbot";
 import { GardenPoint } from "../garden_point";
 import { MapTransformProps } from "../interfaces";
 

--- a/webpack/farm_designer/map/layers/spread_layer.tsx
+++ b/webpack/farm_designer/map/layers/spread_layer.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { Component } from "react";
-import { TaggedPlantPointer } from "../../../resources/tagged_resources";
+import { TaggedPlantPointer } from "farmbot";
 import { round, transformXY } from "../util";
 import { cachedCrop } from "../../../open_farm/icons";
 import { MapTransformProps } from "../interfaces";

--- a/webpack/farm_designer/map/map_image.tsx
+++ b/webpack/farm_designer/map/map_image.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { TaggedImage } from "../../resources/tagged_resources";
+import { TaggedImage } from "farmbot";
 import { CameraCalibrationData, BotOriginQuadrant } from "../interfaces";
 import { MapTransformProps } from "./interfaces";
 import { transformXY } from "./util";

--- a/webpack/farm_designer/plants/create_points.tsx
+++ b/webpack/farm_designer/plants/create_points.tsx
@@ -8,7 +8,7 @@ import {
 } from "../../ui/index";
 import { CurrentPointPayl } from "../interfaces";
 import { Actions } from "../../constants";
-import { TaggedPoint, SpecialStatus } from "../../resources/tagged_resources";
+import { TaggedPoint, SpecialStatus } from "farmbot";
 import { deletePoints } from "../../farmware/weed_detector/actions";
 import { clone } from "lodash";
 

--- a/webpack/farm_designer/plants/edit_plant_info.tsx
+++ b/webpack/farm_designer/plants/edit_plant_info.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { connect } from "react-redux";
 import { t } from "i18next";
 import { BackArrow } from "../../ui/index";
-import { TaggedPlantPointer } from "../../resources/tagged_resources";
+import { TaggedPlantPointer } from "farmbot";
 import { mapStateToProps, formatPlantInfo } from "./map_state_to_props";
 import { PlantInfoBase } from "./plant_info_base";
 import { PlantPanel } from "./plant_panel";

--- a/webpack/farm_designer/plants/map_state_to_props.tsx
+++ b/webpack/farm_designer/plants/map_state_to_props.tsx
@@ -3,7 +3,7 @@ import { Everything } from "../../interfaces";
 import { EditPlantInfoProps } from "../interfaces";
 import { maybeFindPlantById } from "../../resources/selectors";
 import { history } from "../../history";
-import { TaggedPlantPointer } from "../../resources/tagged_resources";
+import { TaggedPlantPointer } from "farmbot";
 import * as _ from "lodash";
 import { PlantStage } from "farmbot";
 

--- a/webpack/farm_designer/plants/plant_info.tsx
+++ b/webpack/farm_designer/plants/plant_info.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { connect } from "react-redux";
 import { t } from "i18next";
 import { Link } from "react-router";
-import { TaggedPlantPointer } from "../../resources/tagged_resources";
+import { TaggedPlantPointer } from "farmbot";
 import { mapStateToProps, formatPlantInfo } from "./map_state_to_props";
 import { PlantInfoBase } from "./plant_info_base";
 import { PlantPanel } from "./plant_panel";

--- a/webpack/farm_designer/plants/plant_inventory.tsx
+++ b/webpack/farm_designer/plants/plant_inventory.tsx
@@ -4,7 +4,7 @@ import { Link } from "react-router";
 import { t } from "i18next";
 import { selectAllPlantPointers } from "../../resources/selectors";
 import { PlantInventoryItem } from "./plant_inventory_item";
-import { TaggedPlantPointer } from "../../resources/tagged_resources";
+import { TaggedPlantPointer } from "farmbot";
 import { Everything } from "../../interfaces";
 import { DesignerNavTabs } from "../panel_header";
 

--- a/webpack/farm_designer/plants/plant_inventory_item.tsx
+++ b/webpack/farm_designer/plants/plant_inventory_item.tsx
@@ -3,7 +3,7 @@ import { t } from "i18next";
 import * as moment from "moment";
 import { DEFAULT_ICON, cachedCrop, svgToUrl } from "../../open_farm/icons";
 import { push } from "../../history";
-import { TaggedPlantPointer } from "../../resources/tagged_resources";
+import { TaggedPlantPointer } from "farmbot";
 import { Actions } from "../../constants";
 
 type IMGEvent = React.SyntheticEvent<HTMLImageElement>;

--- a/webpack/farm_designer/plants/select_plants.tsx
+++ b/webpack/farm_designer/plants/select_plants.tsx
@@ -3,7 +3,7 @@ import { history } from "../../history";
 import { t } from "i18next";
 import { connect } from "react-redux";
 import { Everything } from "../../interfaces";
-import { TaggedPlantPointer } from "../../resources/tagged_resources";
+import { TaggedPlantPointer } from "farmbot";
 import { selectAllPlantPointers } from "../../resources/selectors";
 import { PlantInventoryItem } from "./plant_inventory_item";
 import { destroy } from "../../api/crud";
@@ -66,7 +66,7 @@ export class SelectPlants
 
   destroySelected = (plantUUIDs: string[]) => {
     if (plantUUIDs &&
-      confirm(t("Are you sure you want to delete {{length}} plants?",  {length : plantUUIDs.length} ))) {
+      confirm(t("Are you sure you want to delete {{length}} plants?", { length: plantUUIDs.length }))) {
       plantUUIDs.map(uuid => {
         this
           .props

--- a/webpack/farm_designer/reducer.ts
+++ b/webpack/farm_designer/reducer.ts
@@ -2,7 +2,7 @@ import { CropLiveSearchResult, CurrentPointPayl } from "./interfaces";
 import { generateReducer } from "../redux/generate_reducer";
 import { DesignerState, HoveredPlantPayl } from "./interfaces";
 import { cloneDeep } from "lodash";
-import { TaggedResource } from "../resources/tagged_resources";
+import { TaggedResource } from "farmbot";
 import { Actions } from "../constants";
 import { BotPosition } from "../devices/interfaces";
 

--- a/webpack/farmware/camera_calibration/interfaces.ts
+++ b/webpack/farmware/camera_calibration/interfaces.ts
@@ -1,4 +1,4 @@
-import { TaggedImage } from "../../resources/tagged_resources";
+import { TaggedImage } from "farmbot";
 import { WD_ENV } from "../weed_detector/remote_env/interfaces";
 import { NetworkState } from "../../connectivity/interfaces";
 import { SyncStatus } from "farmbot";

--- a/webpack/farmware/images/__tests__/image_flipper_test.tsx
+++ b/webpack/farmware/images/__tests__/image_flipper_test.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { shallow, mount } from "enzyme";
 import { ImageFlipper } from "../image_flipper";
 import { fakeImages } from "../../../__test_support__/fake_state/images";
-import { TaggedImage } from "../../../resources/tagged_resources";
+import { TaggedImage } from "farmbot";
 import { defensiveClone } from "../../../util";
 
 describe("<ImageFlipper/>", () => {

--- a/webpack/farmware/images/__tests__/photos_test.tsx
+++ b/webpack/farmware/images/__tests__/photos_test.tsx
@@ -7,7 +7,7 @@ jest.mock("farmbot-toastr", () => ({ success: jest.fn() }));
 import * as React from "react";
 import { mount } from "enzyme";
 import { Photos } from "../photos";
-import { TaggedImage } from "../../../resources/tagged_resources";
+import { TaggedImage } from "farmbot";
 import { fakeImages } from "../../../__test_support__/fake_state/images";
 import { defensiveClone } from "../../../util";
 import { destroy } from "../../../api/crud";

--- a/webpack/farmware/images/interfaces.ts
+++ b/webpack/farmware/images/interfaces.ts
@@ -1,4 +1,4 @@
-import { TaggedImage } from "../../resources/tagged_resources";
+import { TaggedImage } from "farmbot";
 
 export interface Image {
   id: number;

--- a/webpack/farmware/reducer.ts
+++ b/webpack/farmware/reducer.ts
@@ -1,6 +1,6 @@
 import { generateReducer } from "../redux/generate_reducer";
 import { FarmwareState } from "./interfaces";
-import { TaggedResource } from "../resources/tagged_resources";
+import { TaggedResource } from "farmbot";
 import { Actions } from "../constants";
 
 export let farmwareState: FarmwareState = {

--- a/webpack/farmware/weed_detector/image_workspace.tsx
+++ b/webpack/farmware/weed_detector/image_workspace.tsx
@@ -4,7 +4,7 @@ import { BlurableInput, Row, Col } from "../../ui/index";
 import { ImageFlipper } from "../images/image_flipper";
 import { HSV } from "./interfaces";
 import { WeedDetectorSlider } from "./slider";
-import { TaggedImage } from "../../resources/tagged_resources";
+import { TaggedImage } from "farmbot";
 import { t } from "i18next";
 
 const RANGES = {

--- a/webpack/logs/__tests__/index_test.tsx
+++ b/webpack/logs/__tests__/index_test.tsx
@@ -28,7 +28,7 @@ import * as React from "react";
 import { mount } from "enzyme";
 import { Logs } from "../index";
 import { ToolTips } from "../../constants";
-import { TaggedLog } from "../../resources/tagged_resources";
+import { TaggedLog } from "farmbot";
 import { bot } from "../../__test_support__/fake_state/bot";
 import { Dictionary } from "farmbot";
 import { NumericSetting } from "../../session_keys";

--- a/webpack/logs/__tests__/state_to_props_test.ts
+++ b/webpack/logs/__tests__/state_to_props_test.ts
@@ -1,7 +1,7 @@
 import { mapStateToProps } from "../state_to_props";
 import { fakeState } from "../../__test_support__/fake_state";
 import { buildResourceIndex } from "../../__test_support__/resource_index_builder";
-import { TaggedLog } from "../../resources/tagged_resources";
+import { TaggedLog } from "farmbot";
 import { times } from "lodash";
 import { fakeFbosConfig, fakeLog } from "../../__test_support__/fake_state/resources";
 

--- a/webpack/logs/components/logs_table.tsx
+++ b/webpack/logs/components/logs_table.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { t } from "i18next";
-import { TaggedLog } from "../../resources/tagged_resources";
+import { TaggedLog } from "farmbot";
 import { LogsState, LogsTableProps, Filters } from "../interfaces";
 import { formatLogTime } from "../index";
 import { Classes } from "@blueprintjs/core";

--- a/webpack/logs/interfaces.ts
+++ b/webpack/logs/interfaces.ts
@@ -1,4 +1,4 @@
-import { TaggedLog } from "../resources/tagged_resources";
+import { TaggedLog } from "farmbot";
 import { BotState, SourceFbosConfig } from "../devices/interfaces";
 import { ConfigurationName, ALLOWED_MESSAGE_TYPES } from "farmbot";
 

--- a/webpack/logs/state_to_props.ts
+++ b/webpack/logs/state_to_props.ts
@@ -8,7 +8,7 @@ import {
 import { getFbosConfig } from "../resources/selectors_by_kind";
 import { validFbosConfig } from "../util";
 import { ResourceIndex } from "../resources/interfaces";
-import { TaggedLog } from "../resources/tagged_resources";
+import { TaggedLog } from "farmbot";
 
 /** Take the specified number of logs after sorting by time created. */
 export function takeSortedLogs(

--- a/webpack/nav/interfaces.ts
+++ b/webpack/nav/interfaces.ts
@@ -1,5 +1,5 @@
 import { BotState } from "../devices/interfaces";
-import { TaggedUser, TaggedLog } from "../resources/tagged_resources";
+import { TaggedUser, TaggedLog } from "farmbot";
 
 export interface NavButtonProps {
   user: TaggedUser | undefined;

--- a/webpack/nav/ticker_list.tsx
+++ b/webpack/nav/ticker_list.tsx
@@ -9,7 +9,7 @@ import { Session, safeNumericSetting } from "../session";
 import { ErrorBoundary } from "../error_boundary";
 import { ALLOWED_MESSAGE_TYPES } from "farmbot";
 import { filterByVerbosity } from "../logs/components/logs_table";
-import { TaggedLog, SpecialStatus } from "../resources/tagged_resources";
+import { TaggedLog, SpecialStatus } from "farmbot";
 import { isNumber } from "lodash";
 
 /** Get current verbosity filter level for a message type from WebAppConfig. */

--- a/webpack/redux/__tests__/subscribers_test.ts
+++ b/webpack/redux/__tests__/subscribers_test.ts
@@ -7,7 +7,7 @@ import {
   buildResourceIndex
 } from "../../__test_support__/resource_index_builder";
 import { WebAppConfig } from "../../config_storage/web_app_configs";
-import { SpecialStatus, TaggedWebAppConfig } from "../../resources/tagged_resources";
+import { SpecialStatus, TaggedWebAppConfig } from "farmbot";
 import { fakeState } from "../../__test_support__/fake_state";
 
 describe("unsavedCheck", () => {

--- a/webpack/redux/refilter_logs_middleware.ts
+++ b/webpack/redux/refilter_logs_middleware.ts
@@ -1,7 +1,7 @@
 import { Actions } from "../constants";
 import { Middleware } from "redux";
 import { MiddlewareConfig } from "./middlewares";
-import { ResourceName } from "../resources/tagged_resources";
+import { ResourceName } from "farmbot";
 import { throttledLogRefresh } from "./refresh_logs";
 
 const WEB_APP_CONFIG: ResourceName = "WebAppConfig";

--- a/webpack/redux/refresh_logs.ts
+++ b/webpack/redux/refresh_logs.ts
@@ -3,7 +3,7 @@ import { API } from "../api";
 import { Log } from "../interfaces";
 import { noop, throttle } from "lodash";
 import axios from "axios";
-import { ResourceName } from "../resources/tagged_resources";
+import { ResourceName } from "farmbot";
 const name: ResourceName = "Log";
 
 /** re-Downloads all logs from the API and force replaces all entries for logs

--- a/webpack/redux/revert_to_english_middleware.ts
+++ b/webpack/redux/revert_to_english_middleware.ts
@@ -1,7 +1,7 @@
 import { Middleware } from "redux";
 import { Actions } from "../constants";
 import { MiddlewareConfig } from "./middlewares";
-import { ResourceName } from "../resources/tagged_resources";
+import { ResourceName } from "farmbot";
 import { revertToEnglish } from "../revert_to_english";
 import { WebAppConfig } from "../config_storage/web_app_configs";
 const WEB_APP_CONFIG: ResourceName = "WebAppConfig";

--- a/webpack/regimens/__tests__/actions_test.ts
+++ b/webpack/regimens/__tests__/actions_test.ts
@@ -1,7 +1,7 @@
 import { editRegimen, selectRegimen } from "../actions";
 import { fakeRegimen } from "../../__test_support__/fake_state/resources";
 import { Actions } from "../../constants";
-import { SpecialStatus } from "../../resources/tagged_resources";
+import { SpecialStatus } from "farmbot";
 
 describe("editRegimen()", () => {
   it("doesn't call edit", () => {

--- a/webpack/regimens/__tests__/state_to_props_test.ts
+++ b/webpack/regimens/__tests__/state_to_props_test.ts
@@ -1,6 +1,6 @@
 import { mapStateToProps } from "../state_to_props";
 import { fakeState } from "../../__test_support__/fake_state";
-import { TaggedResource, SpecialStatus } from "../../resources/tagged_resources";
+import { TaggedResource, SpecialStatus } from "farmbot";
 import { buildResourceIndex } from "../../__test_support__/resource_index_builder";
 
 describe("mapStateToProps()", () => {

--- a/webpack/regimens/actions.ts
+++ b/webpack/regimens/actions.ts
@@ -1,8 +1,9 @@
 import { Regimen } from "./interfaces";
 import { edit } from "../api/crud";
-import { TaggedRegimen, isTaggedRegimen } from "../resources/tagged_resources";
+import { isTaggedRegimen } from "../resources/tagged_resources";
 import { SelectRegimen } from "./editor/interfaces";
 import { Actions } from "../constants";
+import { TaggedRegimen } from "farmbot";
 
 export function editRegimen(r: TaggedRegimen | undefined,
   update: Partial<Regimen>) {

--- a/webpack/regimens/bulk_scheduler/__tests__/actions_test.ts
+++ b/webpack/regimens/bulk_scheduler/__tests__/actions_test.ts
@@ -5,7 +5,7 @@ jest.mock("farmbot-toastr", () => ({ error: mockErr, warning: mockErr }));
 import { commitBulkEditor, setTimeOffset, toggleDay, setSequence } from "../actions";
 import { fakeState } from "../../../__test_support__/fake_state";
 import { buildResourceIndex } from "../../../__test_support__/resource_index_builder";
-import { TaggedResource, SpecialStatus } from "../../../resources/tagged_resources";
+import { TaggedResource, SpecialStatus } from "farmbot";
 import { Actions } from "../../../constants";
 import { Everything } from "../../../interfaces";
 import { ToggleDayParams } from "../interfaces";

--- a/webpack/regimens/bulk_scheduler/interfaces.ts
+++ b/webpack/regimens/bulk_scheduler/interfaces.ts
@@ -1,5 +1,5 @@
 import { RegimenItem } from "../interfaces";
-import { TaggedSequence } from "../../resources/tagged_resources";
+import { TaggedSequence } from "farmbot";
 import { ResourceIndex } from "../../resources/interfaces";
 
 export interface BulkSchedulerOutput {

--- a/webpack/regimens/editor/__tests__/active_editor_test.tsx
+++ b/webpack/regimens/editor/__tests__/active_editor_test.tsx
@@ -4,7 +4,7 @@ import { ActiveEditor } from "../active_editor";
 import { fakeRegimen } from "../../../__test_support__/fake_state/resources";
 import { ActiveEditorProps } from "../interfaces";
 import { Actions } from "../../../constants";
-import { SpecialStatus } from "../../../resources/tagged_resources";
+import { SpecialStatus } from "farmbot";
 
 describe("<ActiveEditor />", () => {
   const props: ActiveEditorProps = {

--- a/webpack/regimens/editor/__tests__/copy_button_test.tsx
+++ b/webpack/regimens/editor/__tests__/copy_button_test.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import { mount } from "enzyme";
 import { CopyButton } from "../copy_button";
 import { fakeRegimen } from "../../../__test_support__/fake_state/resources";
-import { SpecialStatus } from "../../../resources/tagged_resources";
+import { SpecialStatus } from "farmbot";
 import { Actions } from "../../../constants";
 import { push } from "../../../history";
 

--- a/webpack/regimens/editor/__tests__/index_test.tsx
+++ b/webpack/regimens/editor/__tests__/index_test.tsx
@@ -13,7 +13,7 @@ import { fakeRegimen } from "../../../__test_support__/fake_state/resources";
 import { RegimenEditorProps } from "../interfaces";
 import { destroy, save } from "../../../api/crud";
 import { clickButton } from "../../../__test_support__/helpers";
-import { SpecialStatus } from "../../../resources/tagged_resources";
+import { SpecialStatus } from "farmbot";
 
 describe("<RegimenEditor />", () => {
   function fakeProps(): RegimenEditorProps {

--- a/webpack/regimens/editor/active_editor.tsx
+++ b/webpack/regimens/editor/active_editor.tsx
@@ -3,7 +3,7 @@ import { RegimenNameInput } from "./regimen_name_input";
 import { ActiveEditorProps } from "./interfaces";
 import { t } from "i18next";
 import { RegimenItem } from "../interfaces";
-import { TaggedRegimen } from "../../resources/tagged_resources";
+import { TaggedRegimen } from "farmbot";
 import { defensiveClone } from "../../util";
 import { overwrite, save, destroy } from "../../api/crud";
 import { SaveBtn } from "../../ui";

--- a/webpack/regimens/editor/copy_button.tsx
+++ b/webpack/regimens/editor/copy_button.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { CopyButtnProps } from "./interfaces";
 import { t } from "i18next";
 import { init } from "../../api/crud";
-import { TaggedRegimen } from "../../resources/tagged_resources";
+import { TaggedRegimen } from "farmbot";
 import { defensiveClone, urlFriendly } from "../../util";
 import { push } from "../../history";
 

--- a/webpack/regimens/editor/interfaces.ts
+++ b/webpack/regimens/editor/interfaces.ts
@@ -3,7 +3,7 @@ import {
   CalendarRow,
   RegimenItemCalendarRow
 } from "../interfaces";
-import { TaggedRegimen } from "../../resources/tagged_resources";
+import { TaggedRegimen } from "farmbot";
 import { Actions } from "../../constants";
 
 export interface ActiveEditorProps {

--- a/webpack/regimens/interfaces.ts
+++ b/webpack/regimens/interfaces.ts
@@ -2,7 +2,7 @@ import { Color } from "../interfaces";
 import { Week } from "./bulk_scheduler/interfaces";
 import { AuthState } from "../auth/interfaces";
 import { BotState } from "../devices/interfaces";
-import { TaggedRegimen, TaggedSequence } from "../resources/tagged_resources";
+import { TaggedRegimen, TaggedSequence } from "farmbot";
 import { ResourceIndex } from "../resources/interfaces";
 
 export interface CalendarRow {

--- a/webpack/regimens/list/__tests__/regimen_list_item_test.tsx
+++ b/webpack/regimens/list/__tests__/regimen_list_item_test.tsx
@@ -3,7 +3,7 @@ import { RegimenListItemProps } from "../../interfaces";
 import { RegimenListItem } from "../regimen_list_item";
 import { render, shallow } from "enzyme";
 import { fakeRegimen } from "../../../__test_support__/fake_state/resources";
-import { SpecialStatus } from "../../../resources/tagged_resources";
+import { SpecialStatus } from "farmbot";
 import { Actions } from "../../../constants";
 
 describe("<RegimenListItem/>", () => {

--- a/webpack/regimens/list/add_button.tsx
+++ b/webpack/regimens/list/add_button.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { t } from "i18next";
 import { AddRegimenProps } from "../interfaces";
 import { push } from "../../history";
-import { TaggedRegimen, SpecialStatus } from "../../resources/tagged_resources";
+import { TaggedRegimen, SpecialStatus } from "farmbot";
 import { init } from "../../api/crud";
 
 function emptyRegimen(length: number): TaggedRegimen {

--- a/webpack/regimens/list/regimen_list_item.tsx
+++ b/webpack/regimens/list/regimen_list_item.tsx
@@ -4,11 +4,11 @@ import { RegimenListItemProps } from "../interfaces";
 import { lastUrlChunk, urlFriendly } from "../../util";
 import { selectRegimen } from "../actions";
 import {
-  TaggedRegimen,
   isTaggedRegimen
 } from "../../resources/tagged_resources";
 import { t } from "i18next";
 import { Content } from "../../constants";
+import { TaggedRegimen } from "farmbot";
 
 export function RegimenListItem({ regimen, dispatch }: RegimenListItemProps) {
   const name = (regimen.body.name || "") + (regimen.specialStatus ? " *" : "");

--- a/webpack/regimens/reducer.ts
+++ b/webpack/regimens/reducer.ts
@@ -2,7 +2,7 @@ import * as _ from "lodash";
 import { Dictionary } from "farmbot";
 import { Week, DAYS } from "./bulk_scheduler/interfaces";
 import { generateReducer } from "../redux/generate_reducer";
-import { TaggedResource } from "../resources/tagged_resources";
+import { TaggedResource } from "farmbot";
 import { Actions } from "../constants";
 
 export interface RegimenState {

--- a/webpack/regimens/state_to_props.ts
+++ b/webpack/regimens/state_to_props.ts
@@ -8,7 +8,7 @@ import {
   findId,
   findSequence
 } from "../resources/selectors";
-import { TaggedRegimen } from "../resources/tagged_resources";
+import { TaggedRegimen } from "farmbot";
 import { duration } from "moment";
 import * as moment from "moment";
 import { ResourceIndex } from "../resources/interfaces";

--- a/webpack/resources/__tests__/actions_test.ts
+++ b/webpack/resources/__tests__/actions_test.ts
@@ -6,7 +6,7 @@ import { updateOK, generalizedError, GeneralizedError } from "../actions";
 import { fakeUser } from "../../__test_support__/fake_state/resources";
 import { Actions } from "../../constants";
 import { toastErrors } from "../../toast_errors";
-import { SpecialStatus } from "../tagged_resources";
+import { SpecialStatus } from "farmbot";
 
 describe("updateOK()", () => {
   it("creates an action", () => {

--- a/webpack/resources/__tests__/reducer_test.ts
+++ b/webpack/resources/__tests__/reducer_test.ts
@@ -1,7 +1,7 @@
 import { resourceReducer, findByUuid } from "../reducer";
 import { fakeState } from "../../__test_support__/fake_state";
 import { overwrite, refreshStart, refreshOK, refreshNO } from "../../api/crud";
-import { SpecialStatus, TaggedSequence, TaggedDevice } from "../tagged_resources";
+import { SpecialStatus, TaggedSequence, TaggedDevice } from "farmbot";
 import { buildResourceIndex } from "../../__test_support__/resource_index_builder";
 import { GeneralizedError } from "../actions";
 

--- a/webpack/resources/__tests__/selectors_test.ts
+++ b/webpack/resources/__tests__/selectors_test.ts
@@ -8,7 +8,7 @@ import {
   TaggedTool,
   TaggedToolSlotPointer,
   SpecialStatus
-} from "../tagged_resources";
+} from "farmbot";
 import { createOK } from "../actions";
 import { generateUuid, hasId } from "../util";
 import {

--- a/webpack/resources/__tests__/sequence_tagging_test.ts
+++ b/webpack/resources/__tests__/sequence_tagging_test.ts
@@ -1,4 +1,4 @@
-import { TaggedSequence, SpecialStatus } from "../tagged_resources";
+import { TaggedSequence, SpecialStatus } from "farmbot";
 import { get } from "lodash";
 import { maybeTagSteps, getStepTag } from "../sequence_tagging";
 

--- a/webpack/resources/__tests__/tagged_resource_test.ts
+++ b/webpack/resources/__tests__/tagged_resource_test.ts
@@ -1,5 +1,6 @@
 import { fakeTool } from "../../__test_support__/fake_state/resources";
-import { SpecialStatus, getArrayStatus } from "../tagged_resources";
+import { getArrayStatus } from "../tagged_resources";
+import { SpecialStatus } from "farmbot";
 
 describe("getArrayStatus()", () => {
   const toolArray = () => [fakeTool(), fakeTool(), fakeTool()];

--- a/webpack/resources/actions.ts
+++ b/webpack/resources/actions.ts
@@ -1,4 +1,4 @@
-import { TaggedResource, SpecialStatus } from "./tagged_resources";
+import { TaggedResource, SpecialStatus } from "farmbot";
 import { UnsafeError } from "../interfaces";
 import { Actions } from "../constants";
 import { toastErrors } from "../toast_errors";

--- a/webpack/resources/interfaces.ts
+++ b/webpack/resources/interfaces.ts
@@ -8,7 +8,7 @@ import {
   ResourceName,
   TaggedToolSlotPointer,
   TaggedTool
-} from "./tagged_resources";
+} from "farmbot";
 import { RegimenState } from "../regimens/reducer";
 import { FarmwareState } from "../farmware/interfaces";
 

--- a/webpack/resources/reducer.ts
+++ b/webpack/resources/reducer.ts
@@ -4,10 +4,12 @@ import { RestResources, ResourceIndex } from "./interfaces";
 import {
   TaggedResource,
   ResourceName,
-  sanityCheck,
-  isTaggedResource,
   SpecialStatus,
   TaggedSequence
+} from "farmbot";
+import {
+  sanityCheck,
+  isTaggedResource,
 } from "./tagged_resources";
 import { generateUuid, arrayWrap } from "./util";
 import { EditResourceParams } from "../api/interfaces";

--- a/webpack/resources/selectors.ts
+++ b/webpack/resources/selectors.ts
@@ -2,14 +2,7 @@ import * as _ from "lodash";
 import { ResourceIndex } from "./interfaces";
 import { joinKindAndId } from "./reducer";
 import {
-  isTaggedPlantPointer,
-  isTaggedGenericPointer,
-  isTaggedRegimen,
-  isTaggedSequence,
-  isTaggedTool,
-  isTaggedToolSlotPointer,
   ResourceName,
-  sanityCheck,
   TaggedGenericPointer,
   TaggedPlantPointer,
   TaggedRegimen,
@@ -19,6 +12,15 @@ import {
   TaggedToolSlotPointer,
   TaggedUser,
   TaggedDevice,
+} from "farmbot";
+import {
+  isTaggedPlantPointer,
+  isTaggedGenericPointer,
+  isTaggedRegimen,
+  isTaggedSequence,
+  isTaggedTool,
+  isTaggedToolSlotPointer,
+  sanityCheck,
 } from "./tagged_resources";
 import { betterCompact, bail } from "../util";
 import { findAllById } from "./selectors_by_id";

--- a/webpack/resources/selectors_by_id.ts
+++ b/webpack/resources/selectors_by_id.ts
@@ -6,12 +6,14 @@ import {
   isTaggedSequence,
   isTaggedTool,
   isTaggedToolSlotPointer,
-  ResourceName,
   sanityCheck,
+} from "./tagged_resources";
+import {
+  ResourceName,
   TaggedResource,
   TaggedTool,
   TaggedToolSlotPointer,
-} from "./tagged_resources";
+} from "farmbot";
 import { ResourceIndex } from "./interfaces";
 import { joinKindAndId } from "./reducer";
 import { isNumber } from "lodash";

--- a/webpack/resources/selectors_by_kind.ts
+++ b/webpack/resources/selectors_by_kind.ts
@@ -2,8 +2,6 @@ import { ResourceIndex } from "./interfaces";
 import {
   TaggedResource,
   SpecialStatus,
-  isTaggedResource,
-  sanityCheck,
   TaggedWebcamFeed,
   TaggedFbosConfig,
   TaggedCrop,
@@ -22,6 +20,10 @@ import {
   TaggedPinBinding,
   TaggedDiagnosticDump,
   TaggedSensorReading,
+} from "farmbot";
+import {
+  isTaggedResource,
+  sanityCheck,
 } from "./tagged_resources";
 import { sortResourcesById, betterCompact, bail } from "../util";
 import { error } from "farmbot-toastr";

--- a/webpack/resources/selectors_for_indexing.ts
+++ b/webpack/resources/selectors_for_indexing.ts
@@ -6,7 +6,7 @@ import {
   TaggedFarmEvent,
   TaggedTool,
   TaggedPoint
-} from "./tagged_resources";
+} from "farmbot";
 import { CowardlyDictionary } from "../util";
 import {
   ResourceIndex,

--- a/webpack/resources/sequence_tagging.ts
+++ b/webpack/resources/sequence_tagging.ts
@@ -1,6 +1,6 @@
 import { get, set } from "lodash";
 import { SequenceBodyItem, uuid } from "farmbot/dist";
-import { TaggedResource } from "./tagged_resources";
+import { TaggedResource } from "farmbot";
 
 /** HISTORICAL NOTES:
  *   This file is the result of some very subtle bugs relating to dynamic

--- a/webpack/resources/tagged_resources.ts
+++ b/webpack/resources/tagged_resources.ts
@@ -15,6 +15,7 @@ import {
   TaggedPlantPointer,
   TaggedGenericPointer,
   PointerType,
+  SpecialStatus,
 } from "farmbot";
 
 export interface TaggedResourceBase {
@@ -30,17 +31,6 @@ export interface TaggedResourceBase {
   specialStatus: SpecialStatus;
 }
 
-/** Denotes special status of resource */
-export enum SpecialStatus {
-  /** The local copy is different than the one on the remote end. */
-  DIRTY = "DIRTY",
-  /** The local copy is being saved on the remote end right now? */
-  SAVING = "SAVING",
-  /** API and FE are in sync. Using "" for now because its falsey like old
-   * `undefined` value */
-  SAVED = ""
-}
-
 /** Given an array of TaggedResources, returns the most "important" special status.
  * the hierarchy is SAVED => DIRTY => SAVING  */
 export function getArrayStatus(i: TaggedResource[]): SpecialStatus {
@@ -51,61 +41,6 @@ export function getArrayStatus(i: TaggedResource[]): SpecialStatus {
   } else {
     return SpecialStatus.SAVED;
   }
-}
-export interface Resource<T extends ResourceName, U extends object>
-  extends TaggedResourceBase {
-  kind: T;
-  body: U;
-}
-
-// export type TaggedPinBinding = Resource<"PinBinding", PinBinding>;
-// // export type TaggedDeviceConfig = Resource<"DeviceConfig", DeviceConfig>;
-// export type TaggedRegimen = Resource<"Regimen", Regimen>;
-// export type TaggedTool = Resource<"Tool", Tool>;
-// export type TaggedSequence = Resource<"Sequence", Sequence>;
-// export type TaggedFarmEvent = Resource<"FarmEvent", FarmEvent>;
-// export type TaggedImage = Resource<"Image", Image>;
-// export type TaggedLog = Resource<"Log", Log>;
-// export type TaggedPeripheral = Resource<"Peripheral", Peripheral>;
-// export type TaggedFbosConfig = Resource<"FbosConfig", FbosConfig>;
-// export type TaggedFirmwareConfig = Resource<"FirmwareConfig", FirmwareConfig>;
-// export type TaggedWebAppConfig = Resource<"WebAppConfig", WebAppConfig>;
-// export type TaggedSensorReading = Resource<"SensorReading", SensorReading>;
-// export type TaggedSensor = Resource<"Sensor", Sensor>;
-// export type TaggedSavedGarden = Resource<"SavedGarden", SavedGarden>;
-// export type TaggedPlantTemplate = Resource<"PlantTemplate", PlantTemplate>;
-// export type TaggedDiagnosticDump = Resource<"DiagnosticDump", DiagnosticDump>;
-
-// type PointUnion = GenericPointer | PlantPointer | ToolSlotPointer;
-// export type PointerType =
-//   | TaggedToolSlotPointer
-//   | TaggedGenericPointer
-//   | TaggedPlantPointer;
-
-// export type TaggedGenericPointer = Resource<"Point", GenericPointer>;
-// export type TaggedPlantPointer = Resource<"Point", PlantPointer>;
-// export type TaggedToolSlotPointer = Resource<"Point", ToolSlotPointer>;
-
-// export type TaggedPoint = Resource<"Point", PointUnion>;
-
-// export type TaggedUser = Resource<"User", User>;
-// export type TaggedDevice = Resource<"Device", DeviceAccountSettings>;
-// export type TaggedWebcamFeed = Resource<"WebcamFeed", WebcamFeed>;
-// export type TaggedFarmwareInstallation =
-//   Resource<"FarmwareInstallation", FarmwareInstallation>;
-
-export interface DiagnosticDump {
-  id: number;
-  device_id: number;
-  ticket_identifier: string;
-  fbos_commit: string;
-  fbos_version: string;
-  firmware_commit: string;
-  firmware_state: string;
-  network_interface: string;
-  fbos_dmesg_dump: string;
-  created_at: string;
-  updated_at: string;
 }
 
 /** Spot check to be certain a TaggedResource is what it says it is. */

--- a/webpack/resources/tagged_resources.ts
+++ b/webpack/resources/tagged_resources.ts
@@ -1,56 +1,21 @@
-import { Sequence } from "../sequences/interfaces";
-import { Tool } from "../tools/interfaces";
-import { Regimen } from "../regimens/interfaces";
-import { FarmEvent, Crop, SavedGarden, PlantTemplate } from "../farm_designer/interfaces";
-import {
-  Log,
-  GenericPointer,
-  PlantPointer,
-  ToolSlotPointer,
-  SensorReading,
-  Sensor,
-  DeviceConfig,
-} from "../interfaces";
-import { Peripheral } from "../controls/peripherals/interfaces";
-import { User } from "../auth/interfaces";
-import { DeviceAccountSettings } from "../devices/interfaces";
 import { isObject, isString, get } from "lodash";
-import { Image } from "../farmware/images/interfaces";
 import { betterCompact } from "../util";
 import * as _ from "lodash";
-import { WebcamFeed } from "../controls/interfaces";
-import { FbosConfig } from "../config_storage/fbos_configs";
-import { FirmwareConfig } from "../config_storage/firmware_configs";
-import { WebAppConfig } from "../config_storage/web_app_configs";
-import { FarmwareInstallation } from "../farmware/interfaces";
 import { assertUuid } from "./util";
-import { PinBinding } from "../devices/pin_bindings/interfaces";
-
-export type ResourceName =
-  | "Crop"
-  | "Device"
-  | "DeviceConfig"
-  | "DiagnosticDump"
-  | "FarmEvent"
-  | "FarmwareInstallation"
-  | "FbosConfig"
-  | "FirmwareConfig"
-  | "Image"
-  | "Log"
-  | "Peripheral"
-  | "PinBinding"
-  | "Plant"
-  | "PlantTemplate"
-  | "Point"
-  | "Regimen"
-  | "SavedGarden"
-  | "Sensor"
-  | "SensorReading"
-  | "Sequence"
-  | "Tool"
-  | "User"
-  | "WebAppConfig"
-  | "WebcamFeed";
+import {
+  TaggedCrop,
+  TaggedResource,
+  ResourceName,
+  TaggedRegimen,
+  TaggedSequence,
+  TaggedTool,
+  TaggedFarmEvent,
+  TaggedLog,
+  TaggedToolSlotPointer,
+  TaggedPlantPointer,
+  TaggedGenericPointer,
+  PointerType,
+} from "farmbot";
 
 export interface TaggedResourceBase {
   kind: ResourceName;
@@ -93,62 +58,41 @@ export interface Resource<T extends ResourceName, U extends object>
   body: U;
 }
 
-export type TaggedResource =
-  | TaggedCrop
-  | TaggedDevice
-  | TaggedDiagnosticDump
-  | TaggedFarmEvent
-  | TaggedFarmwareInstallation
-  | TaggedFbosConfig
-  | TaggedFirmwareConfig
-  | TaggedImage
-  | TaggedLog
-  | TaggedPeripheral
-  | TaggedPinBinding
-  | TaggedPlantTemplate
-  | TaggedPoint
-  | TaggedRegimen
-  | TaggedSavedGarden
-  | TaggedSensor
-  | TaggedSensorReading
-  | TaggedSequence
-  | TaggedTool
-  | TaggedUser
-  | TaggedWebAppConfig
-  | TaggedWebcamFeed;
+// export type TaggedPinBinding = Resource<"PinBinding", PinBinding>;
+// // export type TaggedDeviceConfig = Resource<"DeviceConfig", DeviceConfig>;
+// export type TaggedRegimen = Resource<"Regimen", Regimen>;
+// export type TaggedTool = Resource<"Tool", Tool>;
+// export type TaggedSequence = Resource<"Sequence", Sequence>;
+// export type TaggedFarmEvent = Resource<"FarmEvent", FarmEvent>;
+// export type TaggedImage = Resource<"Image", Image>;
+// export type TaggedLog = Resource<"Log", Log>;
+// export type TaggedPeripheral = Resource<"Peripheral", Peripheral>;
+// export type TaggedFbosConfig = Resource<"FbosConfig", FbosConfig>;
+// export type TaggedFirmwareConfig = Resource<"FirmwareConfig", FirmwareConfig>;
+// export type TaggedWebAppConfig = Resource<"WebAppConfig", WebAppConfig>;
+// export type TaggedSensorReading = Resource<"SensorReading", SensorReading>;
+// export type TaggedSensor = Resource<"Sensor", Sensor>;
+// export type TaggedSavedGarden = Resource<"SavedGarden", SavedGarden>;
+// export type TaggedPlantTemplate = Resource<"PlantTemplate", PlantTemplate>;
+// export type TaggedDiagnosticDump = Resource<"DiagnosticDump", DiagnosticDump>;
 
-export type TaggedPinBinding = Resource<"PinBinding", PinBinding>;
-export type TaggedDeviceConfig = Resource<"DeviceConfig", DeviceConfig>;
-export type TaggedRegimen = Resource<"Regimen", Regimen>;
-export type TaggedTool = Resource<"Tool", Tool>;
-export type TaggedSequence = Resource<"Sequence", Sequence>;
-export type TaggedCrop = Resource<"Crop", Crop>;
-export type TaggedFarmEvent = Resource<"FarmEvent", FarmEvent>;
-export type TaggedImage = Resource<"Image", Image>;
-export type TaggedLog = Resource<"Log", Log>;
-export type TaggedPeripheral = Resource<"Peripheral", Peripheral>;
-export type TaggedFbosConfig = Resource<"FbosConfig", FbosConfig>;
-export type TaggedFirmwareConfig = Resource<"FirmwareConfig", FirmwareConfig>;
-export type TaggedWebAppConfig = Resource<"WebAppConfig", WebAppConfig>;
-export type TaggedSensorReading = Resource<"SensorReading", SensorReading>;
-export type TaggedSensor = Resource<"Sensor", Sensor>;
-export type TaggedSavedGarden = Resource<"SavedGarden", SavedGarden>;
-export type TaggedPlantTemplate = Resource<"PlantTemplate", PlantTemplate>;
-export type TaggedDiagnosticDump = Resource<"DiagnosticDump", DiagnosticDump>;
+// type PointUnion = GenericPointer | PlantPointer | ToolSlotPointer;
+// export type PointerType =
+//   | TaggedToolSlotPointer
+//   | TaggedGenericPointer
+//   | TaggedPlantPointer;
 
-type PointUnion = GenericPointer | PlantPointer | ToolSlotPointer;
+// export type TaggedGenericPointer = Resource<"Point", GenericPointer>;
+// export type TaggedPlantPointer = Resource<"Point", PlantPointer>;
+// export type TaggedToolSlotPointer = Resource<"Point", ToolSlotPointer>;
 
-export type TaggedGenericPointer = Resource<"Point", GenericPointer>;
-export type TaggedPlantPointer = Resource<"Point", PlantPointer>;
-export type TaggedToolSlotPointer = Resource<"Point", ToolSlotPointer>;
+// export type TaggedPoint = Resource<"Point", PointUnion>;
 
-export type TaggedPoint = Resource<"Point", PointUnion>;
-
-export type TaggedUser = Resource<"User", User>;
-export type TaggedDevice = Resource<"Device", DeviceAccountSettings>;
-export type TaggedWebcamFeed = Resource<"WebcamFeed", WebcamFeed>;
-export type TaggedFarmwareInstallation =
-  Resource<"FarmwareInstallation", FarmwareInstallation>;
+// export type TaggedUser = Resource<"User", User>;
+// export type TaggedDevice = Resource<"Device", DeviceAccountSettings>;
+// export type TaggedWebcamFeed = Resource<"WebcamFeed", WebcamFeed>;
+// export type TaggedFarmwareInstallation =
+//   Resource<"FarmwareInstallation", FarmwareInstallation>;
 
 export interface DiagnosticDump {
   id: number;
@@ -190,11 +134,6 @@ const is = (r: ResourceName) => function isOfTag(x: object): x is TaggedResource
   }
   return safe;
 };
-
-export type PointerType =
-  | TaggedToolSlotPointer
-  | TaggedGenericPointer
-  | TaggedPlantPointer;
 
 function isTaggedPoint(x: {}): x is PointerType {
   return (is("Point")(x)) && (x.kind === "Point");

--- a/webpack/resources/util.ts
+++ b/webpack/resources/util.ts
@@ -1,4 +1,4 @@
-import { ResourceName } from "./tagged_resources";
+import { ResourceName } from "farmbot";
 import { joinKindAndId } from "./reducer";
 import { Dictionary } from "farmbot/dist";
 import { betterCompact } from "../util";

--- a/webpack/sequences/__tests__/all_steps_test.tsx
+++ b/webpack/sequences/__tests__/all_steps_test.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { AllSteps } from "../all_steps";
 import { buildResourceIndex } from "../../__test_support__/resource_index_builder";
 import { shallow } from "enzyme";
-import { TaggedSequence, SpecialStatus } from "../../resources/tagged_resources";
+import { TaggedSequence, SpecialStatus } from "farmbot";
 import { maybeTagSteps } from "../../resources/sequence_tagging";
 import { TileMoveRelative } from "../step_tiles/tile_move_relative";
 import { TileReadPin } from "../step_tiles/tile_read_pin";

--- a/webpack/sequences/__tests__/sequence_editor_middle_active_test.tsx
+++ b/webpack/sequences/__tests__/sequence_editor_middle_active_test.tsx
@@ -32,7 +32,7 @@ import { destroy, save, edit } from "../../api/crud";
 import {
   fakeHardwareFlags
 } from "../../__test_support__/sequence_hardware_settings";
-import { SpecialStatus } from "../../resources/tagged_resources";
+import { SpecialStatus } from "farmbot";
 import { move, splice } from "../step_tiles";
 import { copySequence, editCurrentSequence } from "../actions";
 import { execSequence } from "../../devices/actions";

--- a/webpack/sequences/__tests__/test_button_test.tsx
+++ b/webpack/sequences/__tests__/test_button_test.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { TestButton, TestBtnProps } from "../test_button";
-import { TaggedSequence, SpecialStatus } from "../../resources/tagged_resources";
+import { TaggedSequence, SpecialStatus } from "farmbot";
 import { mount } from "enzyme";
 
 describe("<TestButton/>", () => {

--- a/webpack/sequences/actions.ts
+++ b/webpack/sequences/actions.ts
@@ -1,7 +1,7 @@
 import { SequenceBodyItem } from "farmbot";
 import { SelectSequence } from "./interfaces";
 import { edit, init, overwrite } from "../api/crud";
-import { TaggedSequence } from "../resources/tagged_resources";
+import { TaggedSequence } from "farmbot";
 import { defensiveClone } from "../util";
 import { push } from "../history";
 import { urlFriendly } from "../util";

--- a/webpack/sequences/all_steps.tsx
+++ b/webpack/sequences/all_steps.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { TaggedSequence } from "../resources/tagged_resources";
+import { TaggedSequence } from "farmbot";
 import { SequenceBodyItem } from "farmbot/dist";
 import { DropArea } from "../draggable/drop_area";
 import { StepDragger } from "../draggable/step_dragger";

--- a/webpack/sequences/inputs/__tests__/input_default_test.tsx
+++ b/webpack/sequences/inputs/__tests__/input_default_test.tsx
@@ -2,7 +2,7 @@ jest.unmock("../../step_tiles/index");
 import * as React from "react";
 import { InputDefault } from "../input_default";
 import { mount } from "enzyme";
-import { TaggedSequence, SpecialStatus } from "../../../resources/tagged_resources";
+import { TaggedSequence, SpecialStatus } from "farmbot";
 import { MoveAbsolute } from "farmbot/dist";
 import { Actions } from "../../../constants";
 

--- a/webpack/sequences/interfaces.ts
+++ b/webpack/sequences/interfaces.ts
@@ -9,7 +9,7 @@ import {
   FarmwareConfig
 } from "farmbot";
 import { StepMoveDataXfer, StepSpliceDataXfer } from "../draggable/interfaces";
-import { TaggedSequence } from "../resources/tagged_resources";
+import { TaggedSequence } from "farmbot";
 import { ResourceIndex } from "../resources/interfaces";
 import { ShouldDisplay } from "../devices/interfaces";
 

--- a/webpack/sequences/locals_list.tsx
+++ b/webpack/sequences/locals_list.tsx
@@ -9,7 +9,7 @@ import {
   LocationData, InputBox, generateList, formatSelectedDropdown, handleSelect
 } from "./step_tiles/tile_move_absolute/index";
 import { overwrite } from "../api/crud";
-import { TaggedSequence } from "../resources/tagged_resources";
+import { TaggedSequence } from "farmbot";
 import { defensiveClone } from "../util";
 import { Row, Col, FBSelect } from "../ui/index";
 import { t } from "i18next";

--- a/webpack/sequences/reducer.ts
+++ b/webpack/sequences/reducer.ts
@@ -1,6 +1,6 @@
 import { SequenceReducerState } from "./interfaces";
 import { generateReducer } from "../redux/generate_reducer";
-import { TaggedResource } from "../resources/tagged_resources";
+import { TaggedResource } from "farmbot";
 import { Actions } from "../constants";
 
 export const initialState: SequenceReducerState = {

--- a/webpack/sequences/sequence_editor_middle_active.tsx
+++ b/webpack/sequences/sequence_editor_middle_active.tsx
@@ -8,7 +8,7 @@ import { BlurableInput, Row, Col, SaveBtn, ColorPicker } from "../ui/index";
 import { DropArea } from "../draggable/drop_area";
 import { stepGet } from "../draggable/actions";
 import { copySequence } from "./actions";
-import { TaggedSequence } from "../resources/tagged_resources";
+import { TaggedSequence } from "farmbot";
 import { save, edit, destroy } from "../api/crud";
 import { TestButton } from "./test_button";
 import { warning } from "farmbot-toastr";

--- a/webpack/sequences/sequences_list.tsx
+++ b/webpack/sequences/sequences_list.tsx
@@ -6,7 +6,7 @@ import { selectSequence } from "./actions";
 import { SequencesListProps, SequencesListState } from "./interfaces";
 import { sortResourcesById, urlFriendly, lastUrlChunk } from "../util";
 import { Row, Col } from "../ui/index";
-import { TaggedSequence, SpecialStatus } from "../resources/tagged_resources";
+import { TaggedSequence, SpecialStatus } from "farmbot";
 import { init } from "../api/crud";
 import { Content } from "../constants";
 import { StepDragger, NULL_DRAGGER_ID } from "../draggable/step_dragger";

--- a/webpack/sequences/step_button_cluster.tsx
+++ b/webpack/sequences/step_button_cluster.tsx
@@ -3,7 +3,7 @@ import { StepButton } from "./step_buttons/index";
 import { t } from "i18next";
 import { scrollToBottom } from "../util";
 import { Row } from "../ui/index";
-import { TaggedSequence } from "../resources/tagged_resources";
+import { TaggedSequence } from "farmbot";
 import { CONFIG_DEFAULTS } from "farmbot/dist/config";
 
 interface StepButtonProps {

--- a/webpack/sequences/step_buttons/index.tsx
+++ b/webpack/sequences/step_buttons/index.tsx
@@ -6,7 +6,7 @@ import { StepDragger, NULL_DRAGGER_ID } from "../../draggable/step_dragger";
 import { pushStep } from "../actions";
 import { StepButtonParams } from "../interfaces";
 import { Col } from "../../ui/index";
-import { TaggedSequence } from "../../resources/tagged_resources";
+import { TaggedSequence } from "farmbot";
 
 export const stepClick =
   (dispatch: Function, step: Step, seq: TaggedSequence | undefined) =>

--- a/webpack/sequences/step_tiles/__tests__/pin_and_peripheral_support_test.tsx
+++ b/webpack/sequences/step_tiles/__tests__/pin_and_peripheral_support_test.tsx
@@ -28,7 +28,7 @@ import {
 } from "../../../__test_support__/fake_state/resources";
 import { DropDownItem } from "../../../ui";
 import { NamedPin, AllowedPinTypes } from "farmbot";
-import { TaggedSensor, TaggedSequence } from "../../../resources/tagged_resources";
+import { TaggedSensor, TaggedSequence } from "farmbot";
 import { StepParams } from "../../interfaces";
 
 describe("Pin and Peripheral support files", () => {

--- a/webpack/sequences/step_tiles/__tests__/tile_move_absolute_test.tsx
+++ b/webpack/sequences/step_tiles/__tests__/tile_move_absolute_test.tsx
@@ -5,7 +5,7 @@ import { fakeSequence } from "../../../__test_support__/fake_state/resources";
 import { MoveAbsolute, SequenceBodyItem } from "farmbot/dist";
 import { emptyState } from "../../../resources/reducer";
 import { buildResourceIndex } from "../../../__test_support__/resource_index_builder";
-import { SpecialStatus } from "../../../resources/tagged_resources";
+import { SpecialStatus } from "farmbot";
 import { fakeHardwareFlags } from "../../../__test_support__/sequence_hardware_settings";
 
 describe("<TileMoveAbsolute/>", () => {

--- a/webpack/sequences/step_tiles/index.tsx
+++ b/webpack/sequences/step_tiles/index.tsx
@@ -15,7 +15,7 @@ import { TileExecuteScript } from "./tile_execute_script";
 import { TileTakePhoto } from "./tile_take_photo";
 import * as _ from "lodash";
 import { CeleryNode, LegalArgString, If, Execute, Nothing } from "farmbot";
-import { TaggedSequence } from "../../resources/tagged_resources";
+import { TaggedSequence } from "farmbot";
 import { overwrite } from "../../api/crud";
 import { TileFindHome } from "./tile_find_home";
 import { t } from "i18next";

--- a/webpack/sequences/step_tiles/pin_and_peripheral_support.tsx
+++ b/webpack/sequences/step_tiles/pin_and_peripheral_support.tsx
@@ -8,7 +8,7 @@ import { DropDownItem } from "../../ui";
 import { range, isNumber, isString } from "lodash";
 import {
   TaggedPeripheral, TaggedSensor, ResourceName
-} from "../../resources/tagged_resources";
+} from "farmbot";
 import { ReadPin, AllowedPinTypes, NamedPin } from "farmbot";
 import { bail } from "../../util/errors";
 import { joinKindAndId } from "../../resources/reducer";

--- a/webpack/sequences/step_tiles/tile_execute.tsx
+++ b/webpack/sequences/step_tiles/tile_execute.tsx
@@ -4,7 +4,7 @@ import { StepParams } from "../interfaces";
 import { t } from "i18next";
 import { Row, Col, DropDownItem } from "../../ui/index";
 import { Execute } from "farmbot/dist";
-import { TaggedSequence } from "../../resources/tagged_resources";
+import { TaggedSequence } from "farmbot";
 import { ResourceIndex } from "../../resources/interfaces";
 import { editStep } from "../../api/crud";
 import { ToolTips } from "../../constants";

--- a/webpack/sequences/step_tiles/tile_find_home.tsx
+++ b/webpack/sequences/step_tiles/tile_find_home.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { t } from "i18next";
 import { FindHome, ALLOWED_AXIS, Xyz } from "farmbot";
 import { StepParams, HardwareFlags } from "../interfaces";
-import { TaggedSequence } from "../../resources/tagged_resources";
+import { TaggedSequence } from "farmbot";
 import { ResourceIndex } from "../../resources/interfaces";
 import { overwrite } from "../../api/crud";
 import { defensiveClone } from "../../util";

--- a/webpack/sequences/step_tiles/tile_if/__tests__/index_test.tsx
+++ b/webpack/sequences/step_tiles/tile_if/__tests__/index_test.tsx
@@ -16,7 +16,7 @@ import {
   buildResourceIndex, FAKE_RESOURCES
 } from "../../../../__test_support__/resource_index_builder";
 import { Execute, If } from "farmbot";
-import { TaggedSequence } from "../../../../resources/tagged_resources";
+import { TaggedSequence } from "farmbot";
 import { overwrite } from "../../../../api/crud";
 import { fakeSensor, fakePeripheral } from "../../../../__test_support__/fake_state/resources";
 

--- a/webpack/sequences/step_tiles/tile_if/__tests__/lhs_test.ts
+++ b/webpack/sequences/step_tiles/tile_if/__tests__/lhs_test.ts
@@ -5,7 +5,7 @@ import {
   SpecialStatus,
   TaggedSequence,
   TaggedPeripheral
-} from "../../../../resources/tagged_resources";
+} from "farmbot";
 import {
   selectAllSequences,
   selectAllPeripherals

--- a/webpack/sequences/step_tiles/tile_if/index.tsx
+++ b/webpack/sequences/step_tiles/tile_if/index.tsx
@@ -2,7 +2,7 @@ import * as _ from "lodash";
 import * as React from "react";
 import { t } from "i18next";
 import { DropDownItem, NULL_CHOICE } from "../../../ui/index";
-import { TaggedSequence } from "../../../resources/tagged_resources";
+import { TaggedSequence } from "farmbot";
 import { If, Execute, Nothing } from "farmbot/dist";
 import { ResourceIndex } from "../../../resources/interfaces";
 import { selectAllSequences, findSequenceById } from "../../../resources/selectors";

--- a/webpack/sequences/step_tiles/tile_if/update_lhs.ts
+++ b/webpack/sequences/step_tiles/tile_if/update_lhs.ts
@@ -1,4 +1,4 @@
-import { TaggedSequence } from "../../../resources/tagged_resources";
+import { TaggedSequence } from "farmbot";
 import { If } from "farmbot";
 import { ResourceIndex } from "../../../resources/interfaces";
 import { defensiveClone, bail } from "../../../util";

--- a/webpack/sequences/step_tiles/tile_move_absolute.tsx
+++ b/webpack/sequences/step_tiles/tile_move_absolute.tsx
@@ -15,9 +15,11 @@ import {
 import { Row, Col } from "../../ui/index";
 import {
   isTaggedSequence,
+} from "../../resources/tagged_resources";
+import {
   TaggedTool,
   TaggedToolSlotPointer
-} from "../../resources/tagged_resources";
+} from "farmbot";
 import {
   findToolById,
   findSlotByToolId,

--- a/webpack/sequences/step_tiles/tile_move_absolute/generate_list.ts
+++ b/webpack/sequences/step_tiles/tile_move_absolute/generate_list.ts
@@ -5,7 +5,7 @@ import {
 } from "../../../resources/selectors";
 import { betterCompact } from "../../../util";
 import { PointerTypeName } from "../../../interfaces";
-import { PointerType, TaggedTool } from "../../../resources/tagged_resources";
+import { PointerType, TaggedTool } from "farmbot";
 import { DropDownItem } from "../../../ui/index";
 import { Vector3 } from "farmbot/dist";
 import { TOOL } from "./interfaces";

--- a/webpack/sequences/step_tiles/tile_move_absolute/test_helpers.ts
+++ b/webpack/sequences/step_tiles/tile_move_absolute/test_helpers.ts
@@ -1,6 +1,6 @@
 import { buildResourceIndex } from "../../../__test_support__/resource_index_builder";
 import { ResourceIndex } from "../../../resources/interfaces";
-import { TaggedResource, SpecialStatus } from "../../../resources/tagged_resources";
+import { TaggedResource, SpecialStatus } from "farmbot";
 
 export function fakeResourceIndex(): ResourceIndex {
   const fakeResources: TaggedResource[] = [

--- a/webpack/sequences/step_tiles/tile_send_message.tsx
+++ b/webpack/sequences/step_tiles/tile_send_message.tsx
@@ -5,7 +5,7 @@ import { StepInputBox } from "../inputs/step_input_box";
 import { SendMessage } from "farmbot";
 import * as _ from "lodash";
 import { StepParams, ChannelName } from "../interfaces";
-import { TaggedSequence } from "../../resources/tagged_resources";
+import { TaggedSequence } from "farmbot";
 import { ResourceIndex } from "../../resources/interfaces";
 import { editStep } from "../../api/crud";
 import { ToolTips } from "../../constants";

--- a/webpack/sequences/step_ui/step_header.tsx
+++ b/webpack/sequences/step_ui/step_header.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { t } from "i18next";
 import { Row, Col } from "../../ui/index";
-import { TaggedSequence } from "../../resources/tagged_resources";
+import { TaggedSequence } from "farmbot";
 import { SequenceBodyItem } from "farmbot";
 import { StepTitleBar } from "../step_tiles/step_title_bar";
 import { StepIconGroup } from "../step_icon_group";

--- a/webpack/sequences/test_button.tsx
+++ b/webpack/sequences/test_button.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { t } from "i18next";
 import { SyncStatus } from "farmbot/dist";
-import { TaggedSequence } from "../resources/tagged_resources";
+import { TaggedSequence } from "farmbot";
 
 export interface TestBtnProps {
   /** Callback fired ONLY if synced. */

--- a/webpack/sync/actions.ts
+++ b/webpack/sync/actions.ts
@@ -8,7 +8,7 @@ import { Peripheral } from "../controls/peripherals/interfaces";
 import { FarmEvent, SavedGarden, PlantTemplate } from "../farm_designer/interfaces";
 import { Image } from "../farmware/images/interfaces";
 import { DeviceAccountSettings } from "../devices/interfaces";
-import { ResourceName, DiagnosticDump } from "../resources/tagged_resources";
+import { ResourceName, DiagnosticDump } from "farmbot";
 import { User } from "../auth/interfaces";
 import { WebcamFeed } from "../controls/interfaces";
 import { WebAppConfig } from "../config_storage/web_app_configs";

--- a/webpack/tools/components/__tests__/toolbay_slot_direction_selection_test.tsx
+++ b/webpack/tools/components/__tests__/toolbay_slot_direction_selection_test.tsx
@@ -5,7 +5,7 @@ import {
 } from "../toolbay_slot_direction_selection";
 import { fakeToolSlot } from "../../../__test_support__/fake_state/resources";
 import { Actions } from "../../../constants";
-import { SpecialStatus } from "../../../resources/tagged_resources";
+import { SpecialStatus } from "farmbot";
 
 describe("<SlotDirectionSelect />", () => {
   const fakeProps = (): SlotDirectionSelectProps => {

--- a/webpack/tools/components/__tests__/toolbay_slot_menu_test.tsx
+++ b/webpack/tools/components/__tests__/toolbay_slot_menu_test.tsx
@@ -3,7 +3,7 @@ import { mount } from "enzyme";
 import { SlotMenu, SlotMenuProps } from "../toolbay_slot_menu";
 import { fakeToolSlot } from "../../../__test_support__/fake_state/resources";
 import { Actions } from "../../../constants";
-import { SpecialStatus } from "../../../resources/tagged_resources";
+import { SpecialStatus } from "farmbot";
 
 describe("<SlotMenu />", () => {
   const fakeProps = (): SlotMenuProps => {

--- a/webpack/tools/components/empty_tool_slot.ts
+++ b/webpack/tools/components/empty_tool_slot.ts
@@ -1,5 +1,5 @@
 import { TaggedToolSlotPointer } from "farmbot";
-import { SpecialStatus } from "../../resources/tagged_resources";
+import { SpecialStatus } from "farmbot";
 
 export function emptyToolSlot(): TaggedToolSlotPointer {
   return {

--- a/webpack/tools/components/empty_tool_slot.ts
+++ b/webpack/tools/components/empty_tool_slot.ts
@@ -1,4 +1,4 @@
-import { TaggedToolSlotPointer } from "../../resources/tagged_resources";
+import { TaggedToolSlotPointer } from "farmbot";
 import { SpecialStatus } from "../../resources/tagged_resources";
 
 export function emptyToolSlot(): TaggedToolSlotPointer {

--- a/webpack/tools/components/tool_form.tsx
+++ b/webpack/tools/components/tool_form.tsx
@@ -10,11 +10,10 @@ import {
   BlurableInput,
   SaveBtn
 } from "../../ui/index";
-import {
-  TaggedTool, getArrayStatus, SpecialStatus
-} from "../../resources/tagged_resources";
+import { getArrayStatus } from "../../resources/tagged_resources";
 import { edit, destroy, init, saveAll } from "../../api/crud";
 import { ToolTips } from "../../constants";
+import { TaggedTool, SpecialStatus } from "farmbot";
 
 export class ToolForm extends React.Component<ToolFormProps, {}> {
   taggedTool = (name: string): TaggedTool => {

--- a/webpack/tools/components/tool_list.tsx
+++ b/webpack/tools/components/tool_list.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { Row, Col, Widget, WidgetBody, WidgetHeader } from "../../ui/index";
 import { t } from "i18next";
 import { ToolListProps } from "../interfaces";
-import { TaggedTool } from "../../resources/tagged_resources";
+import { TaggedTool } from "farmbot";
 import { ToolTips } from "../../constants";
 
 export class ToolList extends React.Component<ToolListProps, {}> {

--- a/webpack/tools/components/tool_slot_row.tsx
+++ b/webpack/tools/components/tool_slot_row.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { Row, Col, FBSelect, DropDownItem } from "../../ui";
 import { Popover, Position } from "@blueprintjs/core";
 import { SlotMenu } from "./toolbay_slot_menu";
-import { TaggedToolSlotPointer } from "../../resources/tagged_resources";
+import { TaggedToolSlotPointer } from "farmbot";
 import { destroy } from "../../api/crud";
 import { Xyz } from "../../devices/interfaces";
 import { ToolBayNumberCol } from "./toolbay_number_column";

--- a/webpack/tools/components/toolbay_form.tsx
+++ b/webpack/tools/components/toolbay_form.tsx
@@ -8,7 +8,6 @@ import {
 } from "../../ui/index";
 import { t } from "i18next";
 import {
-  TaggedToolSlotPointer,
   getArrayStatus
 } from "../../resources/tagged_resources";
 import { saveAll, init } from "../../api/crud";
@@ -16,6 +15,7 @@ import { ToolBayHeader } from "./toolbay_header";
 import { ToolTips } from "../../constants";
 import { ToolSlotRow } from "./tool_slot_row";
 import { emptyToolSlot } from "./empty_tool_slot";
+import { TaggedToolSlotPointer } from "farmbot";
 
 export class ToolBayForm extends React.Component<ToolBayFormProps, {}> {
 

--- a/webpack/tools/components/toolbay_list.tsx
+++ b/webpack/tools/components/toolbay_list.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { t } from "i18next";
 import { Row, Col, Widget, WidgetBody, WidgetHeader } from "../../ui/index";
 import { ToolBayListProps } from "../interfaces";
-import { TaggedToolSlotPointer } from "../../resources/tagged_resources";
+import { TaggedToolSlotPointer } from "farmbot";
 import { ToolBayHeader } from "./toolbay_header";
 import { ToolTips } from "../../constants";
 

--- a/webpack/tools/components/toolbay_number_column.tsx
+++ b/webpack/tools/components/toolbay_number_column.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { TaggedToolSlotPointer } from "../../resources/tagged_resources";
+import { TaggedToolSlotPointer } from "farmbot";
 import { Col, BlurableInput } from "../../ui/index";
 import { edit } from "../../api/crud";
 

--- a/webpack/tools/components/toolbay_slot_direction_selection.tsx
+++ b/webpack/tools/components/toolbay_slot_direction_selection.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { t } from "i18next";
 import { FBSelect, DropDownItem } from "../../ui/index";
-import { TaggedToolSlotPointer } from "../../resources/tagged_resources";
+import { TaggedToolSlotPointer } from "farmbot";
 import { ToolPulloutDirection } from "../../interfaces";
 import { edit } from "../../api/crud";
 import { isNumber } from "lodash";

--- a/webpack/tools/components/toolbay_slot_menu.tsx
+++ b/webpack/tools/components/toolbay_slot_menu.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { t } from "i18next";
 import { isNumber } from "lodash";
 import { BotPosition } from "../../devices/interfaces";
-import { TaggedToolSlotPointer } from "../../resources/tagged_resources";
+import { TaggedToolSlotPointer } from "farmbot";
 import { ToolPulloutDirection } from "../../interfaces";
 import { edit } from "../../api/crud";
 import { SlotDirectionSelect } from "./toolbay_slot_direction_selection";

--- a/webpack/tools/interfaces.ts
+++ b/webpack/tools/interfaces.ts
@@ -2,7 +2,7 @@ import { DropDownItem } from "../ui/index";
 import {
   TaggedTool,
   TaggedToolSlotPointer,
-} from "../resources/tagged_resources";
+} from "farmbot";
 import { BotPosition } from "../devices/interfaces";
 
 export interface ToolsState {

--- a/webpack/tools/state_to_props.ts
+++ b/webpack/tools/state_to_props.ts
@@ -8,12 +8,11 @@ import {
 } from "../resources/selectors";
 import {
   isTaggedTool,
-  TaggedTool,
-  TaggedToolSlotPointer
 } from "../resources/tagged_resources";
 import { edit } from "../api/crud";
 import { DropDownItem, NULL_CHOICE } from "../ui/index";
 import { validBotLocationData } from "../util";
+import { TaggedTool, TaggedToolSlotPointer } from "farmbot";
 
 export function mapStateToProps(props: Everything): Props {
   const toolSlots = selectAllToolSlotPointers(props.resources.index);

--- a/webpack/ui/save_button.tsx
+++ b/webpack/ui/save_button.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { t } from "i18next";
-import { SpecialStatus } from "../resources/tagged_resources";
+import { SpecialStatus } from "farmbot";
 
 interface SaveBtnProps {
   /** Callback */

--- a/webpack/util/util.ts
+++ b/webpack/util/util.ts
@@ -4,8 +4,10 @@ import { Dictionary } from "farmbot";
 import { Color } from "../interfaces";
 import { box } from "boxed_value";
 import {
-  TaggedResource, TaggedFirmwareConfig, TaggedFbosConfig
-} from "../resources/tagged_resources";
+  TaggedResource,
+  TaggedFirmwareConfig,
+  TaggedFbosConfig,
+} from "farmbot";
 import { BotLocationData } from "../devices/interfaces";
 import { FirmwareConfig } from "../config_storage/firmware_configs";
 import { FbosConfig } from "../config_storage/fbos_configs";

--- a/webpack/util/version.ts
+++ b/webpack/util/version.ts
@@ -1,6 +1,6 @@
 import { isString, isUndefined } from "lodash";
 import { BotState, Feature, MinOsFeatureLookup } from "../devices/interfaces";
-import { TaggedDevice } from "../resources/tagged_resources";
+import { TaggedDevice } from "farmbot";
 
 /**
  * for semverCompare()

--- a/yarn.lock
+++ b/yarn.lock
@@ -2417,9 +2417,9 @@ farmbot-toastr@^1.0.0, farmbot-toastr@^1.0.3:
     farmbot-toastr "^1.0.0"
     typescript "^2.3.4"
 
-"farmbot@https://github.com/RickCarlino/farmbot-js.git":
-  version "6.4.1"
-  resolved "https://github.com/RickCarlino/farmbot-js.git#9d7b3f479ba64c92ed904cf1b2150eaa5672da8f"
+farmbot@6.4.2:
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/farmbot/-/farmbot-6.4.2.tgz#8a3a7727cf9329fb4bc39ad4dbec5d17c8146669"
   dependencies:
     mqtt "2.15.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2417,9 +2417,9 @@ farmbot-toastr@^1.0.0, farmbot-toastr@^1.0.3:
     farmbot-toastr "^1.0.0"
     typescript "^2.3.4"
 
-farmbot@6.4.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/farmbot/-/farmbot-6.4.0.tgz#0d79a81aa2283e7b58004da50f5e5d76a3274010"
+"farmbot@https://github.com/RickCarlino/farmbot-js.git":
+  version "6.4.1"
+  resolved "https://github.com/RickCarlino/farmbot-js.git#9d7b3f479ba64c92ed904cf1b2150eaa5672da8f"
   dependencies:
     mqtt "2.15.0"
 


### PR DESCRIPTION
# What's New?

 * `TaggedResource` interfaces now live in FarmBotJS, which is requried to support the update-over-mqtt stuff.

# What's Next?

 * Need to restructure all the `::Update` mutations to have uniform input params
