### PR TITLE
Minor Touchups

### DIFF
--- a/app/views/log_delivery_mailer/log_digest.html.erb
+++ b/app/views/log_delivery_mailer/log_digest.html.erb
@@ -1,0 +1,13 @@
+<p>
+  <%= @device_name %> sent you an email.
+</p>
+
+<p>
+  Here's what your device had to say:
+</p>
+
+<ul>
+  <% @messages.each do |msg| %>
+    <li><%= msg %></li>
+  <% end %>
+</ul>

--- a/app/views/log_delivery_mailer/log_digest.text.erb
+++ b/app/views/log_delivery_mailer/log_digest.text.erb
@@ -4,4 +4,5 @@ Here's what your device had to say:
 
 <% @messages.each do |msg| %>
  * <%= msg %>
-<% end %>
+
+ <% end %>

--- a/webpack/tools/components/toolbay_number_column.tsx
+++ b/webpack/tools/components/toolbay_number_column.tsx
@@ -16,7 +16,7 @@ export function ToolBayNumberCol({ axis, value, dispatch, slot }: NumColProps) {
     <BlurableInput
       value={value.toString()}
       onCommit={(e) => {
-        dispatch(edit(slot, { [axis]: parseInt(e.currentTarget.value, 10) }));
+        dispatch(edit(slot, { [axis]: parseFloat(e.currentTarget.value) }));
       }}
       type="number" />
   </Col>;


### PR DESCRIPTION
 * Allow floats on the FE forms, also (not just API)
 * Update timestamp formatting (no timezone)
 * Add an HTML view for log digests so that HTML-only clients don't show up as one long line of text