### PR TITLE
Fix: Typo in consistency tracker

### DIFF
--- a/spec/mutations/sequences/perf_spec.rb
+++ b/spec/mutations/sequences/perf_spec.rb
@@ -1,7 +1,0 @@
-describe Sequences::Create do
-  it "has performance sprinkles" do
-    body = []
-    # Start recording the time it takes to create a sequence and
-    # graph the results.
-  end
-end

--- a/spec/mutations/sequences/perf_spec.rb
+++ b/spec/mutations/sequences/perf_spec.rb
@@ -1,0 +1,7 @@
+describe Sequences::Create do
+  it "has performance sprinkles" do
+    body = []
+    # Start recording the time it takes to create a sequence and
+    # graph the results.
+  end
+end

--- a/webpack/connectivity/data_consistency.ts
+++ b/webpack/connectivity/data_consistency.ts
@@ -31,7 +31,7 @@ set(window, "outstanding_requests", outstandingRequests);
 const PLACEHOLDER = "placeholder";
 
 /** Max wait in MS before clearing out. */
-const MAX_WAIT = 3500;
+// const MAX_WAIT = 3500;
 
 /**
 * PROBLEM:  You save a sequence and click "RUN" very fast. The remote device

--- a/webpack/connectivity/data_consistency.ts
+++ b/webpack/connectivity/data_consistency.ts
@@ -71,7 +71,7 @@ export function startTracking(uuid = PLACEHOLDER) {
   }
   storeUUID(cleanID);
   getDevice().on(cleanID, () => stopTracking(cleanID));
-  setTimeout(stopTracking, MAX_WAIT);
+  setTimeout(() => stopTracking(uuid), MAX_WAIT);
 }
 
 export function stopTracking(uuid: string) {

--- a/webpack/connectivity/data_consistency.ts
+++ b/webpack/connectivity/data_consistency.ts
@@ -31,7 +31,7 @@ set(window, "outstanding_requests", outstandingRequests);
 const PLACEHOLDER = "placeholder";
 
 /** Max wait in MS before clearing out. */
-// const MAX_WAIT = 3500;
+const MAX_WAIT = 11000;
 
 /**
 * PROBLEM:  You save a sequence and click "RUN" very fast. The remote device
@@ -71,7 +71,7 @@ export function startTracking(uuid = PLACEHOLDER) {
   }
   storeUUID(cleanID);
   getDevice().on(cleanID, () => stopTracking(cleanID));
-  // setTimeout(stop, MAX_WAIT);
+  setTimeout(stopTracking, MAX_WAIT);
 }
 
 export function stopTracking(uuid: string) {

--- a/webpack/connectivity/data_consistency.ts
+++ b/webpack/connectivity/data_consistency.ts
@@ -71,7 +71,7 @@ export function startTracking(uuid = PLACEHOLDER) {
   }
   storeUUID(cleanID);
   getDevice().on(cleanID, () => stopTracking(cleanID));
-  setTimeout(stop, MAX_WAIT);
+  // setTimeout(stop, MAX_WAIT);
 }
 
 export function stopTracking(uuid: string) {


### PR DESCRIPTION
This was causing many network / time-based race conditions.

A timer was calling `window.stop` rather than `stopTracking`
