### PR TITLE
Configuration Default Updates

### DIFF
--- a/config/database.example.yml
+++ b/config/database.example.yml
@@ -4,13 +4,13 @@ default: &default
   pool: 5
 
 development:
-  database: farmbot_development
   <<: *default
+  database: farmbot_development
 
 test:
-  database: farmbot_test
   <<: *default
+  database: farmbot_test
 
 production:
-  database: farmbot_prod
   <<: *default
+  database: farmbot_prod

--- a/config/database.travis.yml
+++ b/config/database.travis.yml
@@ -3,9 +3,9 @@ defaults: &defaults
   min_messages: ERROR
 
 development:
-  database: farmbot_development
   <<: *defaults
+  database: farmbot_development
 
 test:
-  database: farmbot_test
   <<: *defaults
+  database: farmbot_test

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,3 @@
-puts "Seeding database: " + ActiveRecord::Base.connection.current_database
 
 unless Rails.env == "development"
     POINT_COUNT             = 8

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,6 @@
-unless Rails.env == "production"
+puts "Seeding database: " + ActiveRecord::Base.connection.current_database
+
+unless Rails.env == "development"
     POINT_COUNT             = 8
     PLANT_COUNT             = 8
     DATE_RANGE_LO           = 1..3

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,4 @@
-
-unless Rails.env == "development"
+if Rails.env == "development"
     POINT_COUNT             = 8
     PLANT_COUNT             = 8
     DATE_RANGE_LO           = 1..3

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1218,7 +1218,8 @@ CREATE TABLE public.web_app_configs (
     discard_unsaved boolean DEFAULT false,
     xy_swap boolean DEFAULT false,
     home_button_homing boolean DEFAULT false,
-    show_motor_plot boolean DEFAULT false
+    show_motor_plot boolean DEFAULT false,
+    show_historic_points boolean DEFAULT false
 );
 
 
@@ -2324,6 +2325,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180813185430'),
 ('20180815143819'),
 ('20180829211322'),
-('20180910143055');
+('20180910143055'),
+('20180920194120');
 
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -93,8 +93,9 @@ RSpec.configure do |config|
   config.include Helpers
   config.infer_spec_type_from_file_location!
   config.order = "random"
-  config.after(:each) do
-    puts "===" + ActiveRecord::Base.connection.current_database
+  config.before(:each) do
+    db_name = ActiveRecord::Base.connection.current_database
+    raise "WARNING WRONG DATABASE" unless db_name.include?("_test")
   end
   if ENV["DOCS"]
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -93,13 +93,6 @@ RSpec.configure do |config|
   config.include Helpers
   config.infer_spec_type_from_file_location!
   config.order = "random"
-  config.before(:each) do
-    db_name  = ActiveRecord::Base.connection.current_database
-    db_name2 = Rails.configuration.database_configuration[Rails.env]["database"]
-    raise "WARNING WRONG DATABASE" unless db_name.include?("_test")
-    raise "WARNING WRONG DATABASE" unless db_name2.include?("_test")
-    raise "WRONG DATABASE"         unless ENV["RAILS_ENV"] == "test"
-  end
   if ENV["DOCS"]
 
     config.after(:each, type: :controller) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -94,7 +94,6 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.order = "random"
   if ENV["DOCS"]
-
     config.after(:each, type: :controller) do
       SmarfDoc.run!(NiceResponse.new(request), response)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -94,8 +94,11 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.order = "random"
   config.before(:each) do
-    db_name = ActiveRecord::Base.connection.current_database
+    db_name  = ActiveRecord::Base.connection.current_database
+    db_name2 = Rails.configuration.database_configuration[Rails.env]["database"]
     raise "WARNING WRONG DATABASE" unless db_name.include?("_test")
+    raise "WARNING WRONG DATABASE" unless db_name2.include?("_test")
+    raise "WRONG DATABASE"         unless ENV["RAILS_ENV"] == "test"
   end
   if ENV["DOCS"]
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -93,7 +93,11 @@ RSpec.configure do |config|
   config.include Helpers
   config.infer_spec_type_from_file_location!
   config.order = "random"
+  config.after(:each) do
+    puts "===" + ActiveRecord::Base.connection.current_database
+  end
   if ENV["DOCS"]
+
     config.after(:each, type: :controller) do
       SmarfDoc.run!(NiceResponse.new(request), response)
     end


### PR DESCRIPTION
This PR introduces a fix that prevents the `development` database from being dropped under certain circumstances (after running tests).