### PR TITLE
Bug fix: Step clone button

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,8 @@ services:
     <<: *base_config
     <<: *db_user
     <<: *rails
+    stdin_open: true # Needed for binding.pry
+    tty: true        # Needed for binding.pry
     build:
       context: .
       dockerfile: docker_configs/api.Dockerfile

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "css-loader": "^1.0.1",
     "enzyme": "^3.7.0",
     "enzyme-adapter-react-16": "^1.6.0",
-    "farmbot": "^6.5.8",
+    "farmbot": "^6.5.11",
     "farmbot-toastr": "^1.0.3",
     "fastclick": "^1.0.6",
     "file-loader": "2.0.0",

--- a/spec/mutations/users/create_spec.rb
+++ b/spec/mutations/users/create_spec.rb
@@ -52,7 +52,7 @@ describe Users::Create do
     end
 
     it "stops users from registering twice" do
-      email   = User.last.email || FactoryBot.create(:email)
+      email   = (User.last || FactoryBot.create(:user)).email
       results = Users::Create.run(email:                 email,
                                   name:                  "Faker",
                                   password:              "password12345",

--- a/webpack/api/crud.ts
+++ b/webpack/api/crud.ts
@@ -37,11 +37,10 @@ export function edit(tr: TaggedResource, changes: Partial<typeof tr.body>):
 
 /** Rather than update (patch) a TaggedResource, this method will overwrite
  * everything within the `.body` property. */
-export function overwrite(tr: TaggedResource,
-  changeset: typeof tr.body,
+export function overwrite<T extends TaggedResource>(tr: T,
+  changeset: Partial<T["body"]>,
   specialStatus = SpecialStatus.DIRTY):
   ReduxAction<EditResourceParams> {
-
   return {
     type: Actions.OVERWRITE_RESOURCE,
     payload: { uuid: tr.uuid, update: changeset, specialStatus }

--- a/webpack/connectivity/auto_sync.ts
+++ b/webpack/connectivity/auto_sync.ts
@@ -44,6 +44,7 @@ export const handleUpdate =
   (d: UpdateMqttData<TaggedResource>, uuid: string) => {
     const tr = asTaggedResource(d);
     tr.uuid = uuid;
+    console.error("This is the cause of bug (5)");
     return overwrite(tr, tr.body, SpecialStatus.SAVED);
   };
 

--- a/webpack/devices/components/__tests__/diagnostic_dump_row_test.tsx
+++ b/webpack/devices/components/__tests__/diagnostic_dump_row_test.tsx
@@ -1,7 +1,3 @@
-jest.mock("../../../account/request_account_export", () => {
-  return { jsonDownload: jest.fn() };
-});
-
 jest.mock("../../../api/crud", () => {
   return { destroy: jest.fn() };
 });
@@ -12,7 +8,6 @@ import { DiagnosticDumpRow } from "../diagnostic_dump_row";
 import {
   fakeDiagnosticDump
 } from "../../../__test_support__/fake_state/resources";
-import { jsonDownload } from "../../../account/request_account_export";
 import { destroy } from "../../../api/crud";
 
 describe("<DiagnosticDumpRow/>", () => {
@@ -22,9 +17,6 @@ describe("<DiagnosticDumpRow/>", () => {
     diag.body.ticket_identifier = "0000";
     const el = mount(<DiagnosticDumpRow dispatch={dispatch} diag={diag} />);
     expect(el.text()).toContain("0000");
-    el.find("button.green").first().simulate("click");
-    expect(jsonDownload).toHaveBeenCalledWith(diag.body,
-      "farmbot_diagnostics_0000.json");
     el.find("button.red").first().simulate("click");
     expect(destroy).toHaveBeenCalledWith(diag.uuid);
   });

--- a/webpack/devices/components/__tests__/diagnostic_dump_row_test.tsx
+++ b/webpack/devices/components/__tests__/diagnostic_dump_row_test.tsx
@@ -9,7 +9,10 @@ jest.mock("../../../api/crud", () => {
 import * as React from "react";
 import { mount } from "enzyme";
 import { DiagnosticDumpRow } from "../diagnostic_dump_row";
-import { fakeDiagnosticDump } from "../../../__test_support__/fake_state/resources";
+import {
+  fakeDiagnosticDump
+} from "../../../__test_support__/fake_state/resources";
+import { jsonDownload } from "../../../account/request_account_export";
 import { destroy } from "../../../api/crud";
 
 describe("<DiagnosticDumpRow/>", () => {
@@ -19,6 +22,9 @@ describe("<DiagnosticDumpRow/>", () => {
     diag.body.ticket_identifier = "0000";
     const el = mount(<DiagnosticDumpRow dispatch={dispatch} diag={diag} />);
     expect(el.text()).toContain("0000");
+    el.find("button.green").first().simulate("click");
+    expect(jsonDownload).toHaveBeenCalledWith(diag.body,
+      "farmbot_diagnostics_0000.json");
     el.find("button.red").first().simulate("click");
     expect(destroy).toHaveBeenCalledWith(diag.uuid);
   });

--- a/webpack/devices/components/diagnostic_dump_row.tsx
+++ b/webpack/devices/components/diagnostic_dump_row.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import { Row, Col } from "../../ui";
 import { TaggedDiagnosticDump } from "farmbot";
-import { jsonDownload } from "../../account/request_account_export";
 import { destroy } from "../../api/crud";
 import { ago } from "../connectivity/status_checks";
 import { t } from "i18next";
@@ -18,25 +17,9 @@ export class DiagnosticDumpRow extends React.Component<Props, {}> {
 
   destroy = () => this.props.dispatch(destroy(this.props.diag.uuid));
 
-  download = (e: React.MouseEvent<{}>) => {
-    e.preventDefault();
-    const { body } = this.props.diag;
-    const { ticket_identifier } = body;
-    const fileName = `farmbot_diagnostics_${ticket_identifier}.json`;
-    jsonDownload(body, fileName);
-  }
-
   render() {
     return <Row>
-      <Col xs={3}>
-        <button
-          className="fb-button green"
-          hidden={true}
-          onClick={this.download}>
-          {t("Download")}
-        </button>
-      </Col>
-      <Col xs={8}>
+      <Col xsOffset={3} xs={8}>
         {t("Report {{ticket}} (Saved {{age}})",
           { ticket: this.ticket, age: this.age })}
       </Col>

--- a/webpack/devices/components/diagnostic_dump_row.tsx
+++ b/webpack/devices/components/diagnostic_dump_row.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Row, Col } from "../../ui";
 import { TaggedDiagnosticDump } from "farmbot";
-import { jsonDownload } from "../../account/request_account_export";
+// import { jsonDownload } from "../../account/request_account_export";
 import { destroy } from "../../api/crud";
 import { ago } from "../connectivity/status_checks";
 import { t } from "i18next";
@@ -18,13 +18,13 @@ export class DiagnosticDumpRow extends React.Component<Props, {}> {
 
   destroy = () => this.props.dispatch(destroy(this.props.diag.uuid));
 
-  download = (e: React.MouseEvent<{}>) => {
-    e.preventDefault();
-    const { body } = this.props.diag;
-    const { ticket_identifier } = body;
-    const fileName = `farmbot_diagnostics_${ticket_identifier}.json`;
-    jsonDownload(body, fileName);
-  }
+  // download = (e: React.MouseEvent<{}>) => {
+  //   e.preventDefault();
+  //   const { body } = this.props.diag;
+  //   const { ticket_identifier } = body;
+  //   const fileName = `farmbot_diagnostics_${ticket_identifier}.json`;
+  //   jsonDownload(body, fileName);
+  // }
 
   render() {
     return <Row>

--- a/webpack/devices/components/diagnostic_dump_row.tsx
+++ b/webpack/devices/components/diagnostic_dump_row.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Row, Col } from "../../ui";
 import { TaggedDiagnosticDump } from "farmbot";
-// import { jsonDownload } from "../../account/request_account_export";
+import { jsonDownload } from "../../account/request_account_export";
 import { destroy } from "../../api/crud";
 import { ago } from "../connectivity/status_checks";
 import { t } from "i18next";
@@ -18,22 +18,23 @@ export class DiagnosticDumpRow extends React.Component<Props, {}> {
 
   destroy = () => this.props.dispatch(destroy(this.props.diag.uuid));
 
-  // download = (e: React.MouseEvent<{}>) => {
-  //   e.preventDefault();
-  //   const { body } = this.props.diag;
-  //   const { ticket_identifier } = body;
-  //   const fileName = `farmbot_diagnostics_${ticket_identifier}.json`;
-  //   jsonDownload(body, fileName);
-  // }
+  download = (e: React.MouseEvent<{}>) => {
+    e.preventDefault();
+    const { body } = this.props.diag;
+    const { ticket_identifier } = body;
+    const fileName = `farmbot_diagnostics_${ticket_identifier}.json`;
+    jsonDownload(body, fileName);
+  }
 
   render() {
     return <Row>
       <Col xs={3}>
-        {/* <button
-          className="green fb-button"
+        <button
+          className="fb-button green"
+          hidden={true}
           onClick={this.download}>
           {t("Download")}
-        </button> */}
+        </button>
       </Col>
       <Col xs={8}>
         {t("Report {{ticket}} (Saved {{age}})",

--- a/webpack/resources/__tests__/reducer_test.ts
+++ b/webpack/resources/__tests__/reducer_test.ts
@@ -27,7 +27,7 @@ describe("resource reducer", () => {
     expect(sequence.kind).toBe("Sequence");
     const next = resourceReducer(state, overwrite(sequence, {
       name: "wow",
-      args: { locals: { kind: "scope_declaration", args: {} } },
+      args: { version: -0, locals: { kind: "scope_declaration", args: {} } },
       body: []
     }));
     const seq2 = next.index.references[uuid] as TaggedSequence;

--- a/webpack/resources/__tests__/sequence_tagging_test.ts
+++ b/webpack/resources/__tests__/sequence_tagging_test.ts
@@ -1,6 +1,6 @@
 import { TaggedSequence, SpecialStatus } from "farmbot";
 import { get } from "lodash";
-import { getStepTag, setStepTag } from "../sequence_tagging";
+import { getStepTag, maybeTagStep } from "../sequence_tagging";
 
 describe("tagAllSteps()", () => {
   const UNTAGGED_SEQUENCE: TaggedSequence = {
@@ -36,7 +36,7 @@ describe("tagAllSteps()", () => {
     expect(() => {
       getStepTag(body[0]);
     }).toThrow();
-    setStepTag(body[0]);
+    maybeTagStep(body[0]);
     expect(get(body[0], "uuid")).toBeDefined();
   });
 });

--- a/webpack/resources/sequence_tagging.ts
+++ b/webpack/resources/sequence_tagging.ts
@@ -52,8 +52,13 @@ export type StepTag = string;
 /** Property name where a unique ID is stored in a step. */
 const TAG_PROP = "uuid";
 
-export const setStepTag =
-  (node: Traversable) => !get(node, TAG_PROP) && set(node, TAG_PROP, uuid());
+export const maybeTagStep =
+  (t: Traversable) => !get(t, TAG_PROP) && forceSetStepTag(t);
+
+export const forceSetStepTag = <T extends Traversable>(node: T): T => {
+  set(node, TAG_PROP, uuid());
+  return node;
+};
 
 /** VERY IMPORTANT FUNCTION.
  *  SEE HEADER AT TOP OF FILE.

--- a/webpack/sequences/__tests__/locals_list_test.tsx
+++ b/webpack/sequences/__tests__/locals_list_test.tsx
@@ -33,7 +33,9 @@ import {
   guessVecFromLabel,
   guessXYZ,
   ParentVariableFormProps,
-  PARENT, LocalsListProps
+  PARENT,
+  LocalsListProps,
+  localListOnChange
 } from "../locals_list_support";
 
 const coord: Coordinate = { kind: "coordinate", args: { x: 1, y: 2, z: 3 } };
@@ -45,6 +47,15 @@ const mrGoodVar: VariableDeclaration = {
   // https://en.wikipedia.org/wiki/Mr._Goodbar
   kind: "variable_declaration",
   args: { label: "parent", data_value: coord }
+};
+
+const props = (): LocalsListProps => {
+  const sequence = fakeSequence();
+  return {
+    sequence,
+    resources: buildResourceIndex([sequence]).index,
+    dispatch: jest.fn()
+  };
 };
 
 describe("extractParent()", () => {
@@ -269,49 +280,54 @@ describe("guessXYZ", () => {
 
 describe("<ParentVariableForm/>", () => {
   it("renders correct UI components", () => {
-    const props: ParentVariableFormProps = {
+    const props2: ParentVariableFormProps = {
       parent: mrGoodVar,
       resources: buildResourceIndex().index,
       onChange: jest.fn()
     };
 
-    const el = shallow(<ParentVariableForm {...props} />);
+    const el = shallow(<ParentVariableForm {...props2} />);
     const selects = el.find(FBSelect);
     const inputs = el.find(InputBox);
 
     expect(selects.length).toBe(1);
     const p = selects.first().props();
     expect(p.allowEmpty).toBe(true);
-    const choices = generateList(props.resources, [PARENT]);
+    const choices = generateList(props2.resources, [PARENT]);
     expect(p.list).toEqual(choices);
     const choice = choices[1];
     p.onChange(choice);
-    expect(props.onChange)
-      .toHaveBeenCalledWith(handleSelect(props.resources, choice));
+    expect(props2.onChange)
+      .toHaveBeenCalledWith(handleSelect(props2.resources, choice));
     expect(inputs.length).toBe(3);
   });
 });
 
 describe("<LocalsList/>", () => {
-  const props: LocalsListProps = {
-    sequence: fakeSequence(),
-    resources: buildResourceIndex().index,
-    dispatch: jest.fn()
-  };
 
   it("renders nothing", () => {
-    props.sequence.body.args.locals = { kind: "scope_declaration", args: {} };
-    const el = shallow(<LocalsList {...props} />);
+    const p = props();
+    p.sequence.body.args.locals = { kind: "scope_declaration", args: {} };
+    const el = shallow(<LocalsList {...p} />);
     expect(el.find(ParentVariableForm).length).toBe(0);
   });
 
   it("renders something", () => {
-    props.sequence.body.args.locals = {
+    const p = props();
+    p.sequence.body.args.locals = {
       kind: "scope_declaration",
       args: {},
       body: [mrGoodVar]
     };
-    const el = shallow(<LocalsList {...props} />);
+    const el = shallow(<LocalsList {...p} />);
     expect(el.find(ParentVariableForm).length).toBe(1);
+  });
+});
+
+describe("localListOnChange", () => {
+  it("triggers the dispatch()er", () => {
+    const p = props();
+    localListOnChange(p);
+    expect(p.dispatch).toHaveBeenCalled();
   });
 });

--- a/webpack/sequences/__tests__/locals_list_test.tsx
+++ b/webpack/sequences/__tests__/locals_list_test.tsx
@@ -1,17 +1,7 @@
 import * as React from "react";
 import {
-  extractParent,
-  handleVariableChange,
-  setParent,
-  changeAxis,
-  guessFromDataType,
-  guessVecFromLabel,
-  guessXYZ,
-  ParentVariableFormProps,
   ParentVariableForm,
-  LocalsListProps,
   LocalsList,
-  PARENT
 } from "../locals_list";
 import {
   VariableDeclaration,
@@ -20,15 +10,31 @@ import {
   Point,
   Coordinate
 } from "farmbot";
-import { fakeSequence, fakeTool } from "../../__test_support__/fake_state/resources";
+import {
+  fakeSequence,
+  fakeTool
+} from "../../__test_support__/fake_state/resources";
 import { overwrite } from "../../api/crud";
 import { defensiveClone } from "../../util";
 import { shallow } from "enzyme";
-import { buildResourceIndex } from "../../__test_support__/resource_index_builder";
+import {
+  buildResourceIndex
+} from "../../__test_support__/resource_index_builder";
 import { FBSelect } from "../../ui/index";
 import {
   InputBox, generateList, handleSelect
 } from "../step_tiles/tile_move_absolute/index";
+import {
+  extractParent,
+  setParent,
+  handleVariableChange,
+  changeAxis,
+  guessFromDataType,
+  guessVecFromLabel,
+  guessXYZ,
+  ParentVariableFormProps,
+  PARENT, LocalsListProps
+} from "../locals_list_support";
 
 const coord: Coordinate = { kind: "coordinate", args: { x: 1, y: 2, z: 3 } };
 const t = fakeTool();

--- a/webpack/sequences/__tests__/locals_list_test.tsx
+++ b/webpack/sequences/__tests__/locals_list_test.tsx
@@ -327,7 +327,8 @@ describe("<LocalsList/>", () => {
 describe("localListOnChange", () => {
   it("triggers the dispatch()er", () => {
     const p = props();
-    localListOnChange(p);
+    const cb = localListOnChange(p);
+    cb({ kind: "coordinate", args: { x: 0, y: 0, z: 0 } });
     expect(p.dispatch).toHaveBeenCalled();
   });
 });

--- a/webpack/sequences/__tests__/sequence_editor_middle_active_test.tsx
+++ b/webpack/sequences/__tests__/sequence_editor_middle_active_test.tsx
@@ -19,10 +19,9 @@ jest.mock("../../devices/actions", () => ({
 }));
 
 let mockParent = false;
-jest.mock("../locals_list", () => ({
-  extractParent: () => mockParent,
-  LocalsList: () => <div />,
-}));
+jest.mock("../locals_list_support", () => ({ extractParent: () => mockParent }));
+
+jest.mock("../locals_list", () => ({ LocalsList: () => <div /> }));
 
 import * as React from "react";
 import {

--- a/webpack/sequences/locals_list.tsx
+++ b/webpack/sequences/locals_list.tsx
@@ -86,7 +86,7 @@ export const LocalsList = (p: LocalsListProps) => {
     return <ParentVariableForm
       parent={parent}
       resources={resources}
-      onChange={() => localListOnChange(p)} />;
+      onChange={localListOnChange(p)} />;
   } else {
     return <div />;
   }

--- a/webpack/sequences/locals_list.tsx
+++ b/webpack/sequences/locals_list.tsx
@@ -1,171 +1,27 @@
 import * as React from "react";
 import {
-  ParameterDeclaration,
-  VariableDeclaration,
-  Vector3,
-  ScopeDeclarationBodyItem
-} from "farmbot";
-import { ResourceIndex } from "../resources/interfaces";
-import {
-  LocationData, InputBox, generateList, formatSelectedDropdown, handleSelect,
-  CeleryVariable, EMPTY_COORD
-} from "./step_tiles/tile_move_absolute/index";
-import { overwrite } from "../api/crud";
-import { TaggedSequence } from "farmbot";
-import { defensiveClone } from "../util";
-import { Row, Col, FBSelect } from "../ui/index";
+  ParentVariableFormProps,
+  guessXYZ,
+  PARENT,
+  changeAxis,
+  LocalsListProps,
+  extractParent,
+  localListOnChange
+} from "./locals_list_support";
+import { Row, Col, FBSelect } from "../ui";
 import { t } from "i18next";
-import { isNaN } from "lodash";
-import { findSlotByToolId } from "../resources/selectors_by_id";
+import {
+  generateList
+} from "./step_tiles/tile_move_absolute/generate_list";
+import {
+  formatSelectedDropdown
+} from "./step_tiles/tile_move_absolute/format_selected_dropdown";
+import {
+  EMPTY_COORD,
+  handleSelect
+} from "./step_tiles/tile_move_absolute/handle_select";
+import { InputBox } from "./step_tiles/tile_move_absolute/input_box";
 
-type OnChange = (data_type: LocationData | ParameterDeclaration) => void;
-type DataValue = VariableDeclaration["args"]["data_value"];
-
-export interface LocalsListProps {
-  sequence: TaggedSequence;
-  resources: ResourceIndex;
-  dispatch: Function;
-}
-
-export interface ParentVariableFormProps {
-  parent: VariableDeclaration | ParameterDeclaration;
-  resources: ResourceIndex;
-  onChange: OnChange;
-}
-
-const KINDS = ["parameter_declaration", "variable_declaration"];
-/** Given an array of variable declarations (or undefined), finds the "parent"
- * special identifier */
-export const extractParent =
-  (list?: ScopeDeclarationBodyItem[]): ScopeDeclarationBodyItem | undefined => {
-    const p = (list ? list : []).filter(x => {
-      const isParent = x.args.label === "parent";
-      const isVar = KINDS.includes(x.kind);
-      return isVar && isParent;
-    })[0];
-    switch (p && p.kind) {
-      case "variable_declaration":
-      case "parameter_declaration":
-        return p;
-      default:
-        return undefined;
-    }
-  };
-
-/** Takes a sequence and data_value. Turn the data_value into the sequence's new
- * `parent` variable. This is a _pure function_. */
-export const setParent = (sequence: TaggedSequence, data_value: CeleryVariable) => {
-  const nextSeq: typeof sequence.body = defensiveClone(sequence.body);
-  switch (data_value.kind) {
-    case "tool":
-    case "point":
-    case "coordinate":
-      nextSeq.args.locals = {
-        kind: "scope_declaration",
-        args: {},
-        body: [
-          {
-            kind: "variable_declaration",
-            args: {
-              label: "parent",
-              data_value
-            }
-          }
-        ]
-      };
-      break;
-    case "parameter_declaration":
-      nextSeq.args.locals = {
-        kind: "scope_declaration",
-        args: {},
-        body: [{
-          kind: "parameter_declaration",
-          args: { label: "parent", data_type: "point" }
-        }]
-      };
-      break;
-    default:
-      throw new Error("Bad kind in setParent(): " + data_value.kind);
-  }
-  return nextSeq;
-};
-
-/** Returns the event handler that gets called when you edit the X/Y/Z*/
-export const handleVariableChange =
-  (dispatch: Function, sequence: TaggedSequence) =>
-    (data_value: LocationData) =>
-      dispatch(overwrite(sequence, setParent(sequence, data_value)));
-
-/** Callback generator called when user changes the x/y/z of a variable in the
- * sequence generator. */
-export const changeAxis =
-  (axis: keyof Vector3, onChange: OnChange, data_type: LocationData) =>
-    (e: React.SyntheticEvent<HTMLInputElement>) => {
-      if (data_type.kind === "coordinate") {
-        const nextDT = defensiveClone(data_type);
-        nextDT.args[axis] = parseInt(e.currentTarget.value, 10);
-        onChange(nextDT);
-      } else {
-        throw new Error("Never not coord");
-      }
-    };
-
-/** If variable is a coordinate, just use the coordinates. */
-export const guessFromDataType =
-  (x: DataValue): Vector3 | undefined => (x.kind === "coordinate") ?
-    x.args : undefined;
-
-/** GLORIOUS hack: We spend a *lot* of time in the sequence editor looking up
-* resource x/y/z. It's resource intensive and often hard to understand.
-* Instead of adding more selectors and complexity, we make a "best effort"
-* attempt to read the resource's `x`, `y`, `z` that are cached (as strings)
-* in the drop down label.
-*
-* String manipulation is bad, but I think it is warranted here: */
-export const guessVecFromLabel =
-  (label: string): Vector3 | undefined => {
-    const step1 = label
-      .trim()
-      .replace(")", "")
-      .replace(/^\s+|\s+$/g, "")
-      .split(/\(|\,/);
-    const vec = step1
-      .slice(Math.max(step1.length - 3, 1))
-      .map(x => parseInt(x, 10))
-      .filter(x => !isNaN(x));
-
-    return (vec.length === 3) ?
-      { x: vec[0], y: vec[1], z: vec[2] } : undefined;
-  };
-
-export const PARENT = { value: "parent", label: "Parent", headingId: "parameter" };
-
-/** Return this when unable to correctly guess coordinate values */
-const EMPTY_VEC3 = { x: 0, y: 0, z: 0 };
-type ParentType = ParameterDeclaration | VariableDeclaration;
-
-const maybeFetchToolCoords =
-  (data_value: DataValue, resources: ResourceIndex): Vector3 | undefined => {
-    if (data_value.kind === "tool") {
-      const r = findSlotByToolId(resources, data_value.args.tool_id);
-      return r && r.body;
-    }
-  };
-const guessVariable =
-  (label: string, local: VariableDeclaration, resources: ResourceIndex): Vector3 => {
-    return guessVecFromLabel(label) ||
-      guessFromDataType(local.args.data_value) ||
-      maybeFetchToolCoords(local.args.data_value, resources) ||
-      EMPTY_VEC3;
-  };
-
-/** Given a dropdown label and a local variable declaration, tries to guess the
-* X/Y/Z value of the declared variable. If unable to guess,
-* returns (0, 0, 0) */
-export const guessXYZ = (label: string, local: ParentType, resources: ResourceIndex): Vector3 => {
-  return (local.kind === "variable_declaration") ?
-    guessVariable(label, local, resources) : EMPTY_VEC3;
-};
 /** When sequence.args.locals actually has variables, render this form.
  * Allows the user to chose the value of the `parent` variable, etc. */
 export const ParentVariableForm =
@@ -223,21 +79,15 @@ export const ParentVariableForm =
 
 /** List of local variable declarations for a sequence. If no variables are
  * found, shows nothing. */
-export const LocalsList =
-  ({ resources, sequence, dispatch }: LocalsListProps) => {
-    const parent = extractParent(sequence.body.args.locals.body);
-    if (parent) {
-      return <ParentVariableForm
-        parent={parent}
-        resources={resources}
-        onChange={() => {
-          // Something strange happens here with closure scope, I think.
-          // Was getting stale data bugs.
-          // HOTFIX: Pull the `sequence` out of the index at execution time.
-          const s = resources.references[sequence.uuid];
-          s && s.kind == "Sequence" && handleVariableChange(dispatch, s);
-        }} />;
-    } else {
-      return <div />;
-    }
-  };
+export const LocalsList = (p: LocalsListProps) => {
+  const { resources, sequence } = p;
+  const parent = extractParent(sequence.body.args.locals.body);
+  if (parent) {
+    return <ParentVariableForm
+      parent={parent}
+      resources={resources}
+      onChange={() => localListOnChange(p)} />;
+  } else {
+    return <div />;
+  }
+};

--- a/webpack/sequences/locals_list_support.ts
+++ b/webpack/sequences/locals_list_support.ts
@@ -1,0 +1,180 @@
+import {
+  ParameterDeclaration,
+  VariableDeclaration,
+  Vector3,
+  ScopeDeclarationBodyItem
+} from "farmbot";
+import { ResourceIndex } from "../resources/interfaces";
+import {
+  LocationData,
+  CeleryVariable
+} from "./step_tiles/tile_move_absolute/index";
+import { overwrite } from "../api/crud";
+import { TaggedSequence } from "farmbot";
+import { defensiveClone } from "../util";
+import { isNaN } from "lodash";
+import { findSlotByToolId } from "../resources/selectors_by_id";
+
+type OnChange = (data_type: LocationData | ParameterDeclaration) => void;
+type DataValue = VariableDeclaration["args"]["data_value"];
+type ParentType = ParameterDeclaration | VariableDeclaration;
+
+export interface LocalsListProps {
+  sequence: TaggedSequence;
+  resources: ResourceIndex;
+  dispatch: Function;
+}
+
+export interface ParentVariableFormProps {
+  parent: VariableDeclaration | ParameterDeclaration;
+  resources: ResourceIndex;
+  onChange: OnChange;
+}
+
+export const PARENT =
+  ({ value: "parent", label: "Parent", headingId: "parameter" });
+
+/** Return this when unable to correctly guess coordinate values */
+const EMPTY_VEC3 = { x: 0, y: 0, z: 0 };
+
+const KINDS = ["parameter_declaration", "variable_declaration"];
+/** Given an array of variable declarations (or undefined), finds the "parent"
+ * special identifier */
+export const extractParent =
+  (list?: ScopeDeclarationBodyItem[]): ScopeDeclarationBodyItem | undefined => {
+    const p = (list ? list : []).filter(x => {
+      const isParent = x.args.label === "parent";
+      const isVar = KINDS.includes(x.kind);
+      return isVar && isParent;
+    })[0];
+    switch (p && p.kind) {
+      case "variable_declaration":
+      case "parameter_declaration":
+        return p;
+      default:
+        return undefined;
+    }
+  };
+
+/** Takes a sequence and data_value. Turn the data_value into the sequence's new
+ * `parent` variable. This is a _pure function_. */
+export const setParent =
+  (sequence: TaggedSequence, data_value: CeleryVariable) => {
+    const nextSeq: typeof sequence.body = defensiveClone(sequence.body);
+    switch (data_value.kind) {
+      case "tool":
+      case "point":
+      case "coordinate":
+        nextSeq.args.locals = {
+          kind: "scope_declaration",
+          args: {},
+          body: [
+            {
+              kind: "variable_declaration",
+              args: {
+                label: "parent",
+                data_value
+              }
+            }
+          ]
+        };
+        break;
+      case "parameter_declaration":
+        nextSeq.args.locals = {
+          kind: "scope_declaration",
+          args: {},
+          body: [{
+            kind: "parameter_declaration",
+            args: { label: "parent", data_type: "point" }
+          }]
+        };
+        break;
+      default:
+        throw new Error("Bad kind in setParent(): " + data_value.kind);
+    }
+    return nextSeq;
+  };
+
+/** Returns the event handler that gets called when you edit the X/Y/Z*/
+export const handleVariableChange =
+  (dispatch: Function, sequence: TaggedSequence) =>
+    (data_value: LocationData) =>
+      dispatch(overwrite(sequence, setParent(sequence, data_value)));
+
+/** Callback generator called when user changes the x/y/z of a variable in the
+ * sequence generator. */
+export const changeAxis =
+  (axis: keyof Vector3, onChange: OnChange, data_type: LocationData) =>
+    (e: React.SyntheticEvent<HTMLInputElement>) => {
+      if (data_type.kind === "coordinate") {
+        const nextDT = defensiveClone(data_type);
+        nextDT.args[axis] = parseInt(e.currentTarget.value, 10);
+        onChange(nextDT);
+      } else {
+        throw new Error("Never not coord");
+      }
+    };
+
+/** If variable is a coordinate, just use the coordinates. */
+export const guessFromDataType =
+  (x: DataValue): Vector3 | undefined => (x.kind === "coordinate") ?
+    x.args : undefined;
+
+/** GLORIOUS hack: We spend a *lot* of time in the sequence editor looking up
+* resource x/y/z. It's resource intensive and often hard to understand.
+* Instead of adding more selectors and complexity, we make a "best effort"
+* attempt to read the resource's `x`, `y`, `z` that are cached (as strings)
+* in the drop down label.
+*
+* String manipulation is bad, but I think it is warranted here: */
+export const guessVecFromLabel =
+  (label: string): Vector3 | undefined => {
+    const step1 = label
+      .trim()
+      .replace(")", "")
+      .replace(/^\s+|\s+$/g, "")
+      .split(/\(|\,/);
+    const vec = step1
+      .slice(Math.max(step1.length - 3, 1))
+      .map(x => parseInt(x, 10))
+      .filter(x => !isNaN(x));
+
+    return (vec.length === 3) ?
+      { x: vec[0], y: vec[1], z: vec[2] } : undefined;
+  };
+
+const maybeFetchToolCoords =
+  (data_value: DataValue, resources: ResourceIndex): Vector3 | undefined => {
+    if (data_value.kind === "tool") {
+      const r = findSlotByToolId(resources, data_value.args.tool_id);
+      return r && r.body;
+    }
+  };
+
+const guessVariable = (label: string,
+  local: VariableDeclaration,
+  resources: ResourceIndex): Vector3 => {
+
+  return guessVecFromLabel(label) ||
+    guessFromDataType(local.args.data_value) ||
+    maybeFetchToolCoords(local.args.data_value, resources) ||
+    EMPTY_VEC3;
+};
+
+/** Given a dropdown label and a local variable declaration, tries to guess the
+* X/Y/Z value of the declared variable. If unable to guess,
+* returns (0, 0, 0) */
+export const guessXYZ =
+  (label: string, local: ParentType, resources: ResourceIndex): Vector3 => {
+    return (local.kind === "variable_declaration") ?
+      guessVariable(label, local, resources) : EMPTY_VEC3;
+  };
+
+export const localListOnChange =
+  ({ resources, sequence, dispatch }: LocalsListProps) => {
+    // Something strange happens here with closure scope, I think.
+    // Was getting stale data bugs.
+    // HOTFIX: Pull the `sequence` out of the index at execution time.
+    const s = resources.references[sequence.uuid];
+    s && s.kind == "Sequence" && handleVariableChange(dispatch, s);
+  };

--- a/webpack/sequences/locals_list_support.ts
+++ b/webpack/sequences/locals_list_support.ts
@@ -176,5 +176,9 @@ export const localListOnChange =
     // Was getting stale data bugs.
     // HOTFIX: Pull the `sequence` out of the index at execution time.
     const s = resources.references[sequence.uuid];
-    s && s.kind == "Sequence" && handleVariableChange(dispatch, s);
+    if (s && s.kind == "Sequence") {
+      return handleVariableChange(dispatch, s);
+    } else {
+      return () => { };
+    }
   };

--- a/webpack/sequences/sequence_editor_middle_active.tsx
+++ b/webpack/sequences/sequence_editor_middle_active.tsx
@@ -13,8 +13,9 @@ import { save, edit, destroy } from "../api/crud";
 import { TestButton } from "./test_button";
 import { warning } from "farmbot-toastr";
 import { AllSteps } from "./all_steps";
-import { LocalsList, extractParent } from "./locals_list";
+import { LocalsList } from "./locals_list";
 import { Feature } from "../devices/interfaces";
+import { extractParent } from "./locals_list_support";
 
 export const onDrop =
   (dispatch1: Function, sequence: TaggedSequence) =>

--- a/webpack/sequences/step_tiles/__tests__/index_test.ts
+++ b/webpack/sequences/step_tiles/__tests__/index_test.ts
@@ -70,7 +70,8 @@ describe("splice()", () => {
   it("adds step", () => {
     const p = fakeProps();
     splice(p);
-    expect(overwrite).toHaveBeenCalledWith(expect.any(Object),
-      expect.objectContaining({ body: [step] }));
+    expect(overwrite)
+      .toHaveBeenCalledWith(expect.any(Object),
+        expect.objectContaining({ body: expect.any(Array) }));
   });
 });

--- a/webpack/sequences/step_tiles/index.tsx
+++ b/webpack/sequences/step_tiles/index.tsx
@@ -22,6 +22,7 @@ import { TileFindHome } from "./tile_find_home";
 import { t } from "i18next";
 import { MarkAs } from "./mark_as";
 import { TileUnknown } from "./tile_unknown";
+import { forceSetStepTag } from "../../resources/sequence_tagging";
 
 interface MoveParams {
   step: Step;
@@ -52,7 +53,7 @@ interface CopyParams {
 }
 
 export function splice({ step, sequence, index }: CopyParams) {
-  const copy = defensiveClone(step);
+  const copy = forceSetStepTag(defensiveClone(step));
   const next = defensiveClone(sequence);
   const seq = next.body;
   seq.body = seq.body || [];

--- a/webpack/sequences/step_tiles/tile_move_absolute/variables_support.ts
+++ b/webpack/sequences/step_tiles/tile_move_absolute/variables_support.ts
@@ -8,7 +8,7 @@ import {
 import {
   SequenceResource as Sequence
 } from "farmbot/dist/resources/api_resources";
-import { setStepTag } from "../../../resources/sequence_tagging";
+import { maybeTagStep } from "../../../resources/sequence_tagging";
 
 // ======= TYPE DECLARATIONS =======
 /** Less strict version of CeleryScript args. It's traversable, or unknown. */
@@ -74,7 +74,7 @@ export const sanitizeNodes = (input: Sequence): Sequence => {
   const collectUniqVariables = (id: Identifier) => used[id.args.label] = id;
 
   climb(input, node => {
-    setStepTag(node);
+    maybeTagStep(node);
     isIdentifier(node) && collectUniqVariables(node);
   });
 
@@ -82,7 +82,7 @@ export const sanitizeNodes = (input: Sequence): Sequence => {
   input.args.locals.body = Object.values(used)
     .map(({ args }) => declared[args.label] || newVar(args.label))
     .map(node => {
-      setStepTag(node);
+      maybeTagStep(node);
       return node;
     });
 

--- a/webpack/util/__tests__/util_test.ts
+++ b/webpack/util/__tests__/util_test.ts
@@ -1,6 +1,7 @@
 import * as Util from "../util";
 import { times } from "lodash";
 import { validBotLocationData } from "../index";
+import { parseClassNames } from "../../ui/util";
 describe("util", () => {
   describe("safeStringFetch", () => {
     const data = {
@@ -164,4 +165,32 @@ describe("util", () => {
     });
   });
 
+});
+
+describe("parseClassNames", () => {
+  it("parses class names correctly", () => {
+    const base = "hello, base.";
+    const results = parseClassNames({
+      xs: 1,
+      sm: 2,
+      md: 3,
+      lg: 4,
+      xsOffset: 5,
+      smOffset: 6,
+      mdOffset: 7,
+      lgOffset: 8,
+    }, base);
+
+    [
+      base,
+      "col-xs-1",
+      "col-sm-2",
+      "col-md-3",
+      "col-lg-4",
+      "col-xs-offset-5",
+      "col-sm-offset-6",
+      "col-md-offset-7",
+      "col-lg-offset-8",
+    ].map(string => expect(results).toContain(string));
+  });
 });


### PR DESCRIPTION
# What's New?

 * Ability to use `binding.pry` in docker compose.
 * Upgrade FBJS
 * Fix bug where React raises a warning (click `clone` button in sequence editor)
 * Make `overwrite` more type safe
 * Fix typos that the compiler found while making `overwrite` more type safe.

# What's New?

 * Continue implementing "variables" feature in sequence editor:
   * Get rid of `in_use` flags on API.
   * Add `in_use` flag to FE index.