### PR TITLE
Bug fix for `updated_at` staleness noted by @connorrigby

### DIFF
--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -55,7 +55,10 @@ class Sequence < ApplicationRecord
   end
 
   def manually_sync!
-    device.auto_sync_transaction { broadcast! } if device
+    device.auto_sync_transaction do
+      update_attributes!(updated_at: Time.now)
+      broadcast!
+    end if device
   end
 
   # THIS IS AN OVERRIDE - See Sequence#body_as_json

--- a/spec/controllers/api/sequences/sequences_update_spec.rb
+++ b/spec/controllers/api/sequences/sequences_update_spec.rb
@@ -107,15 +107,17 @@ describe Api::SequencesController do
 
     it 'updates existing sequences' do
       sign_in user
-      sequence = FakeSequence.create( device: user.device)
+      sequence = FakeSequence.create(device: user.device)
+      sequence.update_attributes!(updated_at: 2.days.ago)
+      updated_at_before = sequence.updated_at.to_i
       input = { sequence: { name: "Scare Birds", args: {}, body: [] } }
       params = { id: sequence.id }
-      patch :update,
-        params: params,
-        body: input.to_json,
-        format: :json
+      run_jobs_now do
+        patch :update, params: params, body: input.to_json, format: :json
+      end
       expect(response.status).to eq(200)
       sequence.reload
+      expect(sequence.updated_at.to_i).to be > updated_at_before
       expect(sequence.name).to eq(input[:sequence][:name])
     end
   end


### PR DESCRIPTION
# Why?

 * Due to the way tables are structured internally (but not _externally_), it is possible to edit a sequence and not see the `updated_at` column updated.

# What's New?

 * Manually bump the `updated_at` column on `sequences` table when an `edge_node` or `primary_node` changes.