### PR TITLE
Fix "echo" in Auto Sync

### DIFF
--- a/app/jobs/auto_sync_job.rb
+++ b/app/jobs/auto_sync_job.rb
@@ -7,7 +7,8 @@ class AutoSyncJob < ApplicationJob
   def perform(broadcast_payload, id, channel, created_at_utc_integer)
     wayback = Time.at(created_at_utc_integer).utc
     mins    = ((wayback - Time.now.utc) / 1.minute).round
-
+    # klass, rid = "sync.Sequence.58".split(".").last(2).map { |x| eval(x) }
+    # Device.find(id).tell("#{klass} change: " + klass.find(rid).try(:name) || "other")
     Transport.current.amqp_send(broadcast_payload, id, channel) if (mins < 2)
   end
 end

--- a/app/jobs/auto_sync_job.rb
+++ b/app/jobs/auto_sync_job.rb
@@ -7,8 +7,6 @@ class AutoSyncJob < ApplicationJob
   def perform(broadcast_payload, id, channel, created_at_utc_integer)
     wayback = Time.at(created_at_utc_integer).utc
     mins    = ((wayback - Time.now.utc) / 1.minute).round
-    # klass, rid = "sync.Sequence.58".split(".").last(2).map { |x| eval(x) }
-    # Device.find(id).tell("#{klass} change: " + klass.find(rid).try(:name) || "other")
     Transport.current.amqp_send(broadcast_payload, id, channel) if (mins < 2)
   end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -62,7 +62,6 @@ class ApplicationRecord < ActiveRecord::Base
   end
 
   def broadcast!(label = Transport.current.current_request_id)
-    current_device.tell("Changes: " + the_changes.keys.join(", "))
     AutoSyncJob.perform_later(broadcast_payload(label),
                               current_device.id,
                               chan_name,

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -62,6 +62,7 @@ class ApplicationRecord < ActiveRecord::Base
   end
 
   def broadcast!(label = Transport.current.current_request_id)
+    current_device.tell("Changes: " + the_changes.keys.join(", "))
     AutoSyncJob.perform_later(broadcast_payload(label),
                               current_device.id,
                               chan_name,

--- a/app/models/edge_node.rb
+++ b/app/models/edge_node.rb
@@ -12,8 +12,4 @@ class EdgeNode < ApplicationRecord
   def broadcast?
     false
   end
-
-  def is_sequence_id?
-    kind == "sequence_id"
-  end
 end

--- a/app/models/edge_node.rb
+++ b/app/models/edge_node.rb
@@ -8,8 +8,6 @@ class EdgeNode < ApplicationRecord
   belongs_to            :sequence
   serialize             :value, JSON
   validates_presence_of :sequence
-  after_save            :maybe_cascade_save
-  after_destroy         :cascade_destruction
 
   def broadcast?
     false
@@ -17,24 +15,5 @@ class EdgeNode < ApplicationRecord
 
   def is_sequence_id?
     kind == "sequence_id"
-  end
-
-  def maybe_cascade_save
-    (the_changes["value"] || []) # Grab old ID _AND_ new ID
-      .compact
-      .uniq
-      .reject { |x| x == sequence_id } # 🤯 Skip recursive nodes
-      .map { |x| Sequence.find_by(id: x) }
-      .compact
-      .map { |x| x.delay.broadcast!(Transport.current.cascade_id) } if is_sequence_id?
-  end
-
-  # This can't be bundled into the functionality of `maybe_cascade_save`
-  # because `#the_changes` returns an empty change set ({}) on destroy.
-  def cascade_destruction
-    if is_sequence_id?
-      s = Sequence.find_by(id: self.value)
-      s && s.delay.broadcast!
-    end
   end
 end

--- a/app/models/regimen_item.rb
+++ b/app/models/regimen_item.rb
@@ -7,22 +7,6 @@ class RegimenItem < ApplicationRecord
   belongs_to :sequence
   validates  :sequence, presence: true
 
-  after_destroy :cascade_destruction
-  after_save    :maybe_cascade_save
-
-  def maybe_cascade_save
-    (the_changes["sequence_id"] || [])
-      .compact
-      .map { |x| Sequence.find_by(id: x) }
-      .compact
-      .map { |x| x.broadcast!(Transport.current.cascade_id) }
-  end
-
-  def cascade_destruction
-    s = Sequence.find_by(id: sequence_id)
-    s.delay.broadcast! if s
-  end
-
   def broadcast?
     false
   end

--- a/app/models/transport.rb
+++ b/app/models/transport.rb
@@ -62,20 +62,6 @@ class Transport
     amqp_topic.publish(message, routing_key: routing_key)
   end
 
-  # Every RPC / Auto Sync request has a UUID. Sometimes, a single request will
-  # result in a "cascade", meaning that one request generates > 1 response.
-  # The "main" response will contain the `current_request_id`. The "cascaded"
-  # responses will also contain the `current_request_id`, but they will also be
-  # marked as "cascade".
-  # This helps with debugging and the fact that you can't mark requests as half
-  # complete. This can be safely ignored by most developers. It is an API-side
-  # implementation detail.
-  #
-  # - RC 6-AUG-18
-  def cascade_id
-    "cascade-" + current_request_id
-  end
-
   # We need to hoist the Rack X-Farmbot-Rpc-Id to a global state so that it can
   # be used as a unique identifier for AMQP messages.
   def current_request_id


### PR DESCRIPTION
This was caused by legacy code from when we had API-side `in_use` tracking.