### PR TITLE
`every_location` CeleryScript node

### DIFF
--- a/app/models/celery_script_settings_bag.rb
+++ b/app/models/celery_script_settings_bag.rb
@@ -69,6 +69,9 @@ module CeleryScriptSettingsBag
   BAD_POINTER_TYPE      = '"%s" is not a type of point. Allowed values: %s'
   BAD_PIN_TYPE          = '"%s" is not a type of pin. Allowed values: %s'
   BAD_SPEED             = "Speed must be a percentage between 1-100"
+  ONLY_ONE_COORD        = "Move Absolute does not accept a group of locations"\
+                          " as input. Please change your selection to a "\
+                          "single location."
   PIN_TYPE_MAP          = { "Peripheral" => Peripheral,
                             "Sensor"     => Sensor,
                             "BoxLed3"    => BoxLed,
@@ -195,7 +198,12 @@ module CeleryScriptSettingsBag
       .node(:nothing,               [])
       .node(:tool,                  [:tool_id])
       .node(:coordinate,            [:x, :y, :z])
-      .node(:move_absolute,         [:location, :speed, :offset])
+      .node(:move_absolute,         [:location, :speed, :offset]) do |n|
+        loc = n.args[:location].try(:kind)
+        if loc == "every_location"
+          n.invalidate!(ONLY_ONE_COORD)
+        end
+      end
       .node(:move_relative,         [:x, :y, :z, :speed])
       .node(:write_pin,             [:pin_number, :pin_value, :pin_mode ]) do |n|
         no_rpi_analog(n)

--- a/app/models/celery_script_settings_bag.rb
+++ b/app/models/celery_script_settings_bag.rb
@@ -16,7 +16,8 @@ module CeleryScriptSettingsBag
   end
 
   # List of all celery script nodes that can be used as a varaible...
-  ANY_VARIABLE          = [:tool, :coordinate, :point, :identifier]
+  ANY_VARIABLE          = [:tool, :coordinate, :point, :identifier,
+                           :every_location]
   PLANT_STAGES          = %w(planned planted harvested sprouted)
   ALLOWED_PIN_MODES     = [DIGITAL = 0, ANALOG = 1]
   ALLOWED_RPC_NODES     = %w(home emergency_lock emergency_unlock read_status
@@ -246,6 +247,7 @@ module CeleryScriptSettingsBag
       .node(:install_first_party_farmware, [])
       .node(:internal_farm_event,  [], [:variable_declaration])
       .node(:internal_entry_point, [], [])
+      .node(:every_location,       [:pointer_type], [])
       .node(:resource_update,       RESOURCE_UPDATE_ARGS) do |x|
         resource_type = x.args.fetch(:resource_type).value
         resource_id   = x.args.fetch(:resource_id).value

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "css-loader": "^1.0.1",
     "enzyme": "^3.7.0",
     "enzyme-adapter-react-16": "^1.7.0",
-    "farmbot": "^6.6.2",
+    "farmbot": "^6.6.3-rc1",
     "farmbot-toastr": "^1.0.3",
     "fastclick": "^1.0.6",
     "file-loader": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "react-addons-test-utils": "^15.6.2",
     "react-color": "2.14.1",
     "react-dom": "^16.6.3",
-    "react-joyride": "^2.0.0-15",
+    "react-joyride": "2.0.0-15",
     "react-redux": "^5.1.1",
     "react-test-renderer": "^16.6.3",
     "react-transition-group": "2.5.0",

--- a/spec/lib/celery_script/corpus_spec.rb
+++ b/spec/lib/celery_script/corpus_spec.rb
@@ -1,8 +1,22 @@
 require 'spec_helper'
 
 describe CeleryScript::Corpus do
-  let(:device) { FactoryBot}
+  let(:device) { FactoryBot.create(:device) }
   let(:corpus) { Sequence::Corpus }
+
+  it "does not all `every_location` in `move_absolute`" do
+    not_ok = CeleryScript::AstNode.new({
+      kind: "move_absolute",
+      args: {
+        location: { kind: "every_location", args: { x: 1, y: 2, z: 3 } },
+        offset: { kind: "coordinate", args: { x: 0, y: 0, z: 0 } },
+        speed: 100
+      }
+    })
+    check1 = CeleryScript::Checker.new(not_ok, corpus, device)
+    expect(check1.valid?).to eq(false)
+    expect(check1.error.message).to eq(CeleryScriptSettingsBag::ONLY_ONE_COORD)
+  end
 
   it "handles valid move_absolute blocks" do
     ok1 = CeleryScript::AstNode.new({

--- a/webpack/auth/__tests__/actions_test.ts
+++ b/webpack/auth/__tests__/actions_test.ts
@@ -22,6 +22,7 @@ jest.mock("../../api/api", () => ({
 
 jest.mock("../../devices/actions", () => ({
   fetchReleases: jest.fn(),
+  fetchLatestGHBetaRelease: jest.fn(),
   fetchMinOsFeatureData: jest.fn(),
 }));
 
@@ -29,7 +30,7 @@ import { didLogin } from "../actions";
 import { Actions } from "../../constants";
 import { API } from "../../api/api";
 import { AuthState } from "../interfaces";
-import { fetchReleases } from "../../devices/actions";
+import { fetchReleases, fetchLatestGHBetaRelease } from "../../devices/actions";
 
 const mockToken = (): AuthState => ({
   token: {
@@ -56,7 +57,7 @@ describe("didLogin()", () => {
     mockAuth.token.unencoded.beta_os_update_server = "beta_os_update_server";
     didLogin(mockAuth, dispatch);
     expect(fetchReleases).toHaveBeenCalledWith("os_update_server");
-    expect(fetchReleases).toHaveBeenCalledWith("beta_os_update_server",
-      { beta: true });
+    expect(fetchLatestGHBetaRelease)
+      .toHaveBeenCalledWith("beta_os_update_server");
   });
 });

--- a/webpack/auth/actions.ts
+++ b/webpack/auth/actions.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 import {
-  fetchReleases, fetchMinOsFeatureData, FEATURE_MIN_VERSIONS_URL
+  fetchReleases, fetchMinOsFeatureData, FEATURE_MIN_VERSIONS_URL,
+  fetchLatestGHBetaRelease
 } from "../devices/actions";
 import { AuthState } from "./interfaces";
 import { ReduxAction } from "../redux/interfaces";
@@ -20,7 +21,7 @@ export function didLogin(authState: AuthState, dispatch: Function) {
   const { os_update_server, beta_os_update_server } = authState.token.unencoded;
   dispatch(fetchReleases(os_update_server));
   beta_os_update_server && beta_os_update_server != "NOT_SET" &&
-    dispatch(fetchReleases(beta_os_update_server, { beta: true }));
+    dispatch(fetchLatestGHBetaRelease(beta_os_update_server));
   dispatch(getFirstPartyFarmwareList());
   dispatch(fetchMinOsFeatureData(FEATURE_MIN_VERSIONS_URL));
   dispatch(setToken(authState));

--- a/webpack/devices/__tests__/actions_test.ts
+++ b/webpack/devices/__tests__/actions_test.ts
@@ -410,6 +410,32 @@ describe("fetchReleases()", () => {
   });
 });
 
+describe("fetchLatestGHBetaRelease()", () => {
+  it("fetches latest beta OS release version", async () => {
+    mockGetRelease = Promise.resolve({ data: [{ tag_name: "v1.0.0-beta" }] });
+    const dispatch = jest.fn();
+    await actions.fetchLatestGHBetaRelease("url/001")(dispatch);
+    expect(axios.get).toHaveBeenCalledWith("url");
+    expect(error).not.toHaveBeenCalled();
+    expect(dispatch).toHaveBeenCalledWith({
+      payload: { version: "1.0.0-beta", commit: undefined },
+      type: Actions.FETCH_BETA_OS_UPDATE_INFO_OK
+    });
+  });
+
+  it("fails to fetches latest beta OS release version", async () => {
+    mockGetRelease = Promise.reject("error");
+    const dispatch = jest.fn();
+    await actions.fetchLatestGHBetaRelease("url/001")(dispatch);
+    await expect(axios.get).toHaveBeenCalledWith("url");
+    expect(error).not.toHaveBeenCalled();
+    expect(dispatch).toHaveBeenCalledWith({
+      payload: "error",
+      type: Actions.FETCH_BETA_OS_UPDATE_INFO_ERROR
+    });
+  });
+});
+
 describe("fetchMinOsFeatureData()", () => {
   afterEach(() =>
     jest.restoreAllMocks());

--- a/webpack/devices/components/fbos_settings/farmbot_os_row.tsx
+++ b/webpack/devices/components/fbos_settings/farmbot_os_row.tsx
@@ -52,6 +52,7 @@ export function FarmbotOsRow(props: FarmbotOsRowProps) {
       <OsUpdateButton
         bot={bot}
         sourceFbosConfig={sourceFbosConfig}
+        shouldDisplay={props.shouldDisplay}
         botOnline={botOnline} />
     </Col>
   </Row >;

--- a/webpack/devices/components/fbos_settings/interfaces.ts
+++ b/webpack/devices/components/fbos_settings/interfaces.ts
@@ -68,4 +68,5 @@ export interface OsUpdateButtonProps {
   bot: BotState;
   sourceFbosConfig: SourceFbosConfig;
   botOnline: boolean;
+  shouldDisplay: ShouldDisplay;
 }

--- a/webpack/devices/components/fbos_settings/os_update_button.tsx
+++ b/webpack/devices/components/fbos_settings/os_update_button.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { t } from "i18next";
-import { JobProgress } from "farmbot/dist";
+import { JobProgress, ConfigurationName } from "farmbot/dist";
 import { SemverResult, semverCompare } from "../../../util";
 import { OsUpdateButtonProps } from "./interfaces";
 import { checkControllerUpdates } from "../../actions";
 import { isString } from "lodash";
-import { BotState } from "../../interfaces";
+import { BotState, Feature } from "../../interfaces";
 
 /** FBOS update button states. */
 enum UpdateButton { upToDate, needsUpdate, unknown, none }
@@ -151,7 +151,9 @@ export const OsUpdateButton = (props: OsUpdateButtonProps) => {
   const { bot, sourceFbosConfig, botOnline } = props;
 
   /** FBOS beta release opt-in setting. */
-  const betaOptIn = !!sourceFbosConfig("beta_opt_in").value;
+  const betaOptIn = props.shouldDisplay(Feature.use_update_channel)
+    ? sourceFbosConfig("update_channel" as ConfigurationName).value !== "stable"
+    : !!sourceFbosConfig("beta_opt_in").value;
   /** FBOS update availability. */
   const buttonStatusProps = buttonVersionStatus({ bot, betaOptIn });
 

--- a/webpack/farmware/__tests__/state_to_props_test.tsx
+++ b/webpack/farmware/__tests__/state_to_props_test.tsx
@@ -121,6 +121,14 @@ describe("mapStateToProps()", () => {
         time: "2018-11-15 18:13:21.167440Z"
       }]);
   });
+
+  it("handles undefined jobs", () => {
+    const state = fakeState();
+    // tslint:disable-next-line:no-any
+    state.bot.hardware.jobs = undefined as any;
+    const props = mapStateToProps(state);
+    expect(props.imageJobs).toEqual([]);
+  });
 });
 
 describe("saveOrEditFarmwareEnv()", () => {

--- a/webpack/farmware/state_to_props.ts
+++ b/webpack/farmware/state_to_props.ts
@@ -99,7 +99,7 @@ export function mapStateToProps(props: Everything): FarmwareProps {
       }
     });
 
-  const { jobs } = props.bot.hardware;
+  const jobs = props.bot.hardware.jobs || {};
   const imageJobNames = Object.keys(jobs).filter(x => x != "FBOS_OTA");
   const imageJobs: JobProgress[] =
     _(betterCompact(imageJobNames.map(x => jobs[x])))

--- a/webpack/sequences/step_tiles/tile_move_absolute.tsx
+++ b/webpack/sequences/step_tiles/tile_move_absolute.tsx
@@ -147,7 +147,12 @@ export class TileMoveAbsolute extends Component<StepParams, MoveAbsState> {
 
   /** Handle changes to step.args.location. */
   updateLocation = (declaration: VariableDeclaration) => {
-    this.updateArgs({ location: declaration.args.data_value });
+    const location = declaration.args.data_value;
+    if (location.kind === "every_location") {
+      throw new Error("Moving to every_location is not supported.");
+    } else {
+      this.updateArgs({ location });
+    }
   }
 
   /** Prepare step.args.location data for LocationForm. */


### PR DESCRIPTION
# What's New?

 * Merge some recent changes on `staging` into `nightly`
 * A new `every_location` node to CeleryScript (API only).

## What's Next?

 * On frontend, allow use of `every_location` nodes when calling sequences from a FarmEvent.