### PR TITLE
Dont track support tables

### DIFF
--- a/app/models/arg_name.rb
+++ b/app/models/arg_name.rb
@@ -16,4 +16,8 @@ class ArgName < ApplicationRecord
   def self.cached_by_id(id)
     Rails.cache.fetch(KEY % id, expires_in: EXPIRY) { find(id) }
   end
+
+  def broadcast?
+    false
+  end
 end

--- a/app/models/primitive.rb
+++ b/app/models/primitive.rb
@@ -22,4 +22,8 @@ class Primitive < ApplicationRecord
   def length
     value.to_s.length
   end
+
+  def broadcast?
+    false
+  end
 end

--- a/app/models/primitive.rb
+++ b/app/models/primitive.rb
@@ -3,7 +3,8 @@ class Primitive < ApplicationRecord
   PRIMITIVES     = [ FalseClass, TrueClass, Float, Integer, String, Symbol ]
   LENGTH_LIMIT   = 300
   PRIMITIVE_ONLY = "Expected primitive class. Got: %s"
-  BAD_LENGTH     = "Primitives must be shorter than 400 chars in length"
+  BAD_LENGTH     = "Primitives must be shorter than"\
+                   " #{LENGTH_LIMIT} chars in length"
 
   belongs_to :fragment
   has_many   :primitive_pairs

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,23 +8,27 @@ if Rails.env == "development"
     # CREDIT: Faker Ruby Gem
     VEGGIES                 = %w(artichoke arugula asparagus broccoli
     cabbage caper carob carrot cauliflower celery chive cornichon cucumber
-    eggplant endive garlic hijiki jicama kale kohlrabi leek lettuce okra onion
-    parsnip pea pepper potato pumpkin radicchio radish raspberry rhubarb spinach
+    eggplant endive garlic jicama kale kohlrabi leek lettuce okra onion
+    parsnip pepper potato pumpkin radicchio radish raspberry rhubarb spinach
     sprout squash tomato turnip zucchini)
-    [DeviceSerialNumber,
-     Log,
-     PinBinding,
-     Point,
-     Point,
-     TokenIssuance,
-     ToolSlot,
-     User,
-     PlantTemplate,
-     SavedGarden,
-     SensorReading,
-     FarmwareInstallation,
-     Device,
-     Tool].map(&:delete_all)
+    [
+      Sensor,
+      Peripheral,
+      DeviceSerialNumber,
+      Log,
+      PinBinding,
+      Point,
+      Point,
+      TokenIssuance,
+      ToolSlot,
+      User,
+      PlantTemplate,
+      SavedGarden,
+      SensorReading,
+      FarmwareInstallation,
+      Device,
+      Tool,
+    ].map(&:delete_all)
     Users::Create.run!(name:                  "Test",
                        email:                 "test@test.com",
                        password:              "password123",


### PR DESCRIPTION
We have some internal use tables. They were broadcasting auto sync messages. This PR fixes the auto sync message problems.