### PR TITLE
Update ubuntu_setup.sh

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,6 @@
 # A human
 class User < ApplicationRecord
   class AlreadyVerified < StandardError; end
-  # TODO: use GlobalConfig instead of ENV
   ENFORCE_TOS           = ENV.fetch("TOS_URL") { false }
   SKIP_EMAIL_VALIDATION = ENV.fetch("NO_EMAILS") { false }
   validates :email, uniqueness: true

--- a/app/mutations/sequences/update.rb
+++ b/app/mutations/sequences/update.rb
@@ -54,30 +54,5 @@ module Sequences
       FarmEvent => BASE + "it is in use by FarmEvents on these dates: %{items}",
       Regimen   => BASE + "the following Regimen(s) are using it: %{items}",
     }
-
-    # TODO: Bring this back after "sequence variables" rollout. - RC 12 SEP 2018
-    # def regimens_cant_have_parameters
-    #   maybe_stop_parameter_use(resource: Regimen,
-    #                            items: Regimen
-    #                            .includes(:regimen_items)
-    #                            .where(regimen_items: {sequence_id: sequence.id})
-    #                            .map(&:fancy_name))
-    # end
-
-    # TODO: Bring this back after "sequence variables" rollout. - RC 12 SEP 2018
-    # def farm_events_cant_have_parameters
-    #   maybe_stop_parameter_use(resource: FarmEvent,
-    #                            items: FarmEvent
-    #                             .where(executable: sequence)
-    #                             .map(&:fancy_name))
-    # end
-
-    # TODO: Bring this back after "sequence variables" rollout. - RC 12 SEP 2018
-    # def maybe_stop_parameter_use(resource:, items:)
-    #   add_error :sequence, :sequence, EXPL.fetch(resource) % {
-    #     resource: resource,
-    #     items: items.join(", ")
-    #   } if items.present?
-    # end
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -399,8 +399,7 @@ CREATE TABLE public.farmware_installations (
     url character varying,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    package character varying(80),
-    package_error character varying
+    package character varying(80)
 );
 
 

--- a/lib/rabbit_workers.rb
+++ b/lib/rabbit_workers.rb
@@ -34,7 +34,7 @@ class RabbitWorker
   end
 
   def self.go!
-    loop do # TODO: What if only one service
+    loop do
       ThreadsWait.all_waits(self.new.threads)
     end
   end

--- a/lib/tasks/api.rake
+++ b/lib/tasks/api.rake
@@ -1,10 +1,3 @@
-# Going to make an `update` AND `upgrade` task that do the same thing
-def same_thing
-  sh "git pull https://github.com/FarmBot/Farmbot-Web-App.git master"
-  sh "sudo docker-compose run web bundle install"
-  sh "sudo docker-compose run web npm install"
-  sh "sudo docker-compose run web rails db:migrate"
-end
 
 def check_for_digests
   Log
@@ -20,57 +13,6 @@ def check_for_digests
       LogDeliveryMailer.log_digest(device).deliver
     end
   sleep 10.minutes
-end
-
-class V7Migration
-  BIG_WARNING = <<~END
-    ░██████░░███████░░█████░░░██████░░  You have recently upgraded your server
-    ░██░░░░░░░░██░░░░██░░░██░░██░░░██░  from version 6 to version 7.
-    ░██████░░░░██░░░░██░░░██░░██████░░  This requires action on your part.
-    ░░░░░██░░░░██░░░░██░░░██░░██░░░░░░  Please read the instructions below
-    ░██████░░░░██░░░░░████░░░░██░░░░░░  carefully.
-
-    The biggest change from version 6 to version 7 is the addition of Docker for
-    managing services. This simplifies server setup because all software runs
-    inside of a container (no need to install Postgres or Ruby on your local
-    machine). Unfortunately, this change required a number of non-compatible
-    changes to the codebase, particularly related to the database and
-    configuration management.
-
-    The biggest changes for v7:
-      * Use a `.env` file instead of `application.yml`
-      * The database runs in a container
-      * The `mqtt/` directory was renamed `docker_configs/` (this directory
-        contains passwords which were previously `gitignore`ed)
-
-    Please perform the following steps to upgrade:
-
-    1. Follow v7 installation steps found in "ubuntu_example.sh". You will need
-       to skip certain steps. The skipable steps are listed in the instructions.
-
-    2. Stop using `rails api:start` and `rails mqtt:start` commands. The new
-       startup command is `sudo docker-compose up` See "ubuntu_example.sh" for
-       details. All services run in a single command now.
-
-    3. If you wish to continue using your current database:
-       a. To keep using the old database (v6) database, set the `DATABASE_URL`
-          ENV var to match the following format:
-            `postgres://username:password@host_name:5432/database_name`
-       b. Migrate the database to the new container-based DB manually:
-          https://stackoverflow.com/questions/1237725/copying-postgresql-database-to-another-server
-          (NOTE: We do not provide database migration support- consult
-           StackOverflow and the PostgreSQL docs)
-       c. Start a fresh database by following directions in `ubuntu_setup.sh`.
-          Old data will be lost.
-
-    4. Update database.yml to match https://github.com/FarmBot/Farmbot-Web-App/blob/staging/config/database.yml
-
-    5. Migrate the contents of `config/application.yml` to `.env`. Ensure you
-       have removed "quotation marks" and that all entries are `key=value` pairs.
-       See `example.env` for a properly formatted example.
-
-    6. (SECURITY CRITICAL) delete `mqtt/`
-  END
 end
 
 def hard_reset_api
@@ -99,23 +41,14 @@ namespace :api do
   desc "Runs pending email digests. "\
        "Use the `FOREVER` ENV var to continually check."
   task log_digest: :environment do
+    puts "Running log digest loop..."
     ENV["FOREVER"] ? loop { check_for_digests } : check_for_digests
   end
-
-  # TODO: Remove in dec 2018
-  desc "Deprecated. Will be removed in December of 2018"
-  task(:start) { puts V7Migration::BIG_WARNING }
 
   desc "Run Rails _ONLY_. No Webpack."
   task only: :environment do
     sh "sudo docker-compose up --scale webpack=0"
   end
-
-  desc "Pull the latest Farmbot API version"
-  task(update: :environment) { same_thing }
-
-  desc "Pull the latest Farmbot API version"
-  task(upgrade: :environment) { same_thing }
 
   desc "Reset _everything_, including your database"
   task :reset do

--- a/ubuntu_example.sh
+++ b/ubuntu_example.sh
@@ -1,5 +1,14 @@
 # How to install FarmBot Web API on a Fresh Ubuntu 18.04.1 LTS Machine
 
+# IMPORTANT NOTE: Resources are limited and Farmbot, inc. cannot provide
+# longterm support to self-hosted users. For users who have never administered a
+# Ruby on Rails applications, this presents an extremely high risk of data loss.
+#
+# IF YOU ARE NOT A DEVELOPER you are highly encouraged to use the my.farm.bot
+# servers. Self hosted documentation is provided with the assumption that you
+# have experience with Ruby/Javascript development. Self-hosting a Farmbot
+# server is not a simple task.
+
 # Remove old (possibly broke) docker versions
 sudo apt-get remove docker docker-engine docker.io
 
@@ -44,6 +53,16 @@ sudo docker-compose run web rake keys:generate # ⚠ SKIP THIS STEP IF UPGRADING
 sudo docker-compose run web npm run build
 # Run the server! ٩(^‿^)۶
 sudo docker-compose up
+
+# ===
+  # To update to later versions of FarmBot,
+  # shut down the server, create a database backup
+  # and run commands below.
+  git pull https://github.com/FarmBot/Farmbot-Web-App.git master
+  sudo docker-compose run web bundle install
+  sudo docker-compose run web npm install
+  sudo docker-compose run web rails db:migrate
+# ===
 
 # At this point, setup is complete. Content should be visible at ===============
 #  http://YOUR_HOST:3000/.


### PR DESCRIPTION
# Why?

Previous versions of the web app came with a `rails api:update` command. After switching to `docker-compose`, users no longer have a `rails` command available on the host machine (unless they already installed `rails`).

# What's New?

 * Remove `rails api:update` command to avoid confusion.
 * Add a note to `ubuntu_example.sh` about manual updates to the server.
 * Cleanup of old deprecations.

Closes #1099 
