### PR TITLE
Late additions: cache busting

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -47,7 +47,7 @@ class DashboardController < ApplicationController
   PARCEL_ASSET_LIST = (CSS_INPUTS.values + JS_INPUTS.values)
     .sort
     .uniq
-    .map { |x| File.join("frontend", x) }
+    .map { |x| File.join("frontend", x) + CACHE_BUST_STRING }
     .join(" ")
 
   PARCEL_HMR_OPTS   = [

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -40,14 +40,14 @@ class DashboardController < ApplicationController
 
   JS_OUTPUTS = JS_INPUTS.reduce({}) do |acc, (k, v)|
     file   = v.gsub(/\.tsx?$/, ".js")
-    acc[k] = File.join(OUTPUT_URL, file) + CACHE_BUST_STRING
+    acc[k] = File.join(OUTPUT_URL, file)
     acc
   end.with_indifferent_access
 
   PARCEL_ASSET_LIST = (CSS_INPUTS.values + JS_INPUTS.values)
     .sort
     .uniq
-    .map { |x| File.join("frontend", x) + CACHE_BUST_STRING }
+    .map { |x| File.join("frontend", x) }
     .join(" ")
 
   PARCEL_HMR_OPTS   = [
@@ -119,14 +119,15 @@ private
   def load_css_assets
     @css_assets ||= [action_name, :default].reduce([]) do |list, action|
       asset = CSS_OUTPUTS[action] # Not every endpoint has custom CSS.
-      list.push(asset) if asset
+      list.push(asset + CACHE_BUST_STRING) if asset
       list
     end
   end
 
   def load_js_assets
     # Every DashboardController has a JS SBundle.
-    @js_assets ||= [ JS_OUTPUTS.fetch(action_name) ]
+    @js_assets ||= \
+      [ JS_OUTPUTS.fetch(action_name) ].map { |x| x + CACHE_BUST_STRING }
   end
 
   def set_global_config

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -65,6 +65,8 @@ class DashboardController < ApplicationController
         # If you don't do this, you will hit hard to debug
         # CSP errors on local when changing API_HOST.
         response.headers["Cache-Control"] = "no-cache, no-store"
+        response.headers["Pragma"] = "no-cache"
+        response.headers["Expires"] = "0"
         load_css_assets
         load_js_assets
         render actn

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -26,6 +26,10 @@ class DashboardController < ApplicationController
 
   # === THESE CONSTANTS ARE NON-CONFIGURABLE. ===
   # They are calculated based on config above.
+
+  RELEASE_CHUNK     = GlobalConfig::LONG_REVISION == "NONE" ?
+    SecureRandom.hex.first(5) : GlobalConfig::LONG_REVISION
+  CACHE_BUST_STRING = "?version=#{RELEASE_CHUNK}"
   PUBLIC_OUTPUT_DIR = File.join("public", OUTPUT_URL)
 
   CSS_OUTPUTS = CSS_INPUTS.reduce({}) do |acc, (k, v)|
@@ -36,7 +40,7 @@ class DashboardController < ApplicationController
 
   JS_OUTPUTS = JS_INPUTS.reduce({}) do |acc, (k, v)|
     file   = v.gsub(/\.tsx?$/, ".js")
-    acc[k] = File.join(OUTPUT_URL, file)
+    acc[k] = File.join(OUTPUT_URL, file) + CACHE_BUST_STRING
     acc
   end.with_indifferent_access
 
@@ -65,8 +69,8 @@ class DashboardController < ApplicationController
         # If you don't do this, you will hit hard to debug
         # CSP errors on local when changing API_HOST.
         response.headers["Cache-Control"] = "no-cache, no-store"
-        response.headers["Pragma"] = "no-cache"
-        response.headers["Expires"] = "0"
+        response.headers["Pragma"]        = "no-cache"
+        response.headers["Expires"]       = "0"
         load_css_assets
         load_js_assets
         render actn

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,7 +7,7 @@ if Rails.env == "development"
     ENV['OS_UPDATE_SERVER'] = "http://non_legacy_update_url.com"
     # CREDIT: Faker Ruby Gem
     VEGGIES                 = %w(artichoke arugula asparagus broccoli
-    cabbage carrot cauliflower celery chive cornichon cucumber
+    cabbage carrot cauliflower celery chive cucumber
     eggplant endive garlic jicama kale kohlrabi leek lettuce okra onion
     parsnip pepper potato pumpkin radicchio radish raspberry rhubarb spinach
      squash tomato turnip zucchini)

--- a/frontend/config/__tests__/actions_test.ts
+++ b/frontend/config/__tests__/actions_test.ts
@@ -59,7 +59,7 @@ describe("Actions", () => {
     storeToken(old, dispatch)(undefined);
     expect(setToken).toHaveBeenCalledWith(old);
     expect(didLogin).toHaveBeenCalledWith(old, dispatch);
-    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining(
-      "Failed to refresh token"));
+    expect(console.warn)
+      .toHaveBeenCalledWith(expect.stringContaining("Can't refresh token."));
   });
 });

--- a/frontend/config/actions.ts
+++ b/frontend/config/actions.ts
@@ -8,7 +8,7 @@ import { timeout } from "promise-timeout";
 export const storeToken =
   (old: AuthState, dispatch: Function) => (_new: AuthState | undefined) => {
     const t = _new || old;
-    (!_new) && console.warn("Failed to refresh token. Something is wrong.");
+    (!_new) && console.warn("Can't refresh token. Is API_HOST set correctly?");
     dispatch(setToken(t));
     didLogin(t, dispatch);
   };

--- a/frontend/devices/reducer.ts
+++ b/frontend/devices/reducer.ts
@@ -8,7 +8,7 @@ import { maybeNegateStatus } from "../connectivity/maybe_negate_status";
 import { EdgeStatus } from "../connectivity/interfaces";
 import { ReduxAction } from "../redux/interfaces";
 import { connectivityReducer } from "../connectivity/reducer";
-import { versionOK, fancyDebug } from "../util";
+import { versionOK } from "../util";
 import { EXPECTED_MAJOR, EXPECTED_MINOR } from "./actions";
 import { DeepPartial } from "redux";
 import { incomingLegacyStatus } from "../connectivity/connect_device";
@@ -129,7 +129,6 @@ export let botReducer = generateReducer<BotState>(initialState(), afterEach)
       return s;
     })
   .add<DeepPartial<HardwareState>>(Actions.STATUS_UPDATE, (s, { payload }) => {
-    fancyDebug({ payload });
     s.hardware = {
       ...s.hardware,
       ...(payload as typeof s.hardware)


### PR DESCRIPTION
# What's New?

 * Add a `?version=` query string to JS/CSS assets.
 * Add old cache busting headers to HTML endpoints

# What's Next?

 * Deploy and Release