### PR TITLE
Global Refresh Messages

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,5 @@
 worker:         bundle exec rake jobs:work
 rabbit_workers: bin/rails r lib/rabbit_workers.rb
 web:            bundle exec passenger start -p $PORT -e $RAILS_ENV --max-pool-size 2
+# This will perform a hard refresh on all connected browsers.
+release:        rails r User.refresh_everyones_ui

--- a/app/lib/celery_script/ast_node.rb
+++ b/app/lib/celery_script/ast_node.rb
@@ -68,6 +68,7 @@ module CeleryScript
       end
 
       def todo
+
       # Don't delete this- it is currently unreachable code, but as soon as we
       # allow identifiers other than `point`, `tool` and `coordinate` we will
       # need it again (and can write tests)

--- a/app/lib/session_token.rb
+++ b/app/lib/session_token.rb
@@ -39,8 +39,6 @@ class SessionToken < AbstractJwtToken
                 vhost:                 VHOST,
                 mqtt_ws:               MQTT_WS,
                 os_update_server:      url,
-                fw_update_server:      "DEPRECATED",
-                interim_email:         user.email, # Dont use this for anything ever -RC
                 beta_os_update_server: BETA_OS_URL }])
   end
 

--- a/app/models/celery_script_settings_bag.rb
+++ b/app/models/celery_script_settings_bag.rb
@@ -237,7 +237,9 @@ module CeleryScriptSettingsBag
       # (FBOS vs. API). Corpus-native enums cannot be used for validation
       # outside of the API. If `package` _was_ declared as a native enum (rather
       # than a string), it would cause false type errors in FE/FBJS.
-      blk: -> (node) { manual_enum(ALLOWED_PACKAGES, node, BAD_PACKAGE) },
+      blk: -> (node) do
+        manual_enum(ALLOWED_PACKAGES, node, BAD_PACKAGE)
+      end,
     },
     axis: {
       defn: [e(:ALLOWED_AXIS)],
@@ -265,13 +267,6 @@ module CeleryScriptSettingsBag
     defn = conf.fetch(:defn)
     blk ? Corpus.arg(name, defn, &blk) : Corpus.arg(name, defn)
   end
-
-  IDEA_BIN = [
-    :function,
-    :data,
-    :private,
-
-  ]
 
   CORPUS_NODES = {
     _if: {

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -13,16 +13,16 @@ class Log < ApplicationRecord
 
   # Why "EMAIL_ISH"? Because `fatal_email` is LIKE '%email%', but it's probably
   # not the one you want.
-  IS_EMAIL_ISH   = "channels LIKE '%email%'"
+  IS_EMAIL_ISH = "channels LIKE '%email%'"
   IS_FATAL_EMAIL = "channels LIKE '%fatal_email%'"
-  DISCARD        = ["fun", "debug", nil]
-  TYPES          = CeleryScriptSettingsBag::ALLOWED_MESSAGE_TYPES
+  DISCARD = ["fun", "debug", nil]
+  TYPES = CeleryScriptSettingsBag::ALLOWED_MESSAGE_TYPES
   # The means by which the message will be sent. Ex: frontend toast notification
-  serialize  :channels
+  serialize :channels
   belongs_to :device
 
   validates :device, presence: true
-  validates :type,   presence: true
+  validates :type, presence: true
   serialize :meta
   validates :meta, presence: true
   # http://stackoverflow.com/a/5127684/1064917
@@ -36,20 +36,21 @@ class Log < ApplicationRecord
   #  TODO: Remove these once FBOS stops using the `meta` field (FBOS < v6.4.0).
   def meta
     {
-      type:          self.type,
+      type: self.type,
       major_version: self.major_version,
       minor_version: self.minor_version,
-      verbosity:     self.verbosity,
-      x:             self.x,
-      y:             self.y,
-      z:             self.z,
+      verbosity: self.verbosity,
+      x: self.x,
+      y: self.y,
+      z: self.z,
     }
   end
 
   def meta=(hash)
-    hash.map      { |(key, value)| self.send("#{key}=", value)  }
+    hash.map { |(key, value)| self.send("#{key}=", value) }
     self.meta
   end
+
   # End Legacy shims ===========================================================
 
   def broadcast? # Logs get their own special channel. Don't echo twice!

--- a/app/models/transport.rb
+++ b/app/models/transport.rb
@@ -58,6 +58,10 @@ class Transport
   def amqp_send(message, id, channel)
     raise "BAD `id`" unless id.is_a?(String) || id.is_a?(Integer)
     routing_key = "bot.device_#{id}.#{channel}"
+    raw_amqp_send(message, routing_key)
+  end
+
+  def raw_amqp_send(message, routing_key)
     puts message if Rails.env.production?
     amqp_topic.publish(message, routing_key: routing_key)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,4 +42,12 @@ class User < ApplicationRecord
   def update_tracked_fields!(request)
     super(request) unless FbosDetector.is_fbos_ua?(request)
   end
+
+  def self.refresh_everyones_ui
+    Rollbar.error("Global UI refresh triggered")
+
+    Transport
+      .current
+      .raw_amqp_send("X", Api::RmqUtilsController::PUBLIC_BROADCAST)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,8 @@
 # A human
 class User < ApplicationRecord
   class AlreadyVerified < StandardError; end
-  ENFORCE_TOS           = ENV.fetch("TOS_URL") { false }
+
+  ENFORCE_TOS = ENV.fetch("TOS_URL") { false }
   SKIP_EMAIL_VALIDATION = ENV.fetch("NO_EMAILS") { false }
   validates :email, uniqueness: true
 

--- a/app/models/web_app_config.rb
+++ b/app/models/web_app_config.rb
@@ -3,7 +3,12 @@ class WebAppConfig < ApplicationRecord
   belongs_to :device
 
   def internal_use=(data)
-    Rollbar.error("Internal data update use", { object_id: self.id })
+    unless [nil, "null"].include?(data)
+      Rollbar.error("Internal data update use", {
+        self_id: self.id,
+        device_id: self.device_id,
+      })
+    end
     super(data)
   end
 

--- a/frontend/connectivity/__tests__/connect_device/event_listeners_test.ts
+++ b/frontend/connectivity/__tests__/connect_device/event_listeners_test.ts
@@ -2,11 +2,12 @@ const on = jest.fn((_e: string, _cb: unknown) => undefined);
 const stub = () => Promise.resolve();
 const mockBot = {
   client: {
+    subscribe: jest.fn(),
     on
   },
   on,
   readStatus: jest.fn(stub),
-  setUserEnv: stub
+  setUserEnv: stub,
 };
 
 jest.mock("../../../device", () => { return { getDevice: () => mockBot }; });
@@ -41,6 +42,7 @@ describe("attachEventListeners", () => {
       }
     });
     expect(dev.readStatus).toHaveBeenCalled();
+    expect(dev.client && dev.client.subscribe).toHaveBeenCalled();
     expect(startPinging).toHaveBeenCalledWith(dev);
   });
 });

--- a/frontend/connectivity/__tests__/connect_device/index_test.ts
+++ b/frontend/connectivity/__tests__/connect_device/index_test.ts
@@ -223,11 +223,11 @@ describe("onLogs", () => {
 
 describe("onPublicBroadcast", () => {
   it("triggers when appropriate", () => {
-    window.location.reload = jest.fn();
+    location.assign = jest.fn();
     window.confirm = jest.fn(() => true);
     onPublicBroadcast(BROADCAST.CHAN, {});
     expect(window.confirm).toHaveBeenCalledWith(BROADCAST.SOLICIT);
-    expect(window.location.reload).toHaveBeenCalled();
+    expect(location.assign).toHaveBeenCalled();
   });
 
   it("allows cancellation of refresh", () => {
@@ -235,7 +235,7 @@ describe("onPublicBroadcast", () => {
     window.alert = jest.fn();
     onPublicBroadcast(BROADCAST.CHAN, {});
     expect(window.alert).toHaveBeenCalledWith(BROADCAST.WARN);
-    expect(window.location.reload).not.toHaveBeenCalled();
+    expect(location.assign).not.toHaveBeenCalled();
   });
 
   it("does not trigger under usual circumstances", () => {

--- a/frontend/connectivity/__tests__/connect_device/index_test.ts
+++ b/frontend/connectivity/__tests__/connect_device/index_test.ts
@@ -25,7 +25,9 @@ import {
   onSent,
   onOnline,
   onMalformed,
-  speakLogAloud
+  speakLogAloud,
+  onPublicBroadcast,
+  BROADCAST
 } from "../../connect_device";
 import { onLogs } from "../../log_handlers";
 import { Actions, Content } from "../../../constants";
@@ -216,5 +218,29 @@ describe("onLogs", () => {
     fn(log);
     globalQueue.maybeWork();
     expect(dispatchNetworkDown).toHaveBeenCalledWith("bot.mqtt", undefined, A_STRING);
+  });
+});
+
+describe("onPublicBroadcast", () => {
+  it("triggers when appropriate", () => {
+    window.location.reload = jest.fn();
+    window.confirm = jest.fn(() => true);
+    onPublicBroadcast(BROADCAST.CHAN, {});
+    expect(window.confirm).toHaveBeenCalledWith(BROADCAST.SOLICIT);
+    expect(window.location.reload).toHaveBeenCalled();
+  });
+
+  it("allows cancellation of refresh", () => {
+    window.confirm = jest.fn(() => false);
+    window.alert = jest.fn();
+    onPublicBroadcast(BROADCAST.CHAN, {});
+    expect(window.alert).toHaveBeenCalledWith(BROADCAST.WARN);
+    expect(window.location.reload).not.toHaveBeenCalled();
+  });
+
+  it("does not trigger under usual circumstances", () => {
+    window.confirm = jest.fn(() => false);
+    onPublicBroadcast("NOT" + BROADCAST.CHAN, {});
+    expect(window.confirm).not.toHaveBeenCalled();
   });
 });

--- a/frontend/connectivity/connect_device.ts
+++ b/frontend/connectivity/connect_device.ts
@@ -165,13 +165,21 @@ export const onOnline =
 export const onReconnect =
   () => warning(t("Attempting to reconnect to the message broker"), t("Offline"));
 
-function onPublicBroadcast(chan: string, _payl: unknown) {
-  if (chan === "public_broadcast") {
-    if (confirm("A new FarmBot version has been released. Refresh page?")) {
+/** Bag of strings useful for post-deploy app refresh.
+ * Move these constants as needed. - RC */
+export enum BROADCAST {
+  WARN = "You may experience data loss if you do not refresh the page " +
+  "(ctrl + shift + r on most machines)",
+  SOLICIT = "A new FarmBot version has been released. Refresh page?",
+  CHAN = "public_broadcast"
+}
+
+export function onPublicBroadcast(chan: string, _payl: unknown) {
+  if (chan === BROADCAST.CHAN) {
+    if (confirm(t(BROADCAST.SOLICIT))) {
       window.location.reload(true);
     } else {
-      alert("You may experience data loss if you do" +
-        " not refresh the page (ctrl + shift + r on most machines)");
+      alert(t(BROADCAST.WARN));
     }
   }
 }

--- a/frontend/connectivity/connect_device.ts
+++ b/frontend/connectivity/connect_device.ts
@@ -164,6 +164,18 @@ export const onOnline =
   () => dispatchNetworkUp("user.mqtt", undefined, "MQTT.js is online");
 export const onReconnect =
   () => warning(t("Attempting to reconnect to the message broker"), t("Offline"));
+
+function onPublicBroadcast(chan: string, _payl: unknown) {
+  if (chan === "public_broadcast") {
+    if (confirm("A new FarmBot version has been released. Refresh page?")) {
+      window.location.reload(true);
+    } else {
+      alert("You may experience data loss if you do" +
+        " not refresh the page (ctrl + shift + r on most machines)");
+    }
+  }
+}
+
 const attachEventListeners =
   (bot: Farmbot, dispatch: Function, getState: GetState) => {
     if (bot.client) {
@@ -178,6 +190,8 @@ const attachEventListeners =
       bot.on("status_v8", onStatus(dispatch, getState));
       bot.on("malformed", onMalformed);
       bot.client.on("message", autoSync(dispatch, getState));
+      bot.client.subscribe("public_broadcast");
+      bot.client.on("message", onPublicBroadcast);
       bot.client.on("reconnect", onReconnect);
     }
   };

--- a/frontend/connectivity/connect_device.ts
+++ b/frontend/connectivity/connect_device.ts
@@ -177,7 +177,7 @@ export enum BROADCAST {
 export function onPublicBroadcast(chan: string, _payl: unknown) {
   if (chan === BROADCAST.CHAN) {
     if (confirm(t(BROADCAST.SOLICIT))) {
-      window.location.reload(true);
+      location.assign(window.location.origin || "/");
     } else {
       alert(t(BROADCAST.WARN));
     }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   },
   "scripts": {
     "coverage": "cat **/*lcov.info | ./node_modules/coveralls/bin/coveralls.js",
-    "start": "echo 'DEPRECATED. Remove `start` from npm scripts'",
     "test-slow": "jest --coverage --ci -w 6 --colors",
     "test": "jest --no-coverage --cache -w 5 --colors",
     "typecheck": "./node_modules/typescript/bin/tsc --noEmit",

--- a/spec/controllers/api/rmq_utils/rmq_utils_controller_spec.rb
+++ b/spec/controllers/api/rmq_utils/rmq_utils_controller_spec.rb
@@ -26,6 +26,24 @@ describe Api::RmqUtilsController do
     end
   end
 
+  it "denies public_broadcast write access to non-admin users" do
+    routing_key = Api::RmqUtilsController::PUBLIC_CHANNELS.sample
+    permission  = ["write", "configure"].sample
+    p = credentials.merge(routing_key: routing_key, permission: permission)
+    post :topic_action, params: p
+    expect(response.body).to eq("deny")
+    expect(response.status).to eq(403)
+  end
+
+  it "allows public_broadcast read access to non-admin users" do
+    routing_key = Api::RmqUtilsController::PUBLIC_CHANNELS.sample
+    permission  = "read"
+    p = credentials.merge(routing_key: routing_key, permission: permission)
+    post :topic_action, params: p
+    expect(response.body).to eq("allow")
+    expect(response.status).to eq(200)
+  end
+
   it "allows access to ones own topic" do
     p = credentials.merge(routing_key: "bot.#{credentials[:username]}.logs")
     post :topic_action, params: p

--- a/spec/controllers/api/rmq_utils/rmq_utils_controller_spec.rb
+++ b/spec/controllers/api/rmq_utils/rmq_utils_controller_spec.rb
@@ -145,7 +145,7 @@ describe Api::RmqUtilsController do
   end
 
   it "validates topic names" do
-    r = Api::RmqUtilsController::TOPIC_REGEX
+    r = Api::RmqUtilsController::DEVICE_SPECIFIC_CHANNELS
     [ "*",
       "#",
       "foo",

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -11,6 +11,16 @@ describe User do
     const_reassign(User, :SKIP_EMAIL_VALIDATION, original)
   end
 
+  describe ".refresh_everyones_ui" do
+    it "Sends a message over AMQP" do
+      expect(Rollbar).to receive(:error).with("Global UI refresh triggered")
+      get_msg = receive(:raw_amqp_send)
+        .with("X", Api::RmqUtilsController::PUBLIC_BROADCAST)
+      expect(Transport.current).to get_msg
+      User.refresh_everyones_ui
+    end
+  end
+
   describe "SKIP_EMAIL_VALIDATION" do
     let (:user) { FactoryBot.create(:user, confirmed_at: nil) }
 


### PR DESCRIPTION
# What's New?

 * Refactor RabbitMQ permissions handler
 * Formatting auto fixes (using `rufo` + default configs to handle formatting)
 * Add new RabbitMQ channel to trigger optional UI refresh
 * Update Heroku `Procfile` to request UI refresh after every deploy.

# What's Next?

 * Need to write frontend tests for the `onPublicBroadcast` frontend callback