### PR TITLE
Perform account deletion in background worker

### DIFF
--- a/app/mutations/users/destroy.rb
+++ b/app/mutations/users/destroy.rb
@@ -12,10 +12,10 @@ module Users
     end
 
     def execute
-      user.destroy!
+      user.delay.destroy!
     end
 
-private
+    private
 
     def confirm_password
       invalid = !user.valid_password?(password)

--- a/spec/controllers/api/users/users_controller_spec.rb
+++ b/spec/controllers/api/users/users_controller_spec.rb
@@ -33,7 +33,9 @@ describe Api::UsersController do
 
   it "deletes a user account" do
     sign_in user
-    delete :destroy, params: { password: user.password }, format: :json
+    run_jobs_now do
+      delete :destroy, params: { password: user.password }, format: :json
+    end
     expect(response.status).to eq(200)
     expect(User.where(id: user.id).count).to eq(0)
   end


### PR DESCRIPTION
# What's New?

 * Move account resets and deletions to background worker, since, depending on account size, it can be a hefty task.