### PR TITLE
Increase limits, loosen restrictions on `/farmware_env` endpoint.

### DIFF
--- a/app/controllers/api/farmware_envs_controller.rb
+++ b/app/controllers/api/farmware_envs_controller.rb
@@ -6,7 +6,7 @@ module Api
   class FarmwareEnvsController < Api::AbstractController
 
     def create
-      mutate FarmwareEnvs::Create.run(params.as_json, device: current_device)
+      mutate FarmwareEnvs::Create.run(raw_json, device: current_device)
     end
 
     def index

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -1,6 +1,6 @@
 # Farmbot Device models all data related to an actual FarmBot in the real world.
 class Device < ApplicationRecord
-  DEFAULT_MAX_CONFIGS = 100
+  DEFAULT_MAX_CONFIGS = 300
   DEFAULT_MAX_IMAGES = 100
   DEFAULT_MAX_LOGS = 1000
 

--- a/app/models/farmware_env.rb
+++ b/app/models/farmware_env.rb
@@ -1,16 +1,5 @@
 # User definable key/value pairs, usually used for Farmware authorship.
 class FarmwareEnv < ApplicationRecord
   belongs_to :device
-  serialize  :value
-  validate   :primitives_only
-
-  PRIMITIVES_ONLY = "`value` must be a string, number or boolean"
-
-  def primitives_only
-    errors.add(:value, PRIMITIVES_ONLY) unless is_primitive
-  end
-
-  def is_primitive
-    [String, Integer, Float, TrueClass, FalseClass].include?(value.class)
-  end
+  serialize :value, JSON
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,6 @@
+
 if Rails.env == "development"
+  ENV["NO_EMAILS"] = "true"
   POINT_COUNT = 8
   PLANT_COUNT = 8
   DATE_RANGE_LO = 1..3

--- a/spec/controllers/api/farmware_envs/farmware_envs_controller_spec.rb
+++ b/spec/controllers/api/farmware_envs/farmware_envs_controller_spec.rb
@@ -10,7 +10,17 @@ describe Api::FarmwareEnvsController do
     sign_in user
     b4 = FarmwareEnv.count
     input = { key: "Coffee Emoji", value: "☕" }
-    post :create, params: input
+    post :create, body: input.to_json, params: { format: :json }
+    expect(response.status).to eq(200)
+    expect(FarmwareEnv.count).to be > b4
+    input.keys.map { |key| expect(json[key]).to eq(input[key]) }
+  end
+
+  it 'stores compound data types' do
+    sign_in user
+    b4 = FarmwareEnv.count
+    input = { key: "compund_data", value: {x: "y", z: 300} }
+    post :create, body: input.to_json, params: { format: :json }
     expect(response.status).to eq(200)
     expect(FarmwareEnv.count).to be > b4
     input.keys.map { |key| expect(json[key]).to eq(input[key]) }
@@ -23,7 +33,7 @@ describe Api::FarmwareEnvsController do
                           device: device)
     b4 = FarmwareEnv.count
     input = { key: "Coffee Emoji", value: "☕" }
-    post :create, params: input
+    post :create, body: input.to_json, params: { format: :json }
     expect(response.status).to eq(422)
     expect(json[:configs]).to include("over the limit")
     expect(FarmwareEnv.count).to eq(b4)


### PR DESCRIPTION
# What's New?

 * Increase `FarmwareEnv` limit from 100 to 300.
 * Allow use of compound data types in `value` of `FarmwareEnv`. SEE: #1204 
