### PR TITLE
Dont allow JSON primitives when POST/PUTing to API

### DIFF
--- a/app/controllers/api/abstract_controller.rb
+++ b/app/controllers/api/abstract_controller.rb
@@ -42,7 +42,8 @@ module Api
       sorry "You can't perform that action. #{exc.message}", 403
     end
 
-    ONLY_JSON = "This is a JSON API. Please use _valid_ JSON. " \
+    ONLY_JSON = "This is a JSON API. "\
+    "Please use a _valid_ JSON object or array. " \
     "Validate JSON objects at https://jsonlint.com/"
     rescue_from OnlyJson do |e|
       sorry ONLY_JSON, 422
@@ -90,7 +91,9 @@ module Api
 
     def parse_json
       body = request.body.read
-      body.present? ? JSON.parse(body, symbolize_names: true) : nil
+      json = body.present? ? JSON.parse(body, symbolize_names: true) : nil
+      raise OnlyJson unless json.is_a?(Hash) || json.is_a?(Array)
+      json
     end
 
     REQ_ID = "X-Farmbot-Rpc-Id"

--- a/spec/controllers/api/points/create_spec.rb
+++ b/spec/controllers/api/points/create_spec.rb
@@ -97,7 +97,8 @@ describe Api::PointsController do
       SmarfDoc.note("This is what happens when you post bad JSON")
       post :create, body: "{'x': 0, 'this isnt': 'JSON'}", params: { format: :json }
       expect(response.status).to eq(422)
-      expect(json[:error]).to include("Please use _valid_ JSON.")
+      expect(json[:error])
+        .to include("Please use a _valid_ JSON object or array")
     end
 
     it "creates a toolslot with an valid pullout direction" do


### PR DESCRIPTION
Continuing the last PR, this PR rejects non-object/array JSON data. In almost all cases, posting things other than objects/arrays is the result of malformed JSON.