### PR TITLE
Used named_pin when calling `readPin` from sensor panel

### DIFF
--- a/app/mutations/logs/create.rb
+++ b/app/mutations/logs/create.rb
@@ -29,11 +29,6 @@ module Logs
 
     def validate
       add_error :log, :private, BAD_WORDS if has_bad_words
-
-      # I think this was here for legacy reasons and can be removed.
-      # Delete this comment if no log issues are noted after 25 MAR 19. - RC
-      # add_error :device, :no_id, "ID of device can't be nil" unless device.id
-
       @log = Log.new(clean_inputs)
       @log.validate!
     end

--- a/frontend/controls/sensors/__tests__/sensor_list_test.tsx
+++ b/frontend/controls/sensors/__tests__/sensor_list_test.tsx
@@ -54,12 +54,17 @@ describe("<SensorList/>", function () {
     expect(wrapper.find(".indicator").last().text()).toEqual("1");
   });
 
-  const expectedPayload = (pin_number: number, pin_mode: 0 | 1) =>
-    ({
-      pin_number,
-      label: `pin${pin_number}`,
-      pin_mode
-    });
+  const expectedPayload = (pin_id: number, pin_mode: 0 | 1) => ({
+    pin_number: {
+      kind: "named_pin",
+      args: {
+        pin_type: "Sensor",
+        pin_id
+      }
+    },
+    label: `pin${pin_id}`,
+    pin_mode
+  });
 
   it("reads pins", () => {
     const wrapper = mount(<SensorList {...fakeProps()} />);

--- a/frontend/controls/sensors/sensor_list.tsx
+++ b/frontend/controls/sensors/sensor_list.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { readPin } from "../../devices/actions";
+import { readSensor } from "../../devices/actions";
 import { SensorListProps } from "./interfaces";
 import { sortResourcesById } from "../../util";
 import { Row, Col } from "../../ui";
@@ -62,7 +62,7 @@ export const SensorList = (props: SensorListProps) =>
             disabled={props.disabled}
             title={t(`read ${label} sensor`)}
             onClick={() =>
-              readPin(pinNumber, `pin${pin}`, mode as ALLOWED_PIN_MODES)}>
+              readSensor(pinNumber, `pin${pin}`, mode as ALLOWED_PIN_MODES)}>
             {t("read sensor")}
           </button>
         </Col>

--- a/frontend/devices/actions.ts
+++ b/frontend/devices/actions.ts
@@ -10,7 +10,9 @@ import { Thunk, ReduxAction } from "../redux/interfaces";
 import {
   McuParams, Configuration, TaggedFirmwareConfig, ParameterApplication,
   ALLOWED_PIN_MODES,
-  FirmwareHardware
+  FirmwareHardware,
+  AllowedPinTypes,
+  NamedPin
 } from "farmbot";
 import { ControlPanelState } from "../devices/interfaces";
 import { oneOf, versionOK, trim } from "../util";
@@ -326,8 +328,13 @@ export function pinToggle(pin_number: number) {
     .then(noop, commandErr(noun));
 }
 
-export function readPin(pin_number: number, label: string, pin_mode: ALLOWED_PIN_MODES) {
+export function readSensor(pin_id: number,
+  label: string,
+  pin_mode: ALLOWED_PIN_MODES) {
   const noun = "Read pin";
+  const pin_type: AllowedPinTypes = "Sensor";
+  const pin_number: NamedPin =
+    ({ kind: "named_pin", args: { pin_type, pin_id } });
   return getDevice()
     .readPin({ pin_number, label, pin_mode })
     .then(noop, commandErr(noun));


### PR DESCRIPTION
This fixes an ambiguity in FBOS noted by @ConnorRigby . CC: @gabrielburnworth .