### PR TITLE
Update NervesHub `devices` endpoint

### DIFF
--- a/app/lib/nerves_hub.rb
+++ b/app/lib/nerves_hub.rb
@@ -46,6 +46,7 @@ class NervesHub
   NERVES_HUB_HOST = ENV.fetch("NERVES_HUB_HOST") { "api.nerves-hub.org" }
   NERVES_HUB_PORT = ENV.fetch("NERVES_HUB_PORT") { 443 }
   NERVES_HUB_ORG = ENV.fetch("NERVES_HUB_ORG") { "farmbot" }
+  NERVES_HUB_PRODUCT = ENV.fetch("NERVES_HUB_PRODUCT") { "farmbot" }
   NERVES_HUB_BASE_URL = "https://#{NERVES_HUB_HOST}:#{NERVES_HUB_PORT}"
   NERVES_HUB_URI = URI.parse(NERVES_HUB_BASE_URL)
 
@@ -187,7 +188,7 @@ class NervesHub
 
   # Helper for making requests to a device url on NervesHub
   def self.devices_path(*chunks)
-    ["/orgs", NERVES_HUB_ORG, "devices"].concat(chunks).join("/")
+    ["/orgs", NERVES_HUB_ORG, "products", NERVES_HUB_PRODUCT, "devices"].concat(chunks).join("/")
   end
 
   # Helper for making requests to a particular device on NervesHub

--- a/example.env
+++ b/example.env
@@ -147,6 +147,9 @@ NERVES_HUB_PORT=443
 # Organization that the cert and key are authorized to access.
 # DELETE THIS LINE if you are a self-hosted user.
 NERVES_HUB_ORG=delete_this_line
+# Product that the cert and key are assosiated with.
+# DELETE THIS LINE if you are a self-hosted user.
+NERVES_HUB_PRODUCT=delete_this_line
 # Where to temporarily store device cert sign requests
 # DELETE THIS LINE if you are a self-hosted user.
 NERVES_HUB_DEVICE_CSR_DIR=/delete/this/path

--- a/spec/controllers/api/device_cert/decive_certs_create_spec.rb
+++ b/spec/controllers/api/device_cert/decive_certs_create_spec.rb
@@ -31,7 +31,7 @@ describe Api::DeviceCertsController do
                   {"tags": tags}.to_json,
                   NervesHub::HEADERS]
       post_data = a_string_including("\"identifier\":456")
-      post_args = ["/orgs/farmbot/devices/456/certificates/sign",
+      post_args = ["/orgs/farmbot/products/farmbot/devices/456/certificates/sign",
                    post_data,
                    {"Content-Type"=>"application/json"}]
 

--- a/spec/lib/nerves_hub_spec.rb
+++ b/spec/lib/nerves_hub_spec.rb
@@ -26,9 +26,9 @@ describe NervesHub do
   end
 
   it "generates URL paths" do
-    expect(NervesHub.devices_path).to eq "/orgs/farmbot/devices"
-    expect(NervesHub.device_path("foo")).to eq "/orgs/farmbot/devices/foo"
-    expect(NervesHub.device_sign_path(123)).to eq "/orgs/farmbot/devices/123/certificates/sign"
+    expect(NervesHub.devices_path).to eq "/orgs/farmbot/products/farmbot/devices"
+    expect(NervesHub.device_path("foo")).to eq "/orgs/farmbot/products/farmbot/devices/foo"
+    expect(NervesHub.device_sign_path(123)).to eq "/orgs/farmbot/products/farmbot/devices/123/certificates/sign"
   end
 
   it "gets a device via .device" do
@@ -83,11 +83,11 @@ describe NervesHub do
 
   it "calls `new_device` if device does not exist" do
     expect(NervesHub.conn)
-    xpect_args = "/orgs/farmbot/devices/X"
+    xpect_args = "/orgs/farmbot/products/farmbot/devices/X"
     resp = StubResp.new("404", { "data" => {} }.to_json)
     expect(NervesHub.conn).to receive(:get).with(xpect_args).and_return(resp)
     tags = ["A:B", "C:D"]
-    xpect_args2 = ["/orgs/farmbot/devices",
+    xpect_args2 = ["/orgs/farmbot/products/farmbot/devices",
                    { "description": "farmbot-X",
                      "identifier": "X",
                      "tags": tags }.to_json,
@@ -117,7 +117,7 @@ describe NervesHub do
       "data" => { hello: :world, identifier: "?" },
     }.to_json)
     do_it =
-      receive(:get).with("/orgs/farmbot/devices/#{serial_number}").and_return(resp)
+      receive(:get).with("/orgs/farmbot/products/farmbot/devices/#{serial_number}").and_return(resp)
     expect(NervesHub.conn).to do_it
     expect(NervesHub).to receive(:report_problem).with(expected)
     NervesHub.maybe_create_or_update(serial_number, tags)

--- a/spec/models/fbos_config_spec.rb
+++ b/spec/models/fbos_config_spec.rb
@@ -27,7 +27,7 @@ describe FbosConfig do
     it "triggers callbacks" do
       conn = fake_conn("Create a cert")
       NervesHub.set_conn(conn)
-      url    = "/orgs/farmbot/devices/#{device.serial_number}"
+      url    = "/orgs/farmbot/products/farmbot/devices/#{device.serial_number}"
       resp   = StubResp.new("200", { "data" => { "tags": [] } }.to_json)
       resp2  = StubResp.new("201", { "data" => { "tags": [] } }.to_json)
       params = [ url,

--- a/spec/mutations/device_certs/create_spec.rb
+++ b/spec/mutations/device_certs/create_spec.rb
@@ -24,7 +24,7 @@ describe DeviceCerts::Create do
                    {"tags": tags}.to_json,
                    NervesHub::HEADERS]
       hmm       = a_string_including("\"identifier\":456")
-      post_args = ["/orgs/farmbot/devices/456/certificates/sign",
+      post_args = ["/orgs/farmbot/products/farmbot/devices/456/certificates/sign",
                    hmm,
                    {"Content-Type"=>"application/json"}]
       expect(NervesHub.conn).to(receive(:get).with(url).and_return(resp1))


### PR DESCRIPTION
* This addresses the upcoming change to the NervesHub API
  * https://github.com/nerves-hub/nerves_hub_web/pull/499
* Update nerves_hub tests