### PR TITLE
Remove preboot

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -2,4 +2,4 @@ worker:         bundle exec rake jobs:work
 rabbit_workers: bin/rails r lib/rabbit_workers.rb
 web:            bundle exec passenger start -p $PORT -e $RAILS_ENV --max-pool-size 2
 # This will perform a hard refresh on all connected browsers.
-release:        rails r "User.delay(run_at: 5.minutes.from_now).refresh_everyones_ui"
+release:        rails r "User.refresh_everyones_ui"


### PR DESCRIPTION
This PR disables [preboot](https://devcenter.heroku.com/articles/preboot) and removes the 5 minute app refresh delay.