### PR TITLE
Fix nav jiggle by adding data-title attribute and css:after

### DIFF
--- a/frontend/css/navbar.scss
+++ b/frontend/css/navbar.scss
@@ -113,6 +113,14 @@ nav {
     div {
       display: inline;
       vertical-align: middle;
+      &:after{
+        display: block;
+        content: attr(data-title);
+        font-weight: bold;
+        height: 0;
+        overflow: hidden;
+        visibility: hidden;
+      }
     }
   }
 }
@@ -136,6 +144,14 @@ nav {
     i {
       margin-right: 0.8rem;
     }
+  }
+  .nav-name:after{
+    display: block;
+    content: attr(data-title);
+    font-weight: bold;
+    height: 0;
+    overflow: hidden;
+    visibility: hidden;
   }
 }
 

--- a/frontend/nav/index.tsx
+++ b/frontend/nav/index.tsx
@@ -109,7 +109,7 @@ export class NavBar extends React.Component<NavBarProps, Partial<NavBarState>> {
                         position={Position.BOTTOM_RIGHT}
                         isOpen={accountMenuOpen}
                         onClose={this.close("accountMenuOpen")}>
-                        <div className="nav-name"
+                        <div className="nav-name" data-title={firstName}
                           onClick={this.toggle("accountMenuOpen")}>
                           {firstName}
                         </div>

--- a/frontend/nav/nav_links.tsx
+++ b/frontend/nav/nav_links.tsx
@@ -62,7 +62,7 @@ export const NavLinks = (props: NavLinksProps) => {
           draggable={false}
           onClick={props.close("mobileMenuOpen")}>
           <i className={`fa fa-${link.icon}`} />
-          <div>
+          <div data-title={t(link.name)}>
             {t(link.name)}
             {link.slug === "messages" && props.alertCount > 0 &&
               <div className={"saucer fun"}>


### PR DESCRIPTION
This is to fix issue #1414. By adding an :after attribute to the divs with the menu items with the font-weight set to bold, this :after element essentially takes up the space of the bold font and acts as a placeholder. This solves the issue on the desktop menu size.