### PR TITLE
Delete inactive accounts automatically.

### DIFF
--- a/app/controllers/api/abstract_controller.rb
+++ b/app/controllers/api/abstract_controller.rb
@@ -213,7 +213,6 @@ module Api
     # Devices have a `last_saw_api` field to assist users with debugging.
     # We update this column every time an FBOS device talks to the API.
     def mark_as_seen(bot = (current_user && current_user.device))
-      current_user && current_user.reset_inactivity_tracking!
       when_farmbot_os do
         if bot
           v = fbos_version

--- a/app/controllers/api/abstract_controller.rb
+++ b/app/controllers/api/abstract_controller.rb
@@ -213,6 +213,7 @@ module Api
     # Devices have a `last_saw_api` field to assist users with debugging.
     # We update this column every time an FBOS device talks to the API.
     def mark_as_seen(bot = (current_user && current_user.device))
+      current_user && current_user.reset_inactivity_tracking!
       when_farmbot_os do
         if bot
           v = fbos_version

--- a/app/jobs/inactive_account_job.rb
+++ b/app/jobs/inactive_account_job.rb
@@ -1,0 +1,55 @@
+# Recurring task that deletes inactive accounts.
+class InactiveAccountJob < ApplicationJob
+  queue_as :default
+  LIMIT = 1000
+  INACTIVE_WITH_DEVICE = 11.months + 15.days
+  INACTIVE_NO_DEVICE = 2.months + 15.days
+
+  def perform
+    notify_old_accounts
+    delete_old_accounts
+  end
+
+  private
+
+  def notify_old_accounts
+    all_inactive
+      .where(inactivity_warning_sent_at: nil)
+      .map(&:send_inactivity_warning)
+  end
+
+  def delete_old_accounts
+    all_inactive
+      .where
+      .not(inactivity_warning_sent_at: nil)
+      .where("inactivity_warning_sent_at < ?", 14.days.ago)
+      .map(&:deactivate_account)
+  end
+
+  # Returns a Map. Key is the number of warnings sent, value is a User object
+  # (not a device, but device is preloaded)
+  def all_inactive
+    return @all_inactive if @all_inactive
+    users = User.includes(:device)
+
+    # They signed up for an account, but never configured a device.
+    no_device = users
+      .where("devices.fbos_version" => nil)
+      .references(:devices)
+
+    # They signed up for an account and once had a working device.
+    ok_device = users
+      .where
+      .not("devices.fbos_version" => nil)
+      .references(:devices)
+
+    inactive_3mo = no_device
+      .where("last_sign_in_at < ?", INACTIVE_NO_DEVICE.ago)
+    inactive_11mo = ok_device
+      .where("last_sign_in_at < ?", INACTIVE_WITH_DEVICE.ago)
+    @all_inactive = inactive_11mo
+      .or(inactive_3mo)
+      .order("RANDOM()")
+      .limit(LIMIT)
+  end
+end

--- a/app/mailers/inactivity_mailer.rb
+++ b/app/mailers/inactivity_mailer.rb
@@ -1,7 +1,8 @@
 class InactivityMailer < ApplicationMailer
   attr_reader :user
 
-  SUBJECT = "Your FarmBot Account Will Be Deleted Due to Inactivity"
+  SUBJECT = "Your FarmBot account will be deleted "\
+  "due to inactivity unless you login"
   ORDER = { 1 => "First", 2 => "Second", 3 => "Final" }
 
   def send_warning(user)

--- a/app/mailers/inactivity_mailer.rb
+++ b/app/mailers/inactivity_mailer.rb
@@ -1,0 +1,11 @@
+class InactivityMailer < ApplicationMailer
+  attr_reader :user
+
+  SUBJECT = "Your FarmBot Account Will Be Deleted Due to Inactivity"
+  ORDER = { 1 => "First", 2 => "Second", 3 => "Final" }
+
+  def send_warning(user)
+    @user = user
+    mail to: user.email, subject: SUBJECT
+  end
+end

--- a/app/models/token_issuance.rb
+++ b/app/models/token_issuance.rb
@@ -4,6 +4,7 @@ class TokenIssuance < ApplicationRecord
   belongs_to :device
   # Number of ms Rails will wait for the API.
   API_TIMEOUT = Rails.env.test? ? 0.01 : 2.5
+  after_create :reset_inactivity_timer
 
   def broadcast?
     false
@@ -39,5 +40,9 @@ class TokenIssuance < ApplicationRecord
 
   def self.clean_old_tokens
     expired.destroy_all
+  end
+
+  def reset_inactivity_timer
+    device.users.map(&:reset_inactivity_tracking!)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,10 +70,12 @@ class User < ApplicationRecord
 
   def deactivate_account
     User.transaction do
-      raise "HALTING ERRONEOUS DELETION" if last_sign_in_at > 3.months.ago
+      if reload.last_sign_in_at > 3.months.ago
+        raise "HALTING ERRONEOUS DELETION"
+      end
       # Prevent double deletion / race conditions.
-      u.update!(last_sign_in_at: Time.now, inactivity_warning_sent_at: nil)
-      u.delay.destroy!
+      update!(last_sign_in_at: Time.now, inactivity_warning_sent_at: nil)
+      delay.destroy!
     end
   end
 end

--- a/app/views/inactivity_mailer/send_warning.html.erb
+++ b/app/views/inactivity_mailer/send_warning.html.erb
@@ -1,3 +1,3 @@
-You have not logged in <%= time_ago_in_words(user.last_sign_in_at) %>. Your account will be automatically deleted after 14 days of inactivity.
+You have not logged in <%= time_ago_in_words(@user.last_sign_in_at) %>. Your account will be automatically deleted after 14 days of inactivity.
 
-To halt the deletion process, please log in to your account.
+To halt the deletion process, please <%= link_to "login", front_page_url %> to your account in the next 14 days.

--- a/app/views/inactivity_mailer/send_warning.html.erb
+++ b/app/views/inactivity_mailer/send_warning.html.erb
@@ -1,0 +1,3 @@
+You have not logged in <%= time_ago_in_words(user.last_sign_in_at) %>. Your account will be automatically deleted after 14 days of inactivity.
+
+To halt the deletion process, please log in to your account.

--- a/db/migrate/20191119204916_add_inactivity_fields_to_users.rb
+++ b/db/migrate/20191119204916_add_inactivity_fields_to_users.rb
@@ -1,0 +1,5 @@
+class AddInactivityFieldsToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :inactivity_warning_sent_at, :datetime
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1648,7 +1648,8 @@ CREATE TABLE public.users (
     confirmation_token character varying,
     agreed_to_terms_at timestamp without time zone,
     confirmation_sent_at timestamp without time zone,
-    unconfirmed_email character varying
+    unconfirmed_email character varying,
+    inactivity_warning_sent_at timestamp without time zone
 );
 
 
@@ -3366,6 +3367,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190924190539'),
 ('20190930202839'),
 ('20191002125625'),
-('20191107170431');
+('20191107170431'),
+('20191119204916');
 
 

--- a/spec/jobs/inactive_account_job_spec.rb
+++ b/spec/jobs/inactive_account_job_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+
+describe InactiveAccountJob do
+  let!(:yes) { FactoryBot.create(:user, last_sign_in_at: 3.years.ago) }
+  let!(:no) { FactoryBot.create(:user, last_sign_in_at: 3.days.ago) }
+
+  it "Processes deletion" do
+    # === Expect a clean slate.
+    expect(yes.inactivity_warning_sent_at).to be(nil)
+    expect(no.inactivity_warning_sent_at).to be(nil)
+    empty_mail_bag
+
+    # === Perform the first (only) warning.
+    run_jobs_now { InactiveAccountJob.new.perform }
+    mail = ActionMailer::Base.deliveries.last
+
+    # === Expect warnings
+    expect(yes.reload.inactivity_warning_sent_at).not_to be(nil)
+    expect(no.reload.inactivity_warning_sent_at).to be(nil)
+    expect(mail).to be_kind_of(Mail::Message)
+    expect(mail.to).to include(yes.email)
+    expect(mail.subject).to eq("Your FarmBot Account Will Be Deleted Due to Inactivity")
+    expect(mail.body.encoded).to include("You have not logged in about 3 years.")
+
+    # === Wind back the clock to simulate inactivty.
+    yes.update!(inactivity_warning_sent_at: 15.days.ago)
+    run_jobs_now { InactiveAccountJob.new.perform }
+    expect(User.where(id: yes.id).count).to eq(0)
+  end
+
+  it "does not delete an account during the waiting period"
+  it "finishes deletion"
+end

--- a/spec/jobs/inactive_account_job_spec.rb
+++ b/spec/jobs/inactive_account_job_spec.rb
@@ -19,7 +19,8 @@ describe InactiveAccountJob do
     expect(no.reload.inactivity_warning_sent_at).to be(nil)
     expect(mail).to be_kind_of(Mail::Message)
     expect(mail.to).to include(yes.email)
-    expect(mail.subject).to eq("Your FarmBot Account Will Be Deleted Due to Inactivity")
+    subject = "Your FarmBot account will be deleted due to inactivity"
+    expect(mail.subject).to include(subject)
     expect(mail.body.encoded).to include("You have not logged in about 3 years.")
 
     # === Wind back the clock to simulate inactivty.

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,11 @@
 require "spec_helper"
 
 describe User do
+  it "prevents accidental deactivation" do
+    u = FactoryBot.create(:user, last_sign_in_at: Time.now)
+    expect { u.deactivate_account }.to raise_error("HALTING ERRONEOUS DELETION")
+  end
+
   describe "#new" do
     it "Creates a new user" do
       expect(User.new).to be_kind_of(User)


### PR DESCRIPTION
 * Send users a warning email that they must log in after a period of inactivity (1 year for accounts with a real device, 3 months for accounts that have not attached a real bot).
 * Delete the account after 14 days if they do not log in.

Closes #1305

**NOTE:** I must enable a scheduler job for this feature to take effect on production / staging.