### PR TITLE
Update ubuntu_setup.sh

### DIFF
--- a/ubuntu_example.sh
+++ b/ubuntu_example.sh
@@ -45,6 +45,8 @@ micro .env          # ⚠ SKIP THIS STEP IF UPGRADING!
 # ^ This is the most important step
 # READ NOTE ABOVE. Very important!
 
+# Install the correct version of bundler for the project
+sudo docker-compose run web gem install bundler:2.1.4
 # Install application specific Ruby dependencies
 sudo docker-compose run web bundle install
 # Install application specific Javascript deps


### PR DESCRIPTION
Fixes  #1678 noted by @PitouGames 

This is most likely caused by the bundler version specified in the docker base image. We can't upgrade  the Ruby image right now, unfortunately, so this PR will serve as a workaround.