### PR TITLE
Logs responsive

### DIFF
--- a/frontend/css/global.scss
+++ b/frontend/css/global.scss
@@ -1058,6 +1058,9 @@ ul {
   .fa-ban {
     color: $medium_gray;
   }
+  .table-responsive{
+    border: none;
+  }
 }
 
 .logs-settings-menu {

--- a/frontend/logs/components/logs_table.tsx
+++ b/frontend/logs/components/logs_table.tsx
@@ -69,26 +69,28 @@ const LOG_TABLE_CLASS = [
 
 /** All log messages with select data in table form for display in the app. */
 export const LogsTable = (props: LogsTableProps) => {
-  return <table className={LOG_TABLE_CLASS}>
-    <thead>
-      <tr>
-        <th><label>{t("Type")}</label></th>
-        <th><label>{t("Message")}</label></th>
-        <th><label>{t("(x, y, z)")}</label></th>
-        <th><label>{t("Time")}</label></th>
-      </tr>
-    </thead>
-    <tbody>
-      {filterByVerbosity(getFilterLevel(props.state), props.logs)
-        .map((log: TaggedLog) =>
-          <LogsRow
-            key={log.uuid}
-            tlog={log}
-            dispatch={props.dispatch}
-            markdown={props.state.markdown}
-            timeSettings={props.timeSettings} />)}
-    </tbody>
-  </table>;
+  return <div className={"table-responsive"}>
+    <table className={LOG_TABLE_CLASS}>
+      <thead>
+        <tr>
+          <th><label>{t("Type")}</label></th>
+          <th><label>{t("Message")}</label></th>
+          <th><label>{t("(x, y, z)")}</label></th>
+          <th><label>{t("Time")}</label></th>
+        </tr>
+      </thead>
+      <tbody>
+        {filterByVerbosity(getFilterLevel(props.state), props.logs)
+          .map((log: TaggedLog) =>
+            <LogsRow
+              key={log.uuid}
+              tlog={log}
+              dispatch={props.dispatch}
+              markdown={props.state.markdown}
+              timeSettings={props.timeSettings} />)}
+      </tbody>
+    </table>
+  </div>;
 };
 
 /** Get current verbosity filter level for a message type from LogsState. */

--- a/frontend/logs/index.tsx
+++ b/frontend/logs/index.tsx
@@ -37,7 +37,7 @@ export class RawLogs extends React.Component<LogsProps, Partial<LogsState>> {
     } else {
       return currentValue as number;
     }
-  }
+  };
 
   state: LogsState = {
     autoscroll: false,
@@ -61,7 +61,7 @@ export class RawLogs extends React.Component<LogsProps, Partial<LogsState>> {
       this.props.dispatch(
         setWebAppConfigValue(safeNumericSetting(name + "_log"), newSetting));
     };
-  }
+  };
 
   /** Set log type filter level. i.e., level 2 shows verbosity 2 and lower.*/
   setFilterLevel = (name: keyof Filters) => {

--- a/public/app-resources/languages/fr.json
+++ b/public/app-resources/languages/fr.json
@@ -856,7 +856,7 @@
     "This will restart FarmBot's Raspberry Pi and controller software.": "Ceci redémarrera le programme de contrôle de la Raspberry Pi de FarmBot.",
     "This will shutdown FarmBot's Raspberry Pi. To turn it back on, unplug FarmBot and plug it back in.": "Ceci éteindra la Raspberry Pi de FarmBot. Pour la redémarrer, débranchez puis rebranchez FarmBot.",
     "Ticker Notification": "Ticket de Notification",
-    "Time": "Temps",
+    "Time": "Heure",
     "Time in milliseconds": "Temps en millisecondes",
     "Time in minutes to attempt connecting to WiFi before a factory reset.": "Temps en minutes pour tenter de se connecter au WiFi avant une réinitialisation d'usine.",
     "Time is not properly formatted.": "Le temps n'est pas correctement formaté.",


### PR DESCRIPTION
Hello,
The logs page has a table to display logs. Several times I was next to the robot with my phone and needed to know times of some logs, but it was impossible to look at the column "Time" because it was outside the screen.
This PR allow user with touch-screen to scroll horizontally this table, so the last column can be seen on small screen.
It also fix a french translation.