### PR TITLE
PointGroup, SensorReading updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem "scenic"
 gem "secure_headers"
 gem "tzinfo" # For validation of user selected timezone names
 gem "valid_url"
-# gem "farady", "~> 1.0.0"
+gem "kaminari"
 
 group :development, :test do
   gem "climate_control"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,6 +153,18 @@ GEM
     json (2.3.0)
     jsonapi-renderer (0.2.2)
     jwt (2.2.1)
+    kaminari (1.2.0)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.0)
+      kaminari-activerecord (= 1.2.0)
+      kaminari-core (= 1.2.0)
+    kaminari-actionview (1.2.0)
+      actionview
+      kaminari-core (= 1.2.0)
+    kaminari-activerecord (1.2.0)
+      activerecord
+      kaminari-core (= 1.2.0)
+    kaminari-core (1.2.0)
     loofah (2.4.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -320,6 +332,7 @@ DEPENDENCIES
   google-cloud-storage (~> 1.11)
   hashdiff
   jwt
+  kaminari
   mutations
   passenger
   pg

--- a/app/controllers/api/abstract_controller.rb
+++ b/app/controllers/api/abstract_controller.rb
@@ -80,6 +80,16 @@ module Api
       { root: false, user: current_user }
     end
 
+    def maybe_paginate(collection)
+      page = params[:page]
+      per = params[:per]
+
+      if page && per
+        render json: collection.page(page).per(per)
+      else
+        render json: collection
+      end
+    end
     private
 
     def clean_expired_farm_events

--- a/app/controllers/api/alerts_controller.rb
+++ b/app/controllers/api/alerts_controller.rb
@@ -1,7 +1,7 @@
 module Api
   class AlertsController < Api::AbstractController
     def index
-      render json: current_device.alerts
+      maybe_paginate current_device.alerts
     end
 
     def destroy

--- a/app/controllers/api/farm_events_controller.rb
+++ b/app/controllers/api/farm_events_controller.rb
@@ -3,7 +3,7 @@ module Api
     before_action :clean_expired_farm_events, only: [:index]
 
     def index
-      render json: current_device.farm_events
+      maybe_paginate current_device.farm_events
     end
 
     def show

--- a/app/controllers/api/farmware_envs_controller.rb
+++ b/app/controllers/api/farmware_envs_controller.rb
@@ -10,7 +10,7 @@ module Api
     end
 
     def index
-      render json: farmware_envs
+      maybe_paginate farmware_envs
     end
 
     def show

--- a/app/controllers/api/farmware_installations_controller.rb
+++ b/app/controllers/api/farmware_installations_controller.rb
@@ -1,7 +1,7 @@
 module Api
   class FarmwareInstallationsController < Api::AbstractController
     def index
-      render json: farmware_installations
+      maybe_paginate farmware_installations
     end
 
     def show

--- a/app/controllers/api/peripherals_controller.rb
+++ b/app/controllers/api/peripherals_controller.rb
@@ -1,7 +1,7 @@
 module Api
   class PeripheralsController < Api::AbstractController
     def index
-      render json: current_device.peripherals
+      maybe_paginate current_device.peripherals
     end
 
     def show

--- a/app/controllers/api/pin_bindings_controller.rb
+++ b/app/controllers/api/pin_bindings_controller.rb
@@ -1,7 +1,7 @@
 module Api
   class PinBindingsController < Api::AbstractController
     def index
-      render json: pin_bindings
+      maybe_paginate pin_bindings
     end
 
     def show

--- a/app/controllers/api/plant_templates_controller.rb
+++ b/app/controllers/api/plant_templates_controller.rb
@@ -1,7 +1,7 @@
 module Api
   class PlantTemplatesController < Api::AbstractController
     def index
-      render json: current_device.plant_templates
+      maybe_paginate current_device.plant_templates
     end
 
     def create

--- a/app/controllers/api/point_groups_controller.rb
+++ b/app/controllers/api/point_groups_controller.rb
@@ -3,7 +3,7 @@ module Api
     before_action :clean_expired_farm_events, only: [:destroy]
 
     def index
-      render json: your_point_groups
+      maybe_paginate your_point_groups
     end
 
     def show

--- a/app/controllers/api/points_controller.rb
+++ b/app/controllers/api/points_controller.rb
@@ -20,7 +20,7 @@ module Api
         .where("discarded_at < ?", Time.now - HARD_DELETE_AFTER)
         .destroy_all
 
-      render json: points(params.fetch(:filter) { "kept" })
+      maybe_paginate points(params.fetch(:filter) { "kept" })
     end
 
     def show

--- a/app/controllers/api/regimens_controller.rb
+++ b/app/controllers/api/regimens_controller.rb
@@ -3,7 +3,7 @@ module Api
     before_action :clean_expired_farm_events, only: [:destroy]
 
     def index
-      render json: your_regimens
+      maybe_paginate your_regimens
     end
 
     def show

--- a/app/controllers/api/saved_gardens_controller.rb
+++ b/app/controllers/api/saved_gardens_controller.rb
@@ -1,7 +1,7 @@
 module Api
   class SavedGardensController < Api::AbstractController
     def index
-      render json: current_device.saved_gardens
+      maybe_paginate current_device.saved_gardens
     end
 
     def create

--- a/app/controllers/api/sensor_readings_controller.rb
+++ b/app/controllers/api/sensor_readings_controller.rb
@@ -5,7 +5,7 @@ module Api
     end
 
     def index
-      render json: readings
+      maybe_paginate(readings)
     end
 
     def show

--- a/app/controllers/api/sensors_controller.rb
+++ b/app/controllers/api/sensors_controller.rb
@@ -1,7 +1,7 @@
 module Api
   class SensorsController < Api::AbstractController
     def index
-      render json: current_device.sensors
+      maybe_paginate current_device.sensors
     end
 
     def show

--- a/app/controllers/api/tools_controller.rb
+++ b/app/controllers/api/tools_controller.rb
@@ -2,7 +2,7 @@ module Api
   class ToolsController < Api::AbstractController
 
     def index
-      render json: tools
+      maybe_paginate tools
     end
 
     def show

--- a/app/controllers/api/webcam_feeds_controller.rb
+++ b/app/controllers/api/webcam_feeds_controller.rb
@@ -7,7 +7,7 @@ module Api
     end
 
     def index
-      render json: webcams
+      maybe_paginate webcams
     end
 
     def show

--- a/app/serializers/point_group_serializer.rb
+++ b/app/serializers/point_group_serializer.rb
@@ -4,4 +4,8 @@ class PointGroupSerializer < ApplicationSerializer
   def point_ids
     object.point_group_items.pluck(:point_id)
   end
+
+  def criteria
+    object.criteria || PointGroup::DEFAULT_CRITERIA
+  end
 end

--- a/spec/controllers/api/point_groups/show_spec.rb
+++ b/spec/controllers/api/point_groups/show_spec.rb
@@ -17,4 +17,12 @@ describe Api::PointGroupsController do
     expect(response.status).to eq(200)
     expect(json.fetch(:name)).to eq pg.name
   end
+
+  it "fills `nil` criteria with PointGroup::DEFAULT_CRITERIA" do
+    pg = PointGroup.create!(name: "x", device: device, criteria: nil )
+    sign_in user
+    get :show, params: { id: pg.id }
+    expect(response.status).to eq(200)
+    expect(json.fetch(:criteria)).to eq PointGroup::DEFAULT_CRITERIA
+  end
 end

--- a/spec/controllers/api/sensor_readings/controller_spec.rb
+++ b/spec/controllers/api/sensor_readings/controller_spec.rb
@@ -82,6 +82,14 @@ describe Api::SensorReadingsController do
       expect(keys).to include(:x, :y, :z, :value, :pin)
     end
 
+    it "paginates sensor readings" do
+      sign_in user
+      SensorReading.destroy_all
+      FactoryBot.create_list(:sensor_reading, 30, device: user.device)
+      get :index, params: { format: :json, page: 2, per: 5 }
+      expect(json.length).to eq(5)
+    end
+
     it "destroys a reading" do
       sign_in user
       SensorReading.destroy_all


### PR DESCRIPTION
# What's New?

 * Fixed bug where legacy point_group resources would crash on the frontend due to having a `criteria` value of `null`
 * Added pagination to the  `/api/sensor_readings` endpoint, as requested by @PitouGames . Please see example below.

# How to Paginate

Pagination is controlled by two parameters:

 * `?page=` - The page number to retrieve.
 * `?per=` - The size of each page.

For example, to retrieve page 7 of sensor_readings with a page size of 5, perform:

```
GET /api/sensor_readings?page=7&per=5
```
