### PR TITLE
Minor Changes to Sync Endpoint

### DIFF
--- a/app/mutations/devices/sync.rb
+++ b/app/mutations/devices/sync.rb
@@ -37,6 +37,7 @@ module Devices
       real_stuff = QUERIES.reduce({}) do |acc, (key, value)|
         acc.update(key => conn.execute(value + device.id.to_s).values)
       end
+      device.update!(last_saw_api: Time.now)
       real_stuff.merge({ first_party_farmwares: STUB_FARMWARES })
     end
   end

--- a/spec/mutations/devices/sync_spec.rb
+++ b/spec/mutations/devices/sync_spec.rb
@@ -24,7 +24,10 @@ describe Devices::Sync do
   ])
 
   it "is different this time!" do
+    old_timestamp = 5.years.ago
+    device.last_saw_api = old_timestamp
     results = Devices::Sync.run!(device: device)
     expect(Set.new(results.keys)).to eq(TABLES)
+    expect(device.reload.last_saw_api).to be > old_timestamp
   end
 end


### PR DESCRIPTION
It seems there are some issues with `last_saw_api`. In the interim, this fix will always update the `last_saw_api` value when the `/sync` endpoint is hit, since that endpoint is only visited by FBOS devices.