### PR TITLE
Remove Logs page tooltip

### DIFF
--- a/frontend/logs/__tests__/index_test.tsx
+++ b/frontend/logs/__tests__/index_test.tsx
@@ -3,7 +3,6 @@ const mockStorj: Dictionary<number | boolean> = {};
 import * as React from "react";
 import { mount, shallow } from "enzyme";
 import { RawLogs as Logs } from "../index";
-import { ToolTips } from "../../constants";
 import { TaggedLog, Dictionary } from "farmbot";
 import { NumericSetting } from "../../session_keys";
 import { fakeLog } from "../../__test_support__/fake_state/resources";
@@ -33,7 +32,7 @@ describe("<Logs />", () => {
 
   it("renders", () => {
     const wrapper = mount(<Logs {...fakeProps()} />);
-    ["Logs", ToolTips.LOGS, "Type", "Message", "Time", "Info",
+    ["Logs", "Type", "Message", "Time", "Info",
       "Fake log message 1", "Success", "Fake log message 2"]
       .map(string =>
         expect(wrapper.text().toLowerCase()).toContain(string.toLowerCase()));

--- a/frontend/logs/index.tsx
+++ b/frontend/logs/index.tsx
@@ -1,11 +1,10 @@
 import * as React from "react";
 import moment from "moment";
 import { connect } from "react-redux";
-import { Col, Row, Page, ToolTip } from "../ui/index";
+import { Col, Row, Page } from "../ui/index";
 import { mapStateToProps } from "./state_to_props";
 import { Popover, Position } from "@blueprintjs/core";
 import { LogsState, LogsProps, Filters } from "./interfaces";
-import { ToolTips } from "../constants";
 import { LogsSettingsMenu } from "./components/settings_menu";
 import { LogsFilterMenu, filterStateKeys } from "./components/filter_menu";
 import { LogsTable } from "./components/logs_table";
@@ -91,7 +90,6 @@ export class RawLogs extends React.Component<LogsProps, Partial<LogsState>> {
           <h3>
             <i>{t("Logs")}</i>
           </h3>
-          <ToolTip helpText={ToolTips.LOGS} />
         </Col>
         <Col xs={6}>
           <div className={"settings-menu-button"}>


### PR DESCRIPTION
It's small but this is my first open source contribution ever. I'm not familiarized with Ruby so I tried to find the easiest issue and one that didn't need to use Ruby.

Just removed the tooltip like asked and the unnecessary import statements.

I really like what you guys are doing here, hopefully I can contribute more in the future.