### PR TITLE
Loosen restrictions on auto-sync fields in device table.

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,7 +1,7 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
-  after_create  :maybe_broadcast
-  after_update  :maybe_broadcast
+  after_create :maybe_broadcast
+  after_update :maybe_broadcast
   after_destroy :maybe_broadcast
 
   class << self
@@ -9,7 +9,7 @@ class ApplicationRecord < ActiveRecord::Base
   end
 
   DONT_BROADCAST = ["created_at",
-                    "last_saw_api",
+                    # "last_saw_api",
                     "last_saw_mq",
                     "last_sign_in_at",
                     "last_sign_in_ip",

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -100,7 +100,9 @@ class Device < ApplicationRecord
     end_t = violation.ends_at
     # Some log validation errors will result in until_time being `nil`.
     if (throttled_until.nil? || (end_t > throttled_until))
-      reload.update!(throttled_until: end_t, throttled_at: Time.now)
+      auto_sync_transaction do
+        reload.update!(throttled_until: end_t, throttled_at: Time.now)
+      end
       cooldown = end_t.in_time_zone(self.timezone || "UTC").strftime("%I:%M%p")
       info = [violation.explanation, cooldown]
       cooldown_notice(THROTTLE_ON % info, end_t, "warn")

--- a/frontend/connectivity/auto_sync.ts
+++ b/frontend/connectivity/auto_sync.ts
@@ -45,12 +45,13 @@ export function asTaggedResource(data: UpdateMqttData<TaggedResource>):
 export const handleCreate =
   (data: UpdateMqttData<TaggedResource>) => init(data.kind, data.body, true);
 
+let count = 0;
 export const handleUpdate =
   (d: UpdateMqttData<TaggedResource>, uuid: string) => {
     const tr = asTaggedResource(d);
     tr.uuid = uuid;
     if (tr.kind == "Device") {
-      console.log("Received Device auto sync message.")
+      console.log("Received Device auto sync message. " + (count++));
     }
     return overwrite(tr, tr.body, SpecialStatus.SAVED);
   };

--- a/frontend/connectivity/auto_sync.ts
+++ b/frontend/connectivity/auto_sync.ts
@@ -49,6 +49,9 @@ export const handleUpdate =
   (d: UpdateMqttData<TaggedResource>, uuid: string) => {
     const tr = asTaggedResource(d);
     tr.uuid = uuid;
+    if (tr.kind == "Device") {
+      console.log("Received Device auto sync message.")
+    }
     return overwrite(tr, tr.body, SpecialStatus.SAVED);
   };
 

--- a/frontend/connectivity/auto_sync.ts
+++ b/frontend/connectivity/auto_sync.ts
@@ -45,14 +45,10 @@ export function asTaggedResource(data: UpdateMqttData<TaggedResource>):
 export const handleCreate =
   (data: UpdateMqttData<TaggedResource>) => init(data.kind, data.body, true);
 
-let count = 0;
 export const handleUpdate =
   (d: UpdateMqttData<TaggedResource>, uuid: string) => {
     const tr = asTaggedResource(d);
     tr.uuid = uuid;
-    if (tr.kind == "Device") {
-      console.log("Received Device auto sync message. " + (count++));
-    }
     return overwrite(tr, tr.body, SpecialStatus.SAVED);
   };
 


### PR DESCRIPTION
Experimental PR that broadcasts the following fields over auto sync channel:

 * `throttled_at`
 * `throttled_until`
 * `last_saw_api`

This may need to be reverted if it is found to create performance issues.