### PR TITLE
New Rake Task / Report Generator

### DIFF
--- a/db/migrate/20200621012312_add_first_saw_api_to_devices.rb
+++ b/db/migrate/20200621012312_add_first_saw_api_to_devices.rb
@@ -1,0 +1,5 @@
+class AddFirstSawApiToDevices < ActiveRecord::Migration[6.0]
+  def change
+    add_column :devices, :first_saw_api, :datetime
+  end
+end

--- a/db/migrate/20200621012312_add_first_saw_api_to_devices.rb
+++ b/db/migrate/20200621012312_add_first_saw_api_to_devices.rb
@@ -1,5 +1,7 @@
 class AddFirstSawApiToDevices < ActiveRecord::Migration[6.0]
   def change
+    # RUN THIS:
+    # Device.update_all(first_saw_api: 10.years.ago)
     add_column :devices, :first_saw_api, :datetime
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -277,7 +277,8 @@ CREATE TABLE public.devices (
     last_ota timestamp without time zone,
     last_ota_checkup timestamp without time zone,
     ota_hour integer DEFAULT 3,
-    needs_reset boolean DEFAULT false
+    needs_reset boolean DEFAULT false,
+    first_saw_api timestamp without time zone
 );
 
 
@@ -3381,6 +3382,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200204230135'),
 ('20200323235926'),
 ('20200412152208'),
-('20200616172612');
+('20200616172612'),
+('20200621012312');
 
 

--- a/example.env
+++ b/example.env
@@ -174,3 +174,7 @@ NO_CLEAN=true
 # FarmBot uses DataDog for log analytics and for assesing overall system health.
 # Do not add this key if you  do not use DataDog on your server.
 DATADOG_CLIENT_TOKEN=??
+# Comma separated list of emails that wish to receive a daily
+# report of new FarmBot installations (not new users, but
+# actual FarmBot installations).
+CUSTOMER_SUPPORT_SUBSCRIBERS=alice@protonmail.com,bob@yahoo.com

--- a/lib/tasks/news_user_report.rake
+++ b/lib/tasks/news_user_report.rake
@@ -1,0 +1,53 @@
+require_relative "../../app/lib/key_gen"
+
+class NewUserReport
+  EMAILS = (ENV["CUSTOMER_SUPPORT_SUBSCRIBERS"] || "").split(",").map(&:strip).map(&:trim)
+  TPL = <<~HEREDOC
+    Below is a list of new FarmBot installations that may
+    need a customer support checkin:
+
+    === New device installations today:
+    %{daily}
+
+    === New Device installations this week:
+    %{weekly}
+  HEREDOC
+
+  def new_today
+    @new_today ||= User
+      .joins(:device)
+      .where("devices.last_saw_api > ?", 1.day.ago)
+      .pluck(:email)
+      .sort
+  end
+
+  def new_this_week
+    @new_this_week ||= User
+      .joins(:device)
+      .where("devices.last_saw_api > ?", 7.days.ago)
+      .where
+      .not(email: new_today)
+      .pluck(:email)
+      .sort
+  end
+
+  def message
+    @message ||= TPL % {
+      weekly: "",
+      daily: "",
+    }
+  end
+end
+
+namespace :new_user_report do
+  desc "Send email to customer support with new users for the week / day."
+  task run: :environment do
+    report = NewUserReport.new
+    ActionMailer::Base.mail(
+      from: "do-not-reply@farmbot.io",
+      to: emails,
+      subject: "test",
+      body: "test123",
+    ).deliver
+  end
+end

--- a/spec/mutations/devices/sync_spec.rb
+++ b/spec/mutations/devices/sync_spec.rb
@@ -30,4 +30,15 @@ describe Devices::Sync do
     expect(Set.new(results.keys)).to eq(TABLES)
     expect(device.reload.last_saw_api).to be > old_timestamp
   end
+
+  it "sets first_saw_api time" do
+    expect(device.first_saw_api).to be(nil)
+    Devices::Sync.run!(device: device)
+    new_time = device.reload.first_saw_api
+    expect(new_time).to be
+    expect(new_time).to be_kind_of(ActiveSupport::TimeWithZone)
+    Devices::Sync.run!(device: device)
+    new_time2 = device.reload.first_saw_api
+    expect(new_time).to eq(new_time2)
+  end
 end


### PR DESCRIPTION
This is a helper task (that I will run on a cron job) to help support staff identify customers that have installed their device for the first time today / this week.

We will use this information for scheduling followup emails / calls