### PR TITLE
Move v3 changes

### DIFF
--- a/app/models/celery_script_settings_bag.rb
+++ b/app/models/celery_script_settings_bag.rb
@@ -276,14 +276,12 @@ module CeleryScriptSettingsBag
     },
     axis_operand: {
       defn: [
-        n(:coordinate),
         n(:identifier),
         n(:lua),
         n(:numeric),
         n(:point),
         n(:random),
         n(:special_value),
-        n(:tool),
       ],
     },
     number: {
@@ -608,7 +606,6 @@ module CeleryScriptSettingsBag
     },
     move: {
       body: [
-        :special_value,
         :axis_overwrite,
         :axis_addition,
         :speed_overwrite,

--- a/app/models/celery_script_settings_bag.rb
+++ b/app/models/celery_script_settings_bag.rb
@@ -595,7 +595,7 @@ module CeleryScriptSettingsBag
       tags: [:data],
     },
     speed_overwrite: {
-      args: [:speed_setting],
+      args: [:speed_setting, :axis],
       tags: [:data],
     },
     safe_z: {


### PR DESCRIPTION
Some values in the corpus were not being used by the corpus. Removing the values for now to reduce the number of corner cases when implementing.