### PR TITLE
Hotfix for inactive accounts

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -79,6 +79,7 @@ class User < ApplicationRecord
       else
         # Prevent double deletion / race conditions.
         update!(last_sign_in_at: Time.now, inactivity_warning_sent_at: nil)
+        self.device.update!(mounted_tool_id: nil)
         delay.destroy!
         puts "INACTIVITY DELETION FOR #{email}" unless Rails.env.test?
       end

--- a/spec/jobs/inactive_account_job_spec.rb
+++ b/spec/jobs/inactive_account_job_spec.rb
@@ -1,11 +1,16 @@
 require "spec_helper"
 
 describe InactiveAccountJob do
-  let!(:yes) { FactoryBot.create(:user, last_sign_in_at: 3.years.ago) }
+  let!(:yes) do
+    user = FactoryBot.create(:user, last_sign_in_at: 3.years.ago)
+    tool = FactoryBot.create(:tool, device: user.device)
+    user.device.update!(mounted_tool_id: tool.id)
+    user
+  end
   let!(:no) { FactoryBot.create(:user, last_sign_in_at: 3.days.ago) }
   let!(:not_sure) { FactoryBot.create(:user, last_sign_in_at: nil) }
 
-  it "Processes deletion" do
+  it "processes deletion" do
     # === Expect a clean slate.
     expect(not_sure.last_sign_in_at).to be(nil)
     expect(yes.inactivity_warning_sent_at).to be(nil)


### PR DESCRIPTION
App would crash when deleting inactive accounts that had a `mounted_tool_id`.