### PR TITLE
Bugfix: Unable to delete folders during account reset

### DIFF
--- a/app/mutations/devices/reset.rb
+++ b/app/mutations/devices/reset.rb
@@ -21,6 +21,7 @@ module Devices
     def run_it
       ActiveRecord::Base.transaction do
         device.update!(name: "FarmBot", mounted_tool_id: nil)
+        device.folders.update_all(parent_id: nil)
         Device::SINGULAR_RESOURCES.keys.map do |resource|
           device.send(resource).destroy!
         end

--- a/spec/controllers/api/devices/devices_controller_destroy_spec.rb
+++ b/spec/controllers/api/devices/devices_controller_destroy_spec.rb
@@ -14,6 +14,9 @@ describe Api::DevicesController do
     it "resets a bot" do
       sign_in user
       device = user.device
+      f1 = Folder.create!(device: device, name: "f1", parent_id: nil, color: "red")
+      f2 = Folder.create!(device: device, name: "f2", parent_id: f1.id, color: "red")
+      f3 = Folder.create!(device: device, name: "f3", parent_id: f2.id, color: "red")
       resources.map do |resource|
         FactoryBot.create(resource.to_sym, device: device)
       end


### PR DESCRIPTION
Fixes a foreign key constraint error.

CC: @roryaronson 