### PR TITLE
Minor fix for rare edge case

### DIFF
--- a/app/controllers/api/abstract_controller.rb
+++ b/app/controllers/api/abstract_controller.rb
@@ -261,7 +261,7 @@ module Api
           bot.last_saw_api = Time.now
           # Do _not_ set the FBOS version to 0.0.0 if the UA header is missing.
           if v > NULL && v < NOT_FBOS
-            bot.fbos_version = v.to_s
+            bot.fbos_version = (v.to_s || "").first(14)
             bot.save!
           end
         end

--- a/app/controllers/api/rmq_utils_controller.rb
+++ b/app/controllers/api/rmq_utils_controller.rb
@@ -186,7 +186,6 @@ module Api
     end
 
     def deny(reason)
-      puts "=== DENIED: #{reason}"
       maybe_alert_user(reason)
       render json: "deny", status: 403
     end

--- a/app/controllers/api/rmq_utils_controller.rb
+++ b/app/controllers/api/rmq_utils_controller.rb
@@ -186,6 +186,7 @@ module Api
     end
 
     def deny(reason)
+      puts "=== DENIED: #{reason}"
       maybe_alert_user(reason)
       render json: "deny", status: 403
     end


### PR DESCRIPTION
Authentication fails if the user's FBOS version is greater than 15 characters in length.

Since this is extremely rare, I am going to just truncate the FBOS string rather than widen the database table.