### PR TITLE
Updates to Sequence Publishing

### DIFF
--- a/app/mutations/sequences/publish.rb
+++ b/app/mutations/sequences/publish.rb
@@ -44,14 +44,14 @@ module Sequences
       end
     end
 
-    private
-
     def enforce_allow_list
       problems = illegal_content.uniq.sort.join(", ")
       if problems.present?
         add_error :sequence, :illegal, AUTHORIZATION_REQUIRED + problems
       end
     end
+
+    private
 
     def validate_ownership
       if sequence.device_id != device.id

--- a/app/mutations/sequences/publish_unsafe.rb
+++ b/app/mutations/sequences/publish_unsafe.rb
@@ -1,0 +1,12 @@
+module Sequences
+  # This module allows publishing of shared sequences that
+  # contain _any_ node. This circumvents the allow list
+  # defined in Sequences::Publish.
+  # Use this to publish sequences that were manually approved
+  # by FarmBot staff.
+  class PublishUnsafe < Sequences::Publish
+    def enforce_allow_list
+      false
+    end
+  end
+end


### PR DESCRIPTION
This PR allows admin users (with `rails c` access) to publish arbitrary sequences.