### PR TITLE
Revert changes: Do not allow `nothing` as a `default_value`.

### DIFF
--- a/app/models/celery_script_settings_bag.rb
+++ b/app/models/celery_script_settings_bag.rb
@@ -48,8 +48,8 @@ module CeleryScriptSettingsBag
   ALLOWED_SPEC_ACTION = %w(emergency_lock emergency_unlock power_off read_status
                            reboot sync take_photo)
   ALLOWED_SPECIAL_VALUE = %w(current_location safe_height soil_height)
-  ANY_VARIABLE = %i(coordinate identifier nothing numeric point
-                    resource resource_placeholder text tool)
+  ANY_VARIABLE = %i(coordinate identifier numeric point resource
+                    resource_placeholder text tool)
   BAD_ALLOWED_PIN_MODES = '"%s" is not a valid pin_mode. ' \
                           "Allowed values: %s"
   BAD_ASSERTION_TYPE = '"%s" is not a valid assertion type. ' \


### PR DESCRIPTION
Reverts changes in #2309

TODO: Re-publish FBJS with updated corpus.