### PR TITLE
Improve image flipper performance

### DIFF
--- a/frontend/photos/images/__tests__/image_flipper_preload_test.tsx
+++ b/frontend/photos/images/__tests__/image_flipper_preload_test.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { ImageFlipper } from "../image_flipper";
+import { fakeImage } from "../../../__test_support__/fake_state/resources";
+
+let originalImage: any;
+let createdSources: string[] = [];
+class MockImage {
+  onload: (() => void) | null = null;
+  _src = "";
+  naturalWidth = 10;
+  naturalHeight = 10;
+  set src(value: string) {
+    this._src = value;
+    createdSources.push(value);
+    if (this.onload) { this.onload(); }
+  }
+  get src() { return this._src; }
+}
+
+beforeEach(() => {
+  createdSources = [];
+  originalImage = window.Image;
+  (window as any).Image = MockImage;
+});
+
+afterEach(() => {
+  (window as any).Image = originalImage;
+});
+
+const makeImages = () =>
+  Array.from({ length: 4 }, (_, i) => {
+    const img = fakeImage();
+    img.uuid = `${i}`;
+    img.body.attachment_processed_at = "now";
+    img.body.attachment_url = `url${i}`;
+    return img;
+  });
+
+test("preloads current and previous images", async () => {
+  const imgs = makeImages();
+  const props = {
+    id: "flipper",
+    dispatch: jest.fn(),
+    images: imgs,
+    currentImage: imgs[3],
+    currentImageSize: { width: undefined, height: undefined },
+    crop: false,
+    env: {},
+    getConfigValue: jest.fn(),
+    transformImage: false,
+  };
+  render(<ImageFlipper {...props} />);
+  await waitFor(() => expect(createdSources.length).toBe(4));
+  expect(createdSources).toEqual(["url3", "url2", "url1", "url0"]);
+});
+
+test("shows preloaded image without loader", async () => {
+  const imgs = makeImages();
+  const props = {
+    id: "flipper",
+    dispatch: jest.fn(),
+    images: imgs,
+    currentImage: imgs[3],
+    currentImageSize: { width: undefined, height: undefined },
+    crop: false,
+    env: {},
+    getConfigValue: jest.fn(),
+    transformImage: false,
+  };
+  const { rerender } = render(<ImageFlipper {...props} />);
+  await waitFor(() => expect(createdSources.length).toBe(4));
+  rerender(<ImageFlipper {...{ ...props, currentImage: imgs[2] }} />);
+  await waitFor(() =>
+    expect(screen.queryByText("Loading...")).not.toBeInTheDocument(),
+    { timeout: 2000 });
+});

--- a/frontend/photos/images/flipper_image.tsx
+++ b/frontend/photos/images/flipper_image.tsx
@@ -24,18 +24,26 @@ interface TargetProps {
 export class FlipperImage
   extends React.Component<FlipperImageProps, FlipperImageState> {
   state: FlipperImageState = {
-    isLoaded: false,
-    width: undefined,
-    height: undefined,
+    isLoaded: !!this.props.preloadedImage,
+    width: this.props.preloadedImage?.naturalWidth,
+    height: this.props.preloadedImage?.naturalHeight,
   };
 
+  componentDidMount() {
+    if (this.props.preloadedImage) {
+      this.props.onImageLoad(this.props.preloadedImage);
+    }
+  }
+
   onImageLoad = (img: HTMLImageElement) => {
-    this.props.onImageLoad(img);
-    this.setState({
-      isLoaded: true,
-      width: img.naturalWidth,
-      height: img.naturalHeight,
-    });
+    if (!this.state.isLoaded) {
+      this.props.onImageLoad(img);
+      this.setState({
+        isLoaded: true,
+        width: img.naturalWidth,
+        height: img.naturalHeight,
+      });
+    }
   };
 
   Target = (props: TargetProps) => {

--- a/frontend/photos/images/interfaces.ts
+++ b/frontend/photos/images/interfaces.ts
@@ -4,6 +4,7 @@ import { MovementState, TimeSettings } from "../../interfaces";
 import { BotPosition, UserEnv } from "../../devices/interfaces";
 import { GetWebAppConfigValue } from "../../config_storage/actions";
 import { DesignerState } from "../../farm_designer/interfaces";
+import { UUID } from "../../resources/interfaces";
 
 export interface ImageFlipperProps {
   id: string;
@@ -24,6 +25,8 @@ export interface ImageFlipperProps {
 export interface ImageFlipperState {
   disablePrev: boolean;
   disableNext: boolean;
+  /** Map of preloaded images for instant rendering. */
+  preloaded: Record<UUID, HTMLImageElement>;
 }
 
 export interface FlipperImageProps {
@@ -38,6 +41,8 @@ export interface FlipperImageProps {
   hover?(hovered: string | undefined): void;
   target?: Record<"x" | "y", number> | undefined;
   dark?: boolean;
+  /** Preloaded image for instant render. */
+  preloadedImage?: HTMLImageElement;
 }
 
 export interface FlipperImageState {

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -23,6 +23,7 @@
     "sourceMap": true,
     "strictNullChecks": true,
     "target": "es5",
+    "types": ["jest", "@testing-library/jest-dom", "node"]
   },
   "include": [
     "public/app-resources/languages"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,7 @@
     "strictNullChecks": true,
     "target": "es5",
     "resolveJsonModule": true,
+    "types": ["jest", "@testing-library/jest-dom", "node"]
   },
   "include": [
     "frontend"


### PR DESCRIPTION
## Summary
- preload next few images to make flipping snappy
- use preloaded image when available
- add tests for preloading behaviour
- include jest-dom types in tsconfig for tests
- include node types so linters still pass
- use lodash `range` helper in preloader test
- remove lodash usage in preload test

## Testing
- `npm run linters`
- `npm test --silent`
- `npx jest frontend/photos/images/__tests__/image_flipper_preload_test.tsx --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_6854f2091288832e8a5d4fcc653a5b9d