### PR TITLE
Allow CSP API hosts with and without ports

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -76,7 +76,11 @@ module FarmBot
     # ¯\_(ツ)_/¯
     $API_URL = "//#{Rails.application.routes.default_url_options[:host]}:#{Rails.application.routes.default_url_options[:port]}"
     ALL_LOCAL_URIS = ([ENV["API_HOST"]] + (ENV["EXTRA_DOMAINS"] || "").split(","))
-      .map { |x| x.present? ? "#{x}:#{ENV["API_PORT"]}" : nil }.compact
+      .map(&:presence)
+      .compact
+      .flat_map { |host| [host, API_PORT.present? ? "#{host}:#{API_PORT}" : nil] }
+      .compact
+      .uniq
     SecureHeaders::Configuration.default do |config|
       config.hsts = "max-age=#{1.week.to_i}"
       # We need this off in dev mode otherwise email previews won't show up.

--- a/spec/config/application_spec.rb
+++ b/spec/config/application_spec.rb
@@ -1,0 +1,11 @@
+require "spec_helper"
+
+describe "application content security policy" do
+  it "allows the API host with and without its configured port" do
+    api_host = ENV.fetch("API_HOST")
+    api_port = ENV.fetch("API_PORT")
+    sources = FarmBot::Application::ALL_LOCAL_URIS
+
+    expect(sources).to include(api_host, "#{api_host}:#{api_port}")
+  end
+end


### PR DESCRIPTION
## What changed\n\n- Preserve each API host and EXTRA_DOMAINS entry as a valid CSP connect-src source without a port.\n- Also add the configured API_PORT variant when a port is present.\n- Deduplicate the resulting source list.\n- Add a regression spec covering the API host with and without its configured port.\n\n## Why\n\nSelf-hosted deployments commonly place nginx on the public default port while Rails listens on API_PORT (usually 3000). The previous code only emitted host:API_PORT, so browser requests through the public domain could be blocked by the Content Security Policy.\n\n## Impact\n\nBoth direct access to the Rails port and access through a reverse proxy can use the same environment configuration without manually editing application.rb.\n\nFixes #2505\n\n## Validation\n\n- ruby -c config/application.rb\n- ruby -c spec/config/application_spec.rb\n- git diff --check\n\nThe full suite was not run locally because this checkout requires Ruby 4.0.6 and Bun, which are not installed in the current environment.